### PR TITLE
chore(e2e) - remove redundant pnpm-install option for contracts

### DIFF
--- a/.github/workflows/reuse-run-e2e-tests.yml
+++ b/.github/workflows/reuse-run-e2e-tests.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs
         with:
-          pnpm-install-options: '-F contracts -F "e2e..." --frozen-lockfile --prefer-offline'
+          pnpm-install-options: '-F "e2e..." --frozen-lockfile --prefer-offline'
           commands: |
             pnpm run -F "e2e^..." build
       - name: Login to Docker Hub


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts CI dependency install flags for the E2E workflow; low risk aside from potentially changing which workspace packages are installed during CI.
> 
> **Overview**
> Updates the `run-e2e-tests` GitHub Actions workflow to remove the `contracts` workspace filter from `pnpm-install-options`, so the install step targets only the `e2e...` packages before building and running E2E tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 776a64d0cffa43ebc4a211b6f46df27767ec7e80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->