### PR TITLE
chore(misc): update compose profiles

### DIFF
--- a/.github/workflows/reuse-run-e2e-tests.yml
+++ b/.github/workflows/reuse-run-e2e-tests.yml
@@ -96,16 +96,6 @@ jobs:
         run: |
           mkdir -p tmp/local/traces/v2/conflated
           chmod -R a+rw tmp/local/
-      - name: Pull all external-to-monorepo images with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
-        if: ${{ inputs.linea_besu_package_tag == '' }}
-        with:
-          max_attempts: 10
-          retry_on: error
-          retry_wait_seconds: 30
-          timeout_minutes: 10
-          command: |
-            make docker-pull-images-external-to-monorepo
 
       - name: Download local docker image artifacts
         uses: actions/download-artifact@v7

--- a/.github/workflows/reuse-run-e2e-tests.yml
+++ b/.github/workflows/reuse-run-e2e-tests.yml
@@ -96,6 +96,16 @@ jobs:
         run: |
           mkdir -p tmp/local/traces/v2/conflated
           chmod -R a+rw tmp/local/
+      - name: Pull all external-to-monorepo images with retry
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        if: ${{ inputs.linea_besu_package_tag == '' }}
+        with:
+          max_attempts: 10
+          retry_on: error
+          retry_wait_seconds: 30
+          timeout_minutes: 10
+          command: |
+            make docker-pull-images-external-to-monorepo
 
       - name: Download local docker image artifacts
         uses: actions/download-artifact@v7

--- a/.github/workflows/reuse-run-e2e-tests.yml
+++ b/.github/workflows/reuse-run-e2e-tests.yml
@@ -96,16 +96,6 @@ jobs:
         run: |
           mkdir -p tmp/local/traces/v2/conflated
           chmod -R a+rw tmp/local/
-      - name: Pull all external-to-monorepo images with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
-        if: ${{ inputs.linea_besu_package_tag == '' }}
-        with:
-          max_attempts: 10
-          retry_on: error
-          retry_wait_seconds: 30
-          timeout_minutes: 10
-          command: |
-            make docker-pull-images-external-to-monorepo
 
       - name: Download local docker image artifacts
         uses: actions/download-artifact@v7
@@ -151,6 +141,16 @@ jobs:
         run: |
           gunzip -c $GITHUB_WORKSPACE/tmp/artifacts/linea-besu-package-images.tar.gz | docker load
         shell: bash
+      - name: Pull all external-to-monorepo images with retry
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        if: ${{ inputs.linea_besu_package_tag == '' }}
+        with:
+          max_attempts: 10
+          retry_on: error
+          retry_wait_seconds: 30
+          timeout_minutes: 10
+          command: |
+            make docker-pull-images-external-to-monorepo
       - name: Spin up fresh environment with retry
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
         with:

--- a/docker/compose-spec-l1-services.yml
+++ b/docker/compose-spec-l1-services.yml
@@ -3,7 +3,7 @@ services:
     container_name: l1-el-node
     hostname: l1-el-node
     image: consensys/linea-besu-package:${LINEA_BESU_PACKAGE_TAG:-beta-v6-20260410083640-74d51b7}
-    profiles: [ "l1", "debug"]
+    profiles: [ "l1", "debug" ]
     depends_on:
       l1-node-genesis-generator:
         condition: service_completed_successfully
@@ -43,8 +43,6 @@ services:
     image: consensys/teku:25.11.0-jdk24
     profiles: [ "l1", "debug", "external-to-monorepo" ]
     depends_on:
-      l1-el-node:
-        condition: service_started
       l1-node-genesis-generator:
         condition: service_completed_successfully
     healthcheck:

--- a/docker/compose-spec-l1-services.yml
+++ b/docker/compose-spec-l1-services.yml
@@ -3,7 +3,7 @@ services:
     container_name: l1-el-node
     hostname: l1-el-node
     image: consensys/linea-besu-package:${LINEA_BESU_PACKAGE_TAG:-beta-v6-20260410083640-74d51b7}
-    profiles: [ "l1", "debug", "external-to-monorepo" ]
+    profiles: [ "l1", "debug"]
     depends_on:
       l1-node-genesis-generator:
         condition: service_completed_successfully

--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -5,6 +5,7 @@ services:
   l2-genesis-initialization:
     image: busybox:latest
     container_name: l2-genesis-intialization
+    profiles: [ "external-to-monorepo" ]
     environment:
       CREATE_EMPTY_BLOCKS: ${CREATE_EMPTY_BLOCKS:-false}
     entrypoint: [ "sh","/initialization/init.sh" ]
@@ -95,7 +96,7 @@ services:
     hostname: l2-node
     image: consensys/linea-geth:${ZKGETH_TAG:-0588665}
     platform: linux/amd64
-    profiles: [ "l2", "debug" ]
+    profiles: [ "l2", "debug", "external-to-monorepo" ]
     depends_on:
       sequencer:
         condition: service_healthy
@@ -171,7 +172,7 @@ services:
     hostname: l2-node-besu-leader
     container_name: l2-node-besu-leader
     image: consensys/linea-besu-package-with-fleet:${LINEA_BESU_PACKAGE_TAG:-beta-v6-20260410083640-74d51b7}
-    profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
+    profiles: [ "l2", "l2-bc", "debug" ]
     depends_on:
       sequencer:
         condition: service_healthy
@@ -215,7 +216,7 @@ services:
     hostname: l2-node-besu-follower
     container_name: l2-node-besu-follower
     image: consensys/linea-besu-package-with-fleet:${LINEA_BESU_PACKAGE_TAG:-beta-v6-20260410083640-74d51b7}
-    profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
+    profiles: [ "l2", "l2-bc", "debug" ]
     depends_on:
       sequencer:
         condition: service_healthy

--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -5,7 +5,7 @@ services:
   l2-genesis-initialization:
     image: busybox:latest
     container_name: l2-genesis-intialization
-    profiles: [ "external-to-monorepo" ]
+    profiles: [ "l2", "external-to-monorepo" ]
     environment:
       CREATE_EMPTY_BLOCKS: ${CREATE_EMPTY_BLOCKS:-false}
     entrypoint: [ "sh","/initialization/init.sh" ]


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes Docker Compose profile selection and CI image-pull sequencing, which can alter which services start in e2e/dev environments and potentially break CI runs if assumptions about profiles/images were relied on.
> 
> **Overview**
> Updates the `run-e2e-tests` workflow to pull *external-to-monorepo* Docker images **later in the job**, after loading artifacts and (optionally) loading the `linea-besu-package` image.
> 
> Adjusts Docker Compose profiles so some Besu-based services are **no longer tagged** `external-to-monorepo` (e.g. `l1-el-node`, `l2-node-besu-leader`, `l2-node-besu-follower`), while `l2-node` and `l2-genesis-initialization` are **now included** in that profile; also removes `l1-cl-node`’s dependency on `l1-el-node` startup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba256df67ee8d2a07a385c855a590f8b093977a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->