### PR TITLE
fix(linea-stack): isolate deploy dependencies in Docker

### DIFF
--- a/docs/getting-started/linea-stack/README.md
+++ b/docs/getting-started/linea-stack/README.md
@@ -200,7 +200,7 @@ T+1:00  sequencer healthy
 T+1:30  maru + l2-node-besu + shomei healthy
 T+2:00  deploy-contracts begins
         ├─ pre-flight (waits for Sepolia + Shomei reachable)
-        ├─ pnpm install + Foundry install (cold ~3 min, warm ~30s)
+        ├─ Docker-scoped pnpm + Hardhat cache warmup (cold ~3 min, warm no-op)
         ├─ Step 1: deploy L1 LineaRollupV8 (~30s on Sepolia)
         ├─ Step 2: deploy L2 MessageService
         ├─ Step 3-4: deploy TokenBridge L1 + L2
@@ -497,7 +497,7 @@ Optional one-shot local checks:
 ## 7. Tearing down
 
 ```bash
-# Stop, keep volumes — chaindata + addresses persist; next `up` is faster
+# Stop, keep volumes — chaindata, addresses, deploy tooling deps, and Hardhat artifacts persist; next `up` is faster
 docker compose --env-file versions.env --env-file .env --profile stack-partial-prover down
 
 # Wipe everything — REQUIRED if you change L1_RPC_URL or L1_DEPLOYER_PRIVATE_KEY
@@ -609,6 +609,7 @@ and `fork-timestamp.txt` live in Docker volume `linea-stack-l2-genesis`.
 |---------|--------------|-----|
 | `account-setup` exits with "L1 RPC not reachable" | `L1_RPC_URL` rate-limited or wrong | Try a different Sepolia RPC; check the URL with `cast chain-id --rpc-url $L1_RPC_URL` |
 | `account-setup` exits with "could not extract deployers.l1" | malformed JSON output (Foundry version mismatch?) | See [bringup-notes.md](./bringup-notes.md) — `cast wallet address` flag drift is one possibility |
+| deploy-contracts dies with `Cannot find module '@chainsafe/blst-linux-...'` | stale deploy tooling volume or an older checkout reused host `node_modules` inside Linux | On current checkouts, retry once; deploy-contracts uses Docker-scoped Linux `node_modules`. If the stale volume survives, run `docker compose --env-file versions.env --env-file .env --profile stack-partial-prover down -v` and retry |
 | deploy-contracts step 1 fails with "insufficient funds" | deployer's Sepolia balance too low | Top up via faucet; Sepolia gas spikes can blow through 0.5 ETH |
 | deploy-contracts dies with `ADDRESS MISMATCH` | LineaRollupV8 or L2MessageService no longer lands at the boot-critical precomputed address | Usually means the deploy script changed and `account-setup.sh` needs a corresponding nonce/precompute update |
 | Coordinator retries `linea_generateConflatedTracesToFileV2` with `Conflation not finished` on old block ranges | L2 ran far ahead while coordinator was down, beyond Besu's retained Bonsai history | Start over with `docker compose --env-file versions.env --env-file .env --profile stack-partial-prover down -v --remove-orphans`; this quickstart keeps a larger `bonsai-historical-block-limit` to make delayed first boots recoverable |
@@ -772,6 +773,12 @@ docs/getting-started/linea-stack/
 - `linea-stack-rendered-config` — written by `config-render` (full render of 5
   templates) and `deploy-contracts` (in-place patch of coord-config); read by
   sequencer, maru, l2-node-besu, coordinator, prover
+- `linea-stack-contracts-pnpm-store`, `linea-stack-contracts-root-node-modules`,
+  `linea-stack-contracts-package-node-modules`, and
+  `linea-stack-eslint-config-node-modules` — Docker-scoped Linux dependency
+  cache for deploy-contracts
+- `linea-stack-contracts-artifacts` and `linea-stack-contracts-cache` —
+  Docker-scoped Hardhat artifacts and incremental compile cache
 - `linea-stack-local-dev` — chaindata + prover state
 - `linea-stack-logs` — shared log-output volume
 - per-service postgres volumes

--- a/docs/getting-started/linea-stack/docker-compose.yml
+++ b/docs/getting-started/linea-stack/docker-compose.yml
@@ -44,6 +44,18 @@ volumes:
   blockscout-l2-pg-data:
   linea-rendered-config:
     name: "linea-stack-rendered-config"  # coordinator + maru TOMLs rendered with $L1_RPC_URL
+  linea-contracts-pnpm-store:
+    name: "linea-stack-contracts-pnpm-store"
+  linea-contracts-root-node-modules:
+    name: "linea-stack-contracts-root-node-modules"
+  linea-contracts-package-node-modules:
+    name: "linea-stack-contracts-package-node-modules"
+  linea-eslint-config-node-modules:
+    name: "linea-stack-eslint-config-node-modules"
+  linea-contracts-artifacts:
+    name: "linea-stack-contracts-artifacts"
+  linea-contracts-cache:
+    name: "linea-stack-contracts-cache"
 
 services:
 
@@ -614,9 +626,17 @@ services:
       # Mount the whole linea-monorepo at /workspace because contracts/ is a
       # pnpm workspace member that depends on pnpm-workspace.yaml + pnpm-lock.yaml
       # at the repo root. Mounting just contracts/ breaks pnpm catalog resolution.
-      # Side effect: a full `pnpm install` will materialise node_modules at the
-      # repo root on the host. v0 is monorepo-internal by design.
       - ../../..:/workspace
+      # Keep deploy tooling dependencies Linux-native and Docker-scoped. The
+      # source tree still comes from the host bind mount, but node_modules,
+      # pnpm's store, and Hardhat compile output stay in Docker volumes so a
+      # macOS/Windows/Linux host install cannot poison the deploy container.
+      - linea-contracts-pnpm-store:/workspace/.pnpm-store
+      - linea-contracts-root-node-modules:/workspace/node_modules
+      - linea-contracts-package-node-modules:/workspace/contracts/node_modules
+      - linea-eslint-config-node-modules:/workspace/ts-libs/eslint-config/node_modules
+      - linea-contracts-artifacts:/workspace/contracts/artifacts
+      - linea-contracts-cache:/workspace/contracts/cache
       - ./scripts:/scripts:ro
       # Forked deploy script — bind-mounted OVER the upstream path. Fixes the
       # stale ORDERED_NONCE_POST_LINEAROLLUP=7 offset (step 1 actually consumes

--- a/docs/getting-started/linea-stack/scripts/check-quickstart-static.sh
+++ b/docs/getting-started/linea-stack/scripts/check-quickstart-static.sh
@@ -313,6 +313,7 @@ check_partial_prover_guardrails() {
 }
 
 check_reuse_guardrails() {
+  compose="$STACK/docker-compose.yml"
   deploy_contracts="$STACK/scripts/deploy-contracts.sh"
   status_script="$STACK/scripts/status.sh"
   logging_lib="$STACK/scripts/lib/logging.sh"
@@ -326,6 +327,22 @@ check_reuse_guardrails() {
     pass "deploy-contracts verifies L2 code before trusting prior deploy logs"
   else
     fail "deploy-contracts must verify L2 on-chain code before skipping from prior deploy logs"
+  fi
+
+  if grep -q 'check_linux_native_optional_deps' "$deploy_contracts" \
+    && grep -q '@chainsafe/blst-linux-' "$deploy_contracts" \
+    && grep -q '@chainsafe/hashtree-linux-' "$deploy_contracts" \
+    && grep -q -- '--filter linea-monorepo' "$deploy_contracts" \
+    && grep -q -- '--filter contracts...' "$deploy_contracts" \
+    && grep -q 'linea-contracts-pnpm-store:/workspace/.pnpm-store' "$compose" \
+    && grep -q 'linea-contracts-root-node-modules:/workspace/node_modules' "$compose" \
+    && grep -q 'linea-contracts-package-node-modules:/workspace/contracts/node_modules' "$compose" \
+    && grep -q 'linea-eslint-config-node-modules:/workspace/ts-libs/eslint-config/node_modules' "$compose" \
+    && grep -q 'linea-contracts-artifacts:/workspace/contracts/artifacts' "$compose" \
+    && grep -q 'linea-contracts-cache:/workspace/contracts/cache' "$compose"; then
+    pass "deploy-contracts keeps Linux dependency and Hardhat caches in Docker volumes"
+  else
+    fail "deploy-contracts must not reuse host node_modules or throw away the Hardhat cache"
   fi
 
   if grep -q 'l2 rpc latest block' "$status_script" \

--- a/docs/getting-started/linea-stack/scripts/deploy-contracts.sh
+++ b/docs/getting-started/linea-stack/scripts/deploy-contracts.sh
@@ -283,15 +283,64 @@ export L1_CHAIN_ID L1_DEPLOYER_ADDRESS L2_GENESIS_STATE_ROOT L2_GENESIS_SHNARF
 
 step "pnpm install + hardhat compile"
 
+check_linux_native_optional_deps() {
+  node --input-type=module <<'NODE'
+import fs from "node:fs";
+import process from "node:process";
+
+if (process.platform !== "linux" || !["arm64", "x64"].includes(process.arch)) {
+  process.exit(0);
+}
+
+const report = process.report?.getReport?.();
+const libc = report?.header?.glibcVersionRuntime ? "gnu" : "musl";
+const pnpmRoot = "/workspace/node_modules/.pnpm";
+const packages = [
+  `@chainsafe/blst-linux-${process.arch}-${libc}`,
+  `@chainsafe/hashtree-linux-${process.arch}-${libc}`,
+];
+
+const entries = fs.existsSync(pnpmRoot) ? fs.readdirSync(pnpmRoot) : [];
+const missing = packages.filter((pkg) => {
+  const encoded = pkg.replace("/", "+");
+  return !entries.some((entry) => entry.startsWith(`${encoded}@`));
+});
+
+if (missing.length > 0) {
+  console.log(`workspace node_modules is missing Linux native optional dependencies: ${missing.join(", ")}`);
+  process.exit(1);
+}
+NODE
+}
+
+pnpm_install_reason=""
+pnpm_install_force=false
 if [[ ! -d /workspace/node_modules ]]; then
-  log "Installing workspace dependencies (pnpm install --no-frozen-lockfile)"
-  ( cd /workspace && pnpm install --no-frozen-lockfile )
+  pnpm_install_reason="workspace node_modules is missing"
+elif [[ ! -d /workspace/node_modules/.pnpm ]]; then
+  pnpm_install_reason="workspace node_modules virtual store is missing"
+elif [[ ! -x /workspace/node_modules/.bin/ts-node || ! -x /workspace/contracts/node_modules/.bin/hardhat ]]; then
+  pnpm_install_reason="workspace node_modules is missing deploy tooling bins"
+else
+  if ! pnpm_install_reason="$(check_linux_native_optional_deps)"; then
+    [[ -n "$pnpm_install_reason" ]] || pnpm_install_reason="Linux native optional dependency check failed"
+    pnpm_install_force=true
+  else
+    pnpm_install_reason=""
+  fi
 fi
 
-if [[ ! -d artifacts ]]; then
-  log "Compiling contracts (pnpm exec hardhat compile)"
-  pnpm exec hardhat compile
+if [[ -n "$pnpm_install_reason" ]]; then
+  pnpm_install_args=(install --filter linea-monorepo --filter contracts... --no-frozen-lockfile --prefer-offline)
+  if [[ "$pnpm_install_force" == "true" ]]; then
+    pnpm_install_args+=(--force)
+  fi
+  log "Installing workspace dependencies (pnpm ${pnpm_install_args[*]}; reason: $pnpm_install_reason)"
+  ( cd /workspace && HUSKY=0 CI=true pnpm "${pnpm_install_args[@]}" )
 fi
+
+log "Checking contract compilation cache (pnpm exec hardhat compile)"
+pnpm exec hardhat compile
 
 DEFAULT_L1_OPERATOR_ADDRESSES="$L1_DEPLOYER_ADDRESS,$PRECOMPUTED_L1_BLOB_SUBMITTER,$PRECOMPUTED_L1_FINALIZATION_SUBMITTER"
 L1_ROLE_MIN_BALANCE_WEI="${L1_ROLE_MIN_BALANCE_WEI:-100000000000000000}"       # 0.10 ETH


### PR DESCRIPTION
## Summary
- keep deploy-contracts pnpm/node_modules and Hardhat cache in Docker volumes
- detect missing Linux ChainSafe optional native packages before reusing node_modules
- document the warm-cache behavior and native dependency recovery path

## Validation
- bash -n docs/getting-started/linea-stack/scripts/deploy-contracts.sh
- sh -n docs/getting-started/linea-stack/scripts/check-quickstart-static.sh
- docs/getting-started/linea-stack/scripts/check-quickstart-static.sh
- L1_RPC_URL=http://127.0.0.1:8545 L1_DEPLOYER_PRIVATE_KEY=<fake local key> docker compose --env-file versions.env --env-file .env.example --profile stack-partial-prover config -q
- git diff --check -- docs/getting-started/linea-stack/scripts/deploy-contracts.sh docs/getting-started/linea-stack/README.md docs/getting-started/linea-stack/scripts/check-quickstart-static.sh docs/getting-started/linea-stack/docker-compose.yml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the contract deployment container’s dependency installation and caching behavior, which can affect quickstart bring-up and reproducibility across platforms. Risk is moderate due to new volume mounts and new install/validation logic for `pnpm`/Hardhat artifacts.
> 
> **Overview**
> **Deploy tooling is now Docker-scoped instead of host-scoped.** The `deploy-contracts` service mounts new named volumes for `pnpm` store, multiple `node_modules` trees, and Hardhat `artifacts`/`cache`, preventing macOS/Windows/host installs from contaminating the Linux deploy container.
> 
> **Deploy scripts add cache-aware install guardrails.** `deploy-contracts.sh` now detects missing workspace tooling, forces a filtered `pnpm install` when needed (including checks for Linux-native ChainSafe optional deps like `@chainsafe/blst-linux-*`/`hashtree-linux-*`), and always runs `hardhat compile` to leverage the persisted compile cache.
> 
> **Docs and static checks updated.** The README now documents warm-cache behavior, the additional persisted volumes on `down`, and a recovery path for stale volumes; `check-quickstart-static.sh` asserts the new Docker-volume cache wiring is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03244d331e82525154d3b1beb8e0572f69d7a139. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->