### PR TITLE
chore(misc): refine TypeScript config layout

### DIFF
--- a/contracts/integrity-verifier/verifier-core/tsconfig.build.json
+++ b/contracts/integrity-verifier/verifier-core/tsconfig.build.json
@@ -3,12 +3,9 @@
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
-    "inlineSources": true,
     "noEmit": false,
-    "sourceMap": true,
     "outDir": "dist",
-    "rootDir": "src",
-    "composite": false
+    "rootDir": "src"
   },
   "include": ["src"],
   "exclude": ["src/cli.ts"]

--- a/contracts/integrity-verifier/verifier-core/tsconfig.json
+++ b/contracts/integrity-verifier/verifier-core/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
+    "noEmit": true,
     "removeComments": false,
     "isolatedModules": false,
     "strictPropertyInitialization": true,

--- a/contracts/integrity-verifier/verifier-core/tsup.config.ts
+++ b/contracts/integrity-verifier/verifier-core/tsup.config.ts
@@ -13,6 +13,9 @@ export default defineConfig([
     dts: true,
     clean: true,
     sourcemap: true,
+    esbuildOptions(options) {
+      options.sourcesContent = false;
+    },
     minify: true,
     outDir: "dist",
     // Mark Node.js built-ins as external to prevent bundling
@@ -34,6 +37,9 @@ export default defineConfig([
     dts: true,
     clean: false, // Don't clean, we need browser files
     sourcemap: true,
+    esbuildOptions(options) {
+      options.sourcesContent = false;
+    },
     minify: true,
     outDir: "dist",
   },

--- a/contracts/integrity-verifier/verifier-ethers/tsconfig.build.json
+++ b/contracts/integrity-verifier/verifier-ethers/tsconfig.build.json
@@ -3,12 +3,9 @@
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
-    "inlineSources": true,
     "noEmit": false,
-    "sourceMap": true,
     "outDir": "dist",
-    "rootDir": "src",
-    "composite": false
+    "rootDir": "src"
   },
   "include": ["src"]
 }

--- a/contracts/integrity-verifier/verifier-ethers/tsconfig.json
+++ b/contracts/integrity-verifier/verifier-ethers/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
+    "noEmit": true,
     "removeComments": false,
     "isolatedModules": false,
     "strictPropertyInitialization": false,

--- a/contracts/integrity-verifier/verifier-ethers/tsup.config.ts
+++ b/contracts/integrity-verifier/verifier-ethers/tsup.config.ts
@@ -10,6 +10,9 @@ export default defineConfig([
     dts: true,
     clean: true,
     sourcemap: true,
+    esbuildOptions(options) {
+      options.sourcesContent = false;
+    },
     minify: true,
     outDir: "dist",
   },
@@ -22,6 +25,9 @@ export default defineConfig([
     dts: false,
     clean: false,
     sourcemap: true,
+    esbuildOptions(options) {
+      options.sourcesContent = false;
+    },
     minify: false,
     outDir: "dist",
   },

--- a/contracts/integrity-verifier/verifier-viem/tsconfig.build.json
+++ b/contracts/integrity-verifier/verifier-viem/tsconfig.build.json
@@ -3,12 +3,9 @@
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
-    "inlineSources": true,
     "noEmit": false,
-    "sourceMap": true,
     "outDir": "dist",
-    "rootDir": "src",
-    "composite": false
+    "rootDir": "src"
   },
   "include": ["src"]
 }

--- a/contracts/integrity-verifier/verifier-viem/tsconfig.json
+++ b/contracts/integrity-verifier/verifier-viem/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
+    "noEmit": true,
     "removeComments": false,
     "isolatedModules": false,
     "strictPropertyInitialization": false,

--- a/contracts/integrity-verifier/verifier-viem/tsup.config.ts
+++ b/contracts/integrity-verifier/verifier-viem/tsup.config.ts
@@ -10,6 +10,9 @@ export default defineConfig([
     dts: true,
     clean: true,
     sourcemap: true,
+    esbuildOptions(options) {
+      options.sourcesContent = false;
+    },
     minify: true,
     outDir: "dist",
   },
@@ -22,6 +25,9 @@ export default defineConfig([
     dts: false,
     clean: false,
     sourcemap: true,
+    esbuildOptions(options) {
+      options.sourcesContent = false;
+    },
     minify: false,
     outDir: "dist",
   },

--- a/contracts/tsconfig.json
+++ b/contracts/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../tsconfig.json"
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  }
 }

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,17 +1,15 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
+    "noEmit": true,
     "types": ["node", "jest"],
+    // The E2E runner is Jest-based, so this package intentionally keeps
+    // CommonJS module settings even though package.json declares ESM.
     "moduleResolution": "node",
     "module": "commonjs",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false
   },
-  "references": [
-    {
-      "path": "../ts-libs/linea-shared-utils"
-    },
-  ],
   "include": ["**/*.ts", "src/config/clients/linea-rpc"]
 }

--- a/operations/cli/Dockerfile
+++ b/operations/cli/Dockerfile
@@ -11,7 +11,7 @@ FROM base AS builder
 
 WORKDIR /usr/src/app
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json tsconfig.base.json ./
 
 COPY ts-libs/eslint-config/ ./ts-libs/eslint-config/
 COPY operations/cli/ ./operations/cli/

--- a/operations/cli/tsconfig.build.json
+++ b/operations/cli/tsconfig.build.json
@@ -1,4 +1,12 @@
 {
-    "extends": "./tsconfig.json",
-    "exclude": ["src/**/*.test.ts"],
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "inlineSources": false,
+    "sourceMap": true
+  },
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/operations/cli/tsconfig.json
+++ b/operations/cli/tsconfig.json
@@ -1,10 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "declaration": true,
-    "outDir": "dist",
-    "rootDir": "src",
-    "target": "es2022",
+    "noEmit": true
   },
-  "include": ["./src/**/*"],
+  "include": ["./src/**/*"]
 }

--- a/operations/native-yield/automation-service/Dockerfile
+++ b/operations/native-yield/automation-service/Dockerfile
@@ -21,7 +21,7 @@ ENV PNPM_STORE_DIR=/pnpm/store
 
 WORKDIR /usr/src/app
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json tsconfig.base.json ./
 
 COPY ./operations/native-yield/automation-service/package.json ./operations/native-yield/automation-service/package.json
 COPY ./ts-libs/linea-shared-utils/package.json ./ts-libs/linea-shared-utils/package.json

--- a/operations/native-yield/automation-service/tsconfig.build.json
+++ b/operations/native-yield/automation-service/tsconfig.build.json
@@ -3,10 +3,10 @@
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
-    "inlineSources": true,
     "noEmit": false,
     "outDir": "dist",
     "rootDir": ".",
+    "inlineSources": false,
     "sourceMap": true
   },
   "include": ["./src/**/*.ts", "**/run.ts"],

--- a/operations/native-yield/automation-service/tsconfig.json
+++ b/operations/native-yield/automation-service/tsconfig.json
@@ -1,17 +1,10 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "noEmit": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "strictPropertyInitialization": false,
     "exactOptionalPropertyTypes": false
-  },
-  "references": [
-    {
-      "path": "../../../ts-libs/linea-shared-utils"
-    },
-    {
-      "path": "../../../ts-libs/sdk/sdk-ethers"
-    }
-  ]
+  }
 }

--- a/operations/native-yield/lido-governance-monitor/Dockerfile
+++ b/operations/native-yield/lido-governance-monitor/Dockerfile
@@ -19,7 +19,7 @@ FROM base AS builder
 
 WORKDIR /usr/src/app
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json tsconfig.base.json ./
 
 COPY ./operations/native-yield/lido-governance-monitor/package.json ./operations/native-yield/lido-governance-monitor/package.json
 COPY ./ts-libs/linea-shared-utils/package.json ./ts-libs/linea-shared-utils/package.json

--- a/operations/native-yield/lido-governance-monitor/tsconfig.build.json
+++ b/operations/native-yield/lido-governance-monitor/tsconfig.build.json
@@ -3,6 +3,10 @@
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "inlineSources": false,
     "sourceMap": true
   },
   "exclude": ["**/*.test.ts", "**/__tests__/**", "**/__mocks__/**"]

--- a/operations/native-yield/lido-governance-monitor/tsconfig.json
+++ b/operations/native-yield/lido-governance-monitor/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": ".",
+    "noEmit": true,
     "module": "NodeNext",
     "moduleResolution": "NodeNext"
   },

--- a/postman/Dockerfile
+++ b/postman/Dockerfile
@@ -25,7 +25,7 @@ ENV NATIVE_LIBS_RELEASE_TAG=${NATIVE_LIBS_RELEASE_TAG}
 
 # Copy workspace and package files for dependency installation
 # This layer is cached unless these files change
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json tsconfig.base.json ./
 
 COPY ./postman/package.json ./postman/package.json
 COPY ./ts-libs/sdk/sdk-core/package.json ./ts-libs/sdk/sdk-core/package.json

--- a/postman/tsconfig.build.json
+++ b/postman/tsconfig.build.json
@@ -3,10 +3,10 @@
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
-    "inlineSources": true,
     "noEmit": false,
     "outDir": "dist",
     "rootDir": ".",
+    "inlineSources": false,
     "sourceMap": true
   },
   "include": ["./src/**/*.ts", "scripts/**/runPostman.ts"],

--- a/postman/tsconfig.json
+++ b/postman/tsconfig.json
@@ -1,20 +1,10 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
+    "noEmit": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "strictPropertyInitialization": false,
     "exactOptionalPropertyTypes": false
-  },
-  "references": [
-    {
-      "path": "../ts-libs/linea-native-libs"
-    },
-    {
-      "path": "../ts-libs/linea-shared-utils"
-    },
-    {
-      "path": "../ts-libs/sdk/sdk-ethers"
-    }
-  ]
+  }
 }

--- a/ts-libs/linea-native-libs/tsconfig.build.json
+++ b/ts-libs/linea-native-libs/tsconfig.build.json
@@ -1,20 +1,13 @@
 {
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-      "declaration": true,
-      "declarationMap": true,
-      "emitDeclarationOnly": true,
-      "inlineSources": true,
-      "noEmit": false,
-      "outDir": "dist",
-      "rootDir": "src",
-      "sourceMap": true,
-      "composite": false,
-    },
-    "include": ["./src/**/*.ts"],
-    "exclude": [
-      "./src/helpers/**/*",
-      "./src/**/__tests__/**/*",
-      "./src/**/*.test.ts",
-    ]
-  }
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["./src/**/*.ts"],
+  "exclude": ["./src/helpers/**/*", "./src/**/__tests__/**/*", "./src/**/*.test.ts"]
+}

--- a/ts-libs/linea-native-libs/tsconfig.json
+++ b/ts-libs/linea-native-libs/tsconfig.json
@@ -1,8 +1,8 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noUncheckedIndexedAccess": true,
-    "composite": true,
+    "noEmit": true,
     "removeComments": false
   }
 }

--- a/ts-libs/linea-native-libs/tsup.config.ts
+++ b/ts-libs/linea-native-libs/tsup.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
   dts: true,
   clean: true,
   sourcemap: true,
+  esbuildOptions(options) {
+    options.sourcesContent = false;
+  },
   minify: true,
   outDir: "dist",
 });

--- a/ts-libs/linea-shared-utils/package.json
+++ b/ts-libs/linea-shared-utils/package.json
@@ -4,6 +4,9 @@
   "description": "",
   "author": "Consensys Software Inc.",
   "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/ts-libs/linea-shared-utils/tsconfig.build.json
+++ b/ts-libs/linea-shared-utils/tsconfig.build.json
@@ -1,15 +1,13 @@
 {
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-      "declaration": true,
-      "declarationMap": true,
-      "inlineSources": true,
-      "noEmit": false,
-      "emitDecoratorMetadata": false,
-      "sourceMap": true,
-      "outDir": "dist",
-      "rootDir": "src",
-      "composite": false
-    },
-    "include": ["src"],
-  }
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": false,
+    "emitDecoratorMetadata": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/__tests__/**"]
+}

--- a/ts-libs/linea-shared-utils/tsconfig.json
+++ b/ts-libs/linea-shared-utils/tsconfig.json
@@ -1,9 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "composite": true,
+    "noEmit": true,
     "removeComments": false,
     "isolatedModules": false,
     "strictPropertyInitialization": false,

--- a/ts-libs/linea-shared-utils/tsup.config.ts
+++ b/ts-libs/linea-shared-utils/tsup.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
   dts: true,
   clean: true,
   sourcemap: true,
+  esbuildOptions(options) {
+    options.sourcesContent = false;
+  },
   minify: true,
   splitting: false,
   outDir: "dist",

--- a/ts-libs/sdk/sdk-core/tsconfig.build.json
+++ b/ts-libs/sdk/sdk-core/tsconfig.build.json
@@ -1,15 +1,13 @@
 {
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-      "declaration": true,
-      "declarationMap": true,
-      "inlineSources": true,
-      "noEmit": false,
-      "emitDecoratorMetadata": false,
-      "sourceMap": true,
-      "outDir": "dist",
-      "rootDir": "src",
-      "composite": false
-    },
-    "include": ["src"],
-  }
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": false,
+    "emitDecoratorMetadata": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/__tests__/**"]
+}

--- a/ts-libs/sdk/sdk-core/tsconfig.json
+++ b/ts-libs/sdk/sdk-core/tsconfig.json
@@ -1,9 +1,9 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "composite": true,
+    "noEmit": true,
     "removeComments": false,
     "isolatedModules": false,
     "strictPropertyInitialization": false,

--- a/ts-libs/sdk/sdk-core/tsup.config.ts
+++ b/ts-libs/sdk/sdk-core/tsup.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
   dts: true,
   clean: true,
   sourcemap: true,
+  esbuildOptions(options) {
+    options.sourcesContent = false;
+  },
   minify: true,
   outDir: "dist",
 });

--- a/ts-libs/sdk/sdk-ethers/tsconfig.build.json
+++ b/ts-libs/sdk/sdk-ethers/tsconfig.build.json
@@ -1,17 +1,14 @@
 {
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-      "declaration": true,
-      "declarationMap": true,
-      "inlineSources": true,
-      "noEmit": false,
-      "outDir": "dist",
-      "rootDir": "src",
-      "sourceMap": true
-    },
-    "include": ["./src/**/*.ts"],
-    "exclude": [
-      "src/**/*.test.ts",
-      "src/utils/testing/constants/events.ts",
-    ]
-  }
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": false,
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "inlineSources": false,
+    "sourceMap": true
+  },
+  "include": ["./src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "src/utils/testing/constants/events.ts"]
+}

--- a/ts-libs/sdk/sdk-ethers/tsconfig.json
+++ b/ts-libs/sdk/sdk-ethers/tsconfig.json
@@ -1,9 +1,9 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "composite": true,
+    "noEmit": true,
     "removeComments": false,
     "isolatedModules": false,
     "strictPropertyInitialization": false,

--- a/ts-libs/sdk/sdk-viem/tsconfig.build.json
+++ b/ts-libs/sdk/sdk-viem/tsconfig.build.json
@@ -1,9 +1,10 @@
 {
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-      "sourceMap": true,
-      "rootDir": "./src",
-      "composite": false
-    },
-    "include": ["src"],
-  }
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/__tests__/**"]
+}

--- a/ts-libs/sdk/sdk-viem/tsconfig.json
+++ b/ts-libs/sdk/sdk-viem/tsconfig.json
@@ -1,10 +1,9 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "lib": ["ES2022", "DOM"],
-    "noEmit": false,
     "skipLibCheck": true,
-    "noUnusedParameters": true, 
+    "noUnusedParameters": true,
     "noErrorTruncation": true,
     "strictPropertyInitialization": false,
     "experimentalDecorators": true,
@@ -15,9 +14,6 @@
     "exactOptionalPropertyTypes": true,
     "allowSyntheticDefaultImports": false,
     "isolatedModules": true,
-    "composite": true,
-  },
-  "references": [{
-    "path": "../sdk-core"
-  }]
+    "noEmit": true
+  }
 }

--- a/ts-libs/sdk/sdk-viem/tsup.config.ts
+++ b/ts-libs/sdk/sdk-viem/tsup.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
   dts: true,
   clean: true,
   sourcemap: true,
+  esbuildOptions(options) {
+    options.sourcesContent = false;
+  },
   minify: true,
   outDir: "dist",
 });

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "moduleResolution": "nodenext",
+    "module": "nodenext",
+    "target": "es2022",
+    "strict": true,
+    "esModuleInterop": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "removeComments": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "noErrorTruncation": true,
+    "exactOptionalPropertyTypes": true
+  },
+  "exclude": ["**/node_modules", "**/dist", "*.d.ts", "**/.*/"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,24 +1,9 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "baseUrl": ".",
-    "moduleResolution": "nodenext",
-    "module": "nodenext",
-    "target": "es2022",
-    "sourceMap": true,
-    "strict": true,
-    "esModuleInterop": true,
-    "noImplicitReturns": true,
-    "noUnusedLocals": true,
-    "resolveJsonModule": true,
-    "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": true,
-    "removeComments": true,
-    "skipLibCheck": true,
-    "isolatedModules": true,
-    "noErrorTruncation": true,
-    "exactOptionalPropertyTypes": true,
-    "noEmit": false
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true
   },
-  "exclude": ["**/node_modules", "**/dist", "*.d.ts", "**/.*/"]
+  "include": ["*.config.mjs"]
 }


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide monorepo build and typecheck layout change (dropping composite/references) could break CI, Docker builds, or package emits if any package still relied on tsc project references.
> 
> **Overview**
> Introduces **`tsconfig.base.json`** as the shared strict compiler defaults and makes the root **`tsconfig.json`** a thin, **`noEmit`** config for workspace-level tooling (e.g. `*.config.mjs`).
> 
> Across packages (SDK, integrity verifiers, postman, operations, contracts, e2e), **dev `tsconfig.json` files now extend the base and set `noEmit: true`**, dropping **`composite`** and **TypeScript project `references`** in favor of a simpler layout. **Emit settings move into `tsconfig.build.json`** (and tsup), with trimmed duplicate **`sourceMap` / `inlineSources`** on the TypeScript build configs where bundling owns maps.
> 
> **tsup** builds set **`esbuildOptions.sourcesContent = false`** on emitted sourcemaps. **Docker build stages** copy **`tsconfig.base.json`** into the image context. **`@consensys/linea-shared-utils`** adds a **`files: ["dist"]`** publish whitelist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3d4abac24f68e613b9aca02796565361446dd9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->