### PR TITLE
feat(coordinator): implement ExecutionProofGeneratingCoordinator for RISC-V l2-execution proofs

### DIFF
--- a/coordinator/core/src/main/kotlin/lineth/coordination/riscv/execution/ExecutionProofGeneratingCoordinator.kt
+++ b/coordinator/core/src/main/kotlin/lineth/coordination/riscv/execution/ExecutionProofGeneratingCoordinator.kt
@@ -1,0 +1,167 @@
+package lineth.coordination.riscv.execution
+
+import com.github.michaelbull.result.getOrElse
+import com.github.michaelbull.result.runCatching
+import io.vertx.core.Vertx
+import linea.clients.L2ExecutionProofRequestV1
+import linea.clients.L2ExecutionProofResponseV1
+import linea.clients.L2ExecutionProverClientV1
+import linea.domain.BlockIntervalProofIndex
+import linea.domain.BlocksConflation
+import linea.timer.TimerSchedule
+import linea.timer.VertxPeriodicPollingService
+import lineth.conflation.ConflationHandler
+import lineth.metrics.LineaMetricsCategory
+import net.consensys.linea.async.AsyncRetryer
+import net.consensys.linea.metrics.MetricsFacade
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.util.concurrent.ConcurrentLinkedDeque
+import kotlin.time.Duration
+
+fun interface L2ExecutionRequestBuilder {
+  fun build(conflation: BlocksConflation): SafeFuture<L2ExecutionProofRequestV1>
+}
+
+fun interface L2ExecutionProofHandler {
+  fun acceptNewL2ExecutionProof(proof: L2ExecutionProofResponseV1): SafeFuture<*>
+}
+
+class ExecutionProofGeneratingCoordinator(
+  private val l2ExecutionProverClient: L2ExecutionProverClientV1,
+  private val l2ExecutionRequestBuilder: L2ExecutionRequestBuilder,
+  private val l2ExecutionProofHandler: L2ExecutionProofHandler,
+  private val vertx: Vertx,
+  private val config: Config,
+  private val log: Logger = LogManager.getLogger(ExecutionProofGeneratingCoordinator::class.java),
+  metricsFacade: MetricsFacade,
+) : ConflationHandler,
+  VertxPeriodicPollingService(
+    vertx = vertx,
+    name = "L2ExecutionProofPollingService",
+    pollingIntervalMs = config.executionProofPollingInterval.inWholeMilliseconds,
+    log = log,
+    timerSchedule = TimerSchedule.FIXED_DELAY,
+  ) {
+
+  data class Config(
+    val conflationAndProofGenerationRetryBackoffDelay: Duration,
+    val executionProofPollingInterval: Duration,
+    val executionProofPollsPerTick: Int = 200,
+  )
+
+  private val proofRequestsInProgress = ConcurrentLinkedDeque<BlockIntervalProofIndex>()
+
+  init {
+    metricsFacade.createGauge(
+      category = LineaMetricsCategory.BATCH,
+      name = "prover.pendingproofs",
+      description = "Number of l2-execution proof requests waiting for responses",
+      measurementSupplier = { proofRequestsInProgress.size },
+    )
+  }
+
+  private fun pollProofIndex(proofIndex: BlockIntervalProofIndex): SafeFuture<*> {
+    return l2ExecutionProverClient.findProofResponse(proofIndex).thenCompose { proofResponse ->
+      if (proofResponse != null) {
+        log.info("l2-execution proof generated: blocks={}", proofIndex.intervalString())
+        l2ExecutionProofHandler.acceptNewL2ExecutionProof(proofResponse).thenApply {
+          proofRequestsInProgress.remove(proofIndex)
+        }
+      } else {
+        SafeFuture.completedFuture(Unit)
+      }
+    }
+  }
+
+  override fun action(): SafeFuture<*> {
+    if (proofRequestsInProgress.isEmpty()) {
+      return SafeFuture.completedFuture(Unit)
+    }
+    val iterator = proofRequestsInProgress.iterator()
+    val proofIndicesToPoll = mutableListOf<BlockIntervalProofIndex>()
+    while (iterator.hasNext() && proofIndicesToPoll.size < config.executionProofPollsPerTick) {
+      proofIndicesToPoll.add(iterator.next())
+    }
+    val proofsPollFutures = proofIndicesToPoll.map { pollProofIndex(it) }
+    return SafeFuture.allOf(proofsPollFutures.stream())
+  }
+
+  override fun handleConflatedBatch(conflation: BlocksConflation): SafeFuture<*> {
+    val blockIntervalString = conflation.conflationResult.intervalString()
+    return runCatching {
+      log.info(
+        "new batch: batch={} trigger={}",
+        blockIntervalString,
+        conflation.conflationResult.conflationTrigger,
+      )
+      AsyncRetryer.retry(
+        vertx = vertx,
+        backoffDelay = config.conflationAndProofGenerationRetryBackoffDelay,
+        exceptionConsumer = {
+          log.warn(
+            "l2-execution proof creation flow failed batch={} will retry in backOff={} errorMessage={}",
+            blockIntervalString,
+            config.conflationAndProofGenerationRetryBackoffDelay,
+            it.message,
+          )
+        },
+      ) {
+        conflationToProofCreation(conflation)
+      }
+    }.getOrElse { error -> SafeFuture.failedFuture<Unit>(error) }
+      .whenException { th ->
+        log.error(
+          "l2-execution proof request failed: batch={} errorMessage={}",
+          blockIntervalString,
+          th.message,
+          th,
+        )
+      }
+  }
+
+  private fun conflationToProofCreation(conflation: BlocksConflation): SafeFuture<*> {
+    val blockIntervalString = conflation.conflationResult.intervalString()
+    return l2ExecutionRequestBuilder.build(conflation)
+      .whenException { th ->
+        log.debug(
+          "l2-execution request building failed: batch={} errorMessage={}",
+          blockIntervalString,
+          th.message,
+          th,
+        )
+      }
+      .thenCompose { proofRequest ->
+        l2ExecutionProverClient.createProofRequest(proofRequest)
+          .thenCompose { proofIndex ->
+            l2ExecutionProverClient.findProofResponse(proofIndex)
+              .thenCompose<Unit> { existingResponse ->
+                if (existingResponse != null) {
+                  log.info(
+                    "batch={} already proven, skipping l2-execution proof response polling",
+                    blockIntervalString,
+                  )
+                  l2ExecutionProofHandler.acceptNewL2ExecutionProof(existingResponse).thenApply { }
+                } else {
+                  log.info(
+                    "l2-execution proof request generated: proofIndex={} batch={}",
+                    proofIndex,
+                    blockIntervalString,
+                  )
+                  proofRequestsInProgress.addLast(proofIndex)
+                  SafeFuture.completedFuture(Unit)
+                }
+              }
+          }
+          .whenException { th ->
+            log.debug(
+              "l2-execution proof failure: batch={} errorMessage={}",
+              blockIntervalString,
+              th.message,
+              th,
+            )
+          }
+      }
+  }
+}


### PR DESCRIPTION
#3086

## Summary

Adds `ExecutionProofGeneratingCoordinator`, `L2ExecutionRequestBuilder`, and `L2ExecutionProofHandler` to `coordinator/core` for the Type-1 RISC-V conflation flow.

- Receives a `BlocksConflation`, builds an `L2ExecutionProofRequestV1` via the injected `L2ExecutionRequestBuilder`, and submits it idempotently through `L2ExecutionProverClientV1`
- Tracks pending `BlockIntervalProofIndex` entries and polls for responses via `VertxPeriodicPollingService`
- Delivers `L2ExecutionProofResponseV1` (including proof bytes needed downstream for rollup proof assembly) to `L2ExecutionProofHandler`
- On restart: if a proof is already done, skips re-queuing and delivers directly to the handler
- Mirrors the submit-then-poll lifecycle of `ProofGeneratingConflationHandlerImpl` (Type-2 flow)

## Test plan

- [ ] Unit tests: happy path, already-proven skip on restart, retry on transient failure

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New batch/proof orchestration on the critical conflation path; mistakes could stall batches or mishandle already-proven intervals on restart, though behavior mirrors an existing coordinator and uses idempotent prover calls.
> 
> **Overview**
> Introduces a **Type-1 RISC-V** conflation handler that drives **L2 execution proof** generation instead of the existing traces + Type-2 ZK path.
> 
> `ExecutionProofGeneratingCoordinator` implements `ConflationHandler` and a periodic poller: on each conflated batch it builds an `L2ExecutionProofRequestV1` via injectable `L2ExecutionRequestBuilder`, submits through `L2ExecutionProverClientV1`, and either enqueues the `BlockIntervalProofIndex` for polling or, if a response already exists, delivers it immediately to `L2ExecutionProofHandler` without re-queuing. Pending requests are tracked in a deque with a **prover.pendingproofs** gauge; polling is capped per tick (`executionProofPollsPerTick`). Transient failures use `AsyncRetryer` with configurable backoff, matching the submit-then-poll pattern used by `ProofGeneratingConflationHandlerImpl`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87d8b085ea33eb9051535dc041de44ef6edb2b2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->