### PR TITLE
fix(maru): declare jar task dependency on runtimeClasspath to fix manifest race

### DIFF
--- a/maru/app/build.gradle
+++ b/maru/app/build.gradle
@@ -104,6 +104,12 @@ jar {
   // jar task actually runs (execution phase), never during configuration. Resolving it eagerly
   // here (e.g. `.collect {}`) would force Besu dependency resolution on every invocation —
   // including `clean` — which is what previously dragged an on-demand Besu build into a clean.
+  // dependsOn(Configuration) wires the tasks that build runtimeClasspath's artifacts (e.g.
+  // :maru:linea-finalization-provider:jar) as task dependencies without resolving it here;
+  // without this, the manifest Provider below can be queried before those tasks finish under
+  // parallel execution, failing with "Querying the mapped value of provider(...) before task
+  // ':maru:linea-finalization-provider:jar' has completed is not supported".
+  dependsOn(configurations.runtimeClasspath)
   def classPathAttribute = configurations.runtimeClasspath.elements.map { locations ->
     locations
         .collect { it.asFile.name }


### PR DESCRIPTION
The Class-Path manifest attribute in maru/app/build.gradle is computed
  via a Provider that maps over configurations.runtimeClasspath.elements,
  deferring resolution to the jar task's execution phase. However, the
  jar task never declared a dependency on the tasks that build those
  classpath artifacts (e.g. :maru:linea-finalization-provider:jar), so
  under parallel execution Gradle could evaluate the manifest Provider
  before that task finished, failing with:

    Could not copy MANIFEST.MF ...
    Querying the mapped value of provider(java.util.Set) before task
    ':maru:linea-finalization-provider:jar' has completed is not supported

  Add dependsOn(configurations.runtimeClasspath) to the jar task to wire
  the correct task-graph edge. This only affects scheduling order when
  jar is actually requested — it does not resolve the configuration
  eagerly, so clean and other unrelated tasks are unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only Gradle task ordering change with no runtime or application logic impact.
> 
> **Overview**
> Fixes intermittent **`maru` `jar` failures** under parallel Gradle builds when writing **`MANIFEST.MF`**.
> 
> The **`jar`** task builds **`Class-Path`** from a lazy **`runtimeClasspath.elements`** provider. That provider was not tied to the tasks that produce project jars on that classpath (e.g. **`:maru:linea-finalization-provider:jar`**), so Gradle could evaluate the manifest before those tasks finished.
> 
> Adds **`dependsOn(configurations.runtimeClasspath)`** on **`jar`** so those producer tasks run first. Scheduling only applies when **`jar`** is requested; classpath resolution stays deferred so **`clean`** and unrelated tasks are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6457f1beb04f1f5ac1ee9d89e606a07e0772ad8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->