### PR TITLE
chore(docker): use patched Erigon v3.3.0 image for Linea from-scratch sync

### DIFF
--- a/docs/getting-started/linea-mainnet/docker-compose.yml
+++ b/docs/getting-started/linea-mainnet/docker-compose.yml
@@ -118,26 +118,28 @@ services:
 
   # Erigon initialization
   erigon-init:
-    image: erigontech/erigon:2.61.0
+    image: linea-erigon:v3.3.0-linea-patched
     command:
       - init
       - /genesis.json
       - --datadir=/data
     volumes:
-      - ./genesis.json:/genesis.json:ro
-      - linea-mainnet-erigon:/home/erigon/.local/share/erigon/
+      - ./geth/geth-genesis.json:/genesis.json:ro
+      - linea-mainnet-erigon:/data
 
-  # Erigon node
+  # Erigon node (requires --externalcl + Maru for Linea)
   erigon-node:
-    image: erigontech/erigon:2.61.0
-    pull_policy: always
+    hostname: el-client
+    image: linea-erigon:v3.3.0-linea-patched
     restart: unless-stopped
     stop_grace_period: 30s
     depends_on:
       erigon-init:
         condition: service_completed_successfully
     command:
+      - --datadir=/data
       - --networkid=59144
+      - --externalcl
       - --prune=hrtc
       - --http
       - --http.addr=0.0.0.0
@@ -147,13 +149,19 @@ services:
       - --http.vhosts=*
       - --bootnodes=enode://069800db9e6e0ec9cadca670994ef1aea2cfd3d88133e63ecadbc1cdbd1a5847b09838ee08d8b5f02a9c32ee13abeb4d4104bb5514e5322c9d7ee19f41ff3e51@3.132.73.210:31002,enode://97706526cf79df9d930003644f9156805f6c8bd964fc79e083444f7014ce10c9bdd2c5049e63b58040dca1d4c82ebef970822198cf0714de830cff4111534ff1@18.223.198.165:31004,enode://328a18615d5bd7993b2d6af452fd316be6e3a85716faedf4448b3f77713383a872d9f8f62f36407053b368872b109f65c3a74069a71204d3242aa283ff33312e@18.223.198.165:31000,enode://228e1b8a4931e46f383e30721dac21fb8fb4e5e1b32c870e13b25478c82db3dc1cd9e7ceb93d302a766466b55638cc9c5cbfc43aa48fa41ced19baf365951f76@3.1.142.64:31002,enode://c22eb0d40fc3ad5ea710aeddea906567778166bfe18c157955e8c39b23a46c45db18a0fa2ba07f2b64c81178a8c796aec2a29151533920ead06fcdfc6d8d03c6@47.128.192.57:31004,enode://b7c1b2bed65a855f7a2104aac9a14674dfdf018fdac763415b373b29ce18cdb81d36328ba4e5c9f12629f3a50c3e8f9ee048f22dbdbe93a82813da89c6b81334@51.20.235.126:31004,enode://c92b454bed3028c8dfafe0251cd00fc6bc5462a091c03c53569651c17782df88edc7722b29925e66c60bf8c516be00a47f252d9007cd1805653150f492527573@13.50.94.193:31000
       - --verbosity=3
+      - --authrpc.addr=0.0.0.0
+      - --authrpc.port=8550
+      - --authrpc.vhosts=*
+      - --authrpc.jwtsecret=/data/jwt
     ports:
       - 30303:30303
       - 30303:30303/udp
       - 8545:8545
+      - 8550:8550
     volumes:
-      - ./genesis.json:/genesis.json:ro
-      - linea-mainnet-erigon:/home/erigon/.local/share/erigon/
+      - ./geth/geth-genesis.json:/genesis.json:ro
+      - ./engine-jwt:/data/jwt:ro
+      - linea-mainnet-erigon:/data
 
   # Nethermind node
   nethermind-node:

--- a/docs/getting-started/linea-mainnet/docker-compose.yml
+++ b/docs/getting-started/linea-mainnet/docker-compose.yml
@@ -119,10 +119,12 @@ services:
   # Erigon initialization
   erigon-init:
     image: linea-erigon:v3.3.0-linea-patched
+    # Run init as root so it can chown the chain-data volume for the non-root
+    # erigon user (UID 1000) that erigon-node runs as.
+    user: "0:0"
+    entrypoint: ["/bin/sh", "-c"]
     command:
-      - init
-      - /genesis.json
-      - --datadir=/data
+      - "erigon --datadir=/data init /genesis.json && chown -R 1000:1000 /data"
     volumes:
       - ./geth/geth-genesis.json:/genesis.json:ro
       - linea-mainnet-erigon:/data

--- a/docs/getting-started/linea-mainnet/docker-compose.yml
+++ b/docs/getting-started/linea-mainnet/docker-compose.yml
@@ -140,7 +140,7 @@ services:
       - --datadir=/data
       - --networkid=59144
       - --externalcl
-      - --prune=hrtc
+      - --prune.mode=full
       - --http
       - --http.addr=0.0.0.0
       - --http.port=8545

--- a/docs/getting-started/linea-mainnet/erigon-linea/Dockerfile
+++ b/docs/getting-started/linea-mainnet/erigon-linea/Dockerfile
@@ -1,0 +1,39 @@
+# Erigon v3.3.0 patched for Linea
+# Based on Keith C's findings: https://github.com/erigontech/erigon/issues/18160
+
+FROM golang:1.24-bookworm AS builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Clone Erigon v3.3.0
+WORKDIR /build
+RUN git clone --depth 1 --branch v3.3.0 https://github.com/erigontech/erigon.git .
+
+# Patch 1: Disable block downloader v2 (fixes corruption on EC2/slower machines)
+RUN sed -i 's/const sentryMcDisableBlockDownload = true/const sentryMcDisableBlockDownload = false/' node/eth/backend.go
+
+# Patch 2: Return nil instead of error on empty code for EIP-7002 (Linea has empty withdrawal contract)
+RUN sed -i 's/return nil, fmt.Errorf("\[EIP-7002\] Syscall failure: Empty Code at WithdrawalRequestAddress=%x", params.WithdrawalRequestAddress)/return nil, nil/' execution/protocol/rules/misc/eip7002.go
+
+# Patch 3: Return nil instead of error on empty code for EIP-7251 (Linea has empty consolidation contract)
+RUN sed -i 's/return nil, fmt.Errorf("\[EIP-7251\] Syscall failure: Empty Code at ConsolidationRequestAddress=%x", params.ConsolidationRequestAddress)/return nil, nil/' execution/protocol/rules/misc/eip7251.go
+
+# Build Erigon without silkworm (simpler, no external library needed)
+RUN make erigon BUILD_TAGS=nosilkworm
+
+# Final image
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/build/bin/erigon /usr/local/bin/
+
+EXPOSE 8545 8550 30303 30303/udp
+
+ENTRYPOINT ["erigon"]

--- a/docs/getting-started/linea-mainnet/erigon-linea/Dockerfile
+++ b/docs/getting-started/linea-mainnet/erigon-linea/Dockerfile
@@ -1,7 +1,9 @@
 # Erigon v3.3.0 patched for Linea
 # Based on Keith C's findings: https://github.com/erigontech/erigon/issues/18160
 
-FROM golang:1.24-bookworm AS builder
+# Base images pinned by digest for reproducible, tamper-resistant builds.
+# Bump these digests when refreshing golang / debian patch updates.
+FROM golang:1.24-bookworm@sha256:1a6d4452c65dea36aac2e2d606b01b4a029ec90cc1ae53890540ce6173ea77ac AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \
@@ -9,31 +11,48 @@ RUN apt-get update && apt-get install -y \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-# Clone Erigon v3.3.0
+# Clone Erigon at a pinned commit (v3.3.0 tag -> a0c55b4).
+# Pinning by SHA guards against the lightweight v3.3.0 tag being moved upstream.
+ARG ERIGON_REPO=https://github.com/erigontech/erigon.git
+ARG ERIGON_COMMIT=a0c55b440aa6ac54b2583ff9a4232820eb7947ff
 WORKDIR /build
-RUN git clone --depth 1 --branch v3.3.0 https://github.com/erigontech/erigon.git .
+RUN git init . && \
+    git remote add origin ${ERIGON_REPO} && \
+    git fetch --depth 1 origin ${ERIGON_COMMIT} && \
+    git checkout ${ERIGON_COMMIT}
 
-# Patch 1: Disable block downloader v2 (fixes corruption on EC2/slower machines)
-RUN sed -i 's/const sentryMcDisableBlockDownload = true/const sentryMcDisableBlockDownload = false/' node/eth/backend.go
+# Patch 1: Disable block downloader v2 (fixes corruption on EC2/slower machines).
+# grep verifies the substitution applied; sed exits 0 even on a no-match.
+RUN sed -i 's/const sentryMcDisableBlockDownload = true/const sentryMcDisableBlockDownload = false/' node/eth/backend.go && \
+    grep -q 'const sentryMcDisableBlockDownload = false' node/eth/backend.go
 
-# Patch 2: Return nil instead of error on empty code for EIP-7002 (Linea has empty withdrawal contract)
-RUN sed -i 's/return nil, fmt.Errorf("\[EIP-7002\] Syscall failure: Empty Code at WithdrawalRequestAddress=%x", params.WithdrawalRequestAddress)/return nil, nil/' execution/protocol/rules/misc/eip7002.go
+# Patch 2: Return nil instead of error on empty code for EIP-7002 (Linea has empty withdrawal contract).
+# Verify the original error string is gone (the replacement `return nil, nil` is too generic to grep for).
+RUN sed -i 's/return nil, fmt.Errorf("\[EIP-7002\] Syscall failure: Empty Code at WithdrawalRequestAddress=%x", params.WithdrawalRequestAddress)/return nil, nil/' execution/protocol/rules/misc/eip7002.go && \
+    ! grep -q 'Syscall failure: Empty Code at WithdrawalRequestAddress' execution/protocol/rules/misc/eip7002.go
 
-# Patch 3: Return nil instead of error on empty code for EIP-7251 (Linea has empty consolidation contract)
-RUN sed -i 's/return nil, fmt.Errorf("\[EIP-7251\] Syscall failure: Empty Code at ConsolidationRequestAddress=%x", params.ConsolidationRequestAddress)/return nil, nil/' execution/protocol/rules/misc/eip7251.go
+# Patch 3: Return nil instead of error on empty code for EIP-7251 (Linea has empty consolidation contract).
+RUN sed -i 's/return nil, fmt.Errorf("\[EIP-7251\] Syscall failure: Empty Code at ConsolidationRequestAddress=%x", params.ConsolidationRequestAddress)/return nil, nil/' execution/protocol/rules/misc/eip7251.go && \
+    ! grep -q 'Syscall failure: Empty Code at ConsolidationRequestAddress' execution/protocol/rules/misc/eip7251.go
 
 # Build Erigon without silkworm (simpler, no external library needed)
 RUN make erigon BUILD_TAGS=nosilkworm
 
 # Final image
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
+# Run as a non-root user (matches the repo convention for runtime images).
+# The compose erigon-init service runs as root and chowns /data to 1000:1000
+# before erigon-node starts, so this user can write the chain data volume.
+RUN useradd -m -u 1000 erigon
 COPY --from=builder /build/build/bin/erigon /usr/local/bin/
 
 EXPOSE 8545 8550 30303 30303/udp
+
+USER erigon
 
 ENTRYPOINT ["erigon"]

--- a/docs/getting-started/linea-mainnet/erigon-linea/Makefile
+++ b/docs/getting-started/linea-mainnet/erigon-linea/Makefile
@@ -1,0 +1,21 @@
+IMAGE ?= linea-erigon
+TAG ?= v3.3.0-linea-patched
+PLATFORM ?= linux/amd64
+
+.PHONY: build buildx-info
+
+buildx-info:
+	@docker buildx version
+	@docker buildx ls
+
+# Build locally and load into your Docker daemon.
+# On Apple Silicon (arm64), run: make build PLATFORM=linux/arm64
+build:
+	docker buildx build \
+		--platform $(PLATFORM) \
+		--file Dockerfile \
+		--tag $(IMAGE):$(TAG) \
+		--progress=plain \
+		--load \
+		.
+

--- a/docs/getting-started/linea-mainnet/erigon-linea/README.md
+++ b/docs/getting-started/linea-mainnet/erigon-linea/README.md
@@ -1,0 +1,44 @@
+# Linea-patched Erigon image
+
+This folder contains the build recipe for the **Linea-patched Erigon** image referenced by the
+Linea getting-started compose files. Stock Erigon does not sync current Linea from scratch (see
+the Erigon page in the Linea docs); this image applies the three patches needed to make it work.
+
+## What's different vs upstream `erigontech/erigon:v3.3.0`
+
+The Dockerfile clones upstream `erigontech/erigon` tag `v3.3.0` and applies 3 tiny patches + builds without Silkworm:
+
+- `sentryMcDisableBlockDownload = false` (enables EL-driven bootstrap from genesis; fixes the block-0 hang in [erigontech/erigon#22081](https://github.com/erigontech/erigon/issues/22081))
+- Return `nil` instead of error on empty code for **EIP-7002** (Linea has empty withdrawal contract; fixes [erigontech/erigon#18160](https://github.com/erigontech/erigon/issues/18160))
+- Return `nil` instead of error on empty code for **EIP-7251** (Linea has empty consolidation contract)
+- Build with `BUILD_TAGS=nosilkworm`
+
+See `Dockerfile` for the exact patch lines.
+
+## Build locally
+
+From the repo root:
+
+```bash
+cd docs/getting-started/linea-mainnet/erigon-linea
+make build
+```
+
+This builds `linea-erigon:v3.3.0-linea-patched` and loads it into your local Docker daemon. The
+getting-started compose files reference this image name, so after building you can start the
+node directly:
+
+```bash
+cd docs/getting-started/linea-mainnet
+docker compose up erigon-init erigon-node maru-node
+```
+
+### Apple Silicon (arm64)
+
+The default build target is `linux/amd64` (the platform most node operators run). On an
+Apple Silicon Mac, build for arm64 so the image runs natively:
+
+```bash
+make build PLATFORM=linux/arm64
+```
+

--- a/docs/getting-started/linea-sepolia/docker-compose.yml
+++ b/docs/getting-started/linea-sepolia/docker-compose.yml
@@ -120,10 +120,12 @@ services:
   # Erigon initialization
   erigon-init:
     image: linea-erigon:v3.3.0-linea-patched
+    # Run init as root so it can chown the chain-data volume for the non-root
+    # erigon user (UID 1000) that erigon-node runs as.
+    user: "0:0"
+    entrypoint: ["/bin/sh", "-c"]
     command:
-      - init
-      - /genesis.json
-      - --datadir=/data
+      - "erigon --datadir=/data init /genesis.json && chown -R 1000:1000 /data"
     volumes:
       - ./geth/geth-genesis.json:/genesis.json:ro
       - linea-sepolia-erigon:/data

--- a/docs/getting-started/linea-sepolia/docker-compose.yml
+++ b/docs/getting-started/linea-sepolia/docker-compose.yml
@@ -119,26 +119,28 @@ services:
 
   # Erigon initialization
   erigon-init:
-    image: erigontech/erigon:2.61.0
+    image: linea-erigon:v3.3.0-linea-patched
     command:
       - init
       - /genesis.json
       - --datadir=/data
     volumes:
-      - ./genesis.json:/genesis.json:ro
-      - linea-sepolia-erigon:/home/erigon/.local/share/erigon/
+      - ./geth/geth-genesis.json:/genesis.json:ro
+      - linea-sepolia-erigon:/data
 
-  # Erigon node
+  # Erigon node (requires --externalcl + Maru for Linea)
   erigon-node:
-    image: erigontech/erigon:2.61.0
-    pull_policy: always
+    hostname: el-client
+    image: linea-erigon:v3.3.0-linea-patched
     restart: unless-stopped
     stop_grace_period: 30s
     depends_on:
       erigon-init:
         condition: service_completed_successfully
     command:
+      - --datadir=/data
       - --networkid=59141
+      - --externalcl
       - --prune=hrtc
       - --http
       - --http.addr=0.0.0.0
@@ -148,13 +150,19 @@ services:
       - --http.vhosts=*
       - --bootnodes=enode://6f20afbe4397e51b717a7c1ad3095e79aee48c835eebd9237a3e8a16951ade1fe0e66e981e30ea269849fcb6ba03d838da37f524fabd2a557474194a2e2604fa@18.221.100.27:31002,enode://f88736df958261009d5ad40bde172c67abf68b8881200a4d717a8afd72e4cebf044bd3f35c373d45e8a0d6dbc730506b0699be5f16f5d8df2d63a8252d8b5b52@3.23.75.47:31000,enode://1b026a5eb0ae74300f58987d235ef0e3a550df963345cb3574be3b0b54378bd11f14dfd515a8976f2c2d2826090e9507b8ccc24f896a9ffffffcabcfd996a733@3.129.120.128:31001,enode://ef6ffc19e44c3e6db7cff9a4c2ba5c88d8a6a9372c85bd2c5e8be9950e43faa6f19bd3ed2d126a6fb2e213eb6568eb0d5cc4c933bdadde5bee23401d3a721365@3.129.120.128:31003
       - --verbosity=3
+      - --authrpc.addr=0.0.0.0
+      - --authrpc.port=8550
+      - --authrpc.vhosts=*
+      - --authrpc.jwtsecret=/data/jwt
     ports:
       - 30303:30303
       - 30303:30303/udp
       - 8545:8545
+      - 8550:8550
     volumes:
-      - ./genesis.json:/genesis.json:ro
-      - linea-sepolia-erigon:/home/erigon/.local/share/erigon/
+      - ./geth/geth-genesis.json:/genesis.json:ro
+      - ./engine-jwt:/data/jwt:ro
+      - linea-sepolia-erigon:/data
 
   # Nethermind node
   nethermind-node:

--- a/docs/getting-started/linea-sepolia/docker-compose.yml
+++ b/docs/getting-started/linea-sepolia/docker-compose.yml
@@ -141,7 +141,7 @@ services:
       - --datadir=/data
       - --networkid=59141
       - --externalcl
-      - --prune=hrtc
+      - --prune.mode=full
       - --http
       - --http.addr=0.0.0.0
       - --http.port=8545


### PR DESCRIPTION
## Summary
- Updates the getting-started Docker Compose files (mainnet + sepolia) to reference a patched Erigon image `linea-erigon:v3.3.0-linea-patched`, built locally from a Dockerfile shipped in the repo.
- Adds the `erigon-linea/` build directory (Dockerfile, Makefile, README) under `docs/getting-started/linea-mainnet/`.
- The `erigon-node` service now runs with `--externalcl` so Maru drives block delivery over the Engine API; genesis is mounted directly from `./geth/geth-genesis.json` so no manual copy is needed.
- Switches the prune flag from the Erigon 2 `--prune=hrtc` to the Erigon 3 `--prune.mode=full` (the patched image is built from Erigon v3.3.0, which no longer accepts the old flag and would abort startup).
- Hardens the Dockerfile: pins Erigon source to commit `a0c55b4` (the `v3.3.0` tag) instead of the mutable tag; pins the `golang` and `debian` base images by `@sha256` digest; verifies each `sed` patch actually applied (so upstream drift fails the build loudly instead of shipping unpatched); and runs the final image as a non-root user (UID 1000), with `erigon-init` chowning `/data` so the node can write the chain-data volume.

## Why
Stock Erigon does not sync current Linea from scratch:
- `erigontech/erigon:v3.5.0` with `--externalcl` + Maru hangs at block 0 ([erigontech/erigon#22081](https://github.com/erigontech/erigon/issues/22081)).
- Earlier versions hit `[EIP-7002] Syscall failure: Empty Code` at the Fusaka fork because Linea's genesis allocates no code at the withdrawal/consolidation contract addresses ([erigontech/erigon#18160](https://github.com/erigontech/erigon/issues/18160)).

The patched image applies three fixes on top of Erigon `v3.3.0`:
- `sentryMcDisableBlockDownload = false` (enables EL-driven bootstrap from genesis)
- EIP-7002 empty-code syscall returns `nil` instead of erroring (Fusaka fix)
- EIP-7251 empty-code syscall returns `nil` instead of erroring (Fusaka fix)

## Test plan
- [x] `make build` from `docs/getting-started/linea-mainnet/erigon-linea/` produces `linea-erigon:v3.3.0-linea-patched` (SHA-pinned, digest-pinned, sed patches verified at build time)
- [x] `docker compose up erigon-init` writes genesis into `/data` (owned `1000:1000`); `erigon-node` then starts as `uid=1000` with no permission errors
- [ ] `docker compose up erigon-init erigon-node maru-node` from `docs/getting-started/linea-mainnet/` begins syncing
- [ ] Same for Sepolia (`docs/getting-started/linea-sepolia/`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and local Docker getting-started only; no production app or auth changes, though operators must build the image locally before compose will run.
>
> **Overview**
> Adds a **local build** for `linea-erigon:v3.3.0-linea-patched` under `docs/getting-started/linea-mainnet/erigon-linea/` (Dockerfile, Makefile, README). The image pins Erigon **v3.3.0** (by commit SHA) and applies three Linea-specific patches (block download flag, EIP-7002/7251 empty-code handling) plus a `nosilkworm` build; base images are pinned by digest, each `sed` patch is verified, and the final image runs as a non-root user.
>
> **Mainnet and Sepolia** `docker-compose.yml` Erigon services switch from stock `erigontech/erigon:2.61.0` to that patched image. `erigon-init` initializes `/data` from `./geth/geth-genesis.json` and **chowns** the volume for UID 1000. `erigon-node` is wired for **Maru**: `--externalcl`, Engine API on **8550** with JWT from `./engine-jwt`, `--prune.mode=full`, and `hostname: el-client`.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6448a60dd3486dabdb7998155fd151abcb2df155. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
