### PR TITLE
feat(linea-besu): update to 26.7.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,8 +41,8 @@ undercouchDownload = "5.6.0"
 # This is the single source of truth for the Besu version.
 # During task execution, linea-besu/besu/build.gradle resolves this commit,
 # writes linea-besu/besu/.besu-resolved, and read by dependent modules.
-# Besu version: 26.7.0
-besuCommit = "f036a1738493f52999e931e9a61d9a065b749603"
+# Besu version: 26.7.1
+besuCommit = "49026aaf059f832a93f964d8d27191de2f0580e9"
 blobCompressor = "4.0.1"
 commonsIo = "2.21.0"
 blobShnarfCalculator = "3.0.1"

--- a/linea-besu/besu/.besu-resolved
+++ b/linea-besu/besu/.besu-resolved
@@ -2,5 +2,5 @@
 # Written by Gradle (:linea-besu:resolveBesuVersion) and refreshed by CI
 # (.github/workflows/linea-besu-build-and-publish.yml) on besuCommit bumps.
 # Do NOT edit by hand and do NOT commit local changes — this file is gitignored.
-besuCommit=f036a1738493f52999e931e9a61d9a065b749603
-besuVersion=26.7.0-f036a17
+besuCommit=49026aaf059f832a93f964d8d27191de2f0580e9
+besuVersion=26.7.1-49026aa


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrading the core Besu commit affects the entire execution client stack and plugin compatibility, though it is a patch-level bump with no application code changes in this PR.
> 
> **Overview**
> **Bumps the pinned Besu runtime** from **26.7.0** to **26.7.1** by updating `besuCommit` in `gradle/libs.versions.toml` to commit `49026aaf…`.
> 
> That value is the repo’s single source of truth for which `besu-eth/besu` revision is built and consumed by linea-besu and dependent modules; changing it should drive the usual resolve/build flow (e.g. refreshing `linea-besu/besu/.besu-resolved` and related CI when the commit changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d96de2662a4b5897606f32dcced6ac579807611. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->