### PR TITLE
chore(coordinator): rename Linea to Lineth in app and config

### DIFF
--- a/coordinator/Dockerfile
+++ b/coordinator/Dockerfile
@@ -40,7 +40,7 @@ ARG VCS_REF
 ARG VERSION
 LABEL org.label-schema.build-date=$BUILD_DATE \
 	org.label-schema.name="coordinator" \
-	org.label-schema.description="Coordinator for Linea" \
+	org.label-schema.description="Coordinator for Lineth" \
 	org.label-schema.url="https://consensys.io/" \
 	org.label-schema.vcs-ref=$VCS_REF \
 	org.label-schema.vcs-url="https://github.com/LFDT-Lineth/lineth-monorepo" \

--- a/coordinator/app/src/configDocs/kotlin/linea/coordinator/config/v2/docs/CoordinatorConfigDocsSpec.kt
+++ b/coordinator/app/src/configDocs/kotlin/linea/coordinator/config/v2/docs/CoordinatorConfigDocsSpec.kt
@@ -42,7 +42,7 @@ object CoordinatorConfigDocsSpec : ConfigDocsSpec {
     ),
     ConfigFileRoot(
       label = "smart-contract-errors",
-      description = "Mapping of Linea smart-contract revert error codes to messages.",
+      description = "Mapping of Lineth smart-contract revert error codes to messages.",
       rootClass = SmartContractErrorCodesConfigFileToml::class,
     ),
   )

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/CoordinatorAppCli.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/CoordinatorAppCli.kt
@@ -18,7 +18,7 @@ import java.util.concurrent.Callable
   name = CoordinatorAppCli.COMMAND_NAME,
   showDefaultValues = true,
   abbreviateSynopsis = true,
-  description = ["Runs Linea Coordinator"],
+  description = ["Runs Lineth Coordinator"],
   version = ["0.0.1"],
   synopsisHeading = "%n",
   descriptionHeading = "%nDescription:%n%n",

--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/CoordinatorConfigFilesToml.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/CoordinatorConfigFilesToml.kt
@@ -13,7 +13,7 @@ import net.consensys.linea.traces.TracingModuleV5
 data class CoordinatorConfigFileToml(
   @param:ConfigSection("Shared defaults (L1/L2 endpoints and retry policies) reused by coordinator services.")
   val defaults: DefaultsToml = DefaultsToml(),
-  @param:ConfigSection("Linea protocol contract addresses and genesis settings.")
+  @param:ConfigSection("Lineth protocol contract addresses and genesis settings.")
   val protocol: ProtocolToml,
   @param:ConfigSection("Block conflation, blob compression, and proof aggregation settings.")
   val conflation: ConflationToml = ConflationToml(),
@@ -67,7 +67,7 @@ data class GasPriceCapTimeOfDayMultipliersConfigFileToml(
 
 data class SmartContractErrorCodesConfigFileToml(
   @param:ConfigDoc(
-    description = "Mapping of Linea smart-contract revert error codes to human-readable messages, " +
+    description = "Mapping of Lineth smart-contract revert error codes to human-readable messages, " +
       "used to decode on-chain rejection reasons.",
   )
   val smartContractErrors: SmartContractErrors,

--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/ProtocolToml.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/ProtocolToml.kt
@@ -8,7 +8,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 data class ProtocolToml(
-  @param:ConfigSection("Linea genesis state root and shnarf.")
+  @param:ConfigSection("Lineth genesis state root and shnarf.")
   val genesis: Genesis,
   @param:ConfigSection("L1 rollup contract and timing settings.")
   val l1: Layer1Config,
@@ -17,12 +17,12 @@ data class ProtocolToml(
 ) {
   data class Genesis(
     @param:ConfigDoc(
-      description = "Genesis state root hash of the Linea chain (hex).",
+      description = "Genesis state root hash of the Lineth chain (hex).",
       example = "0x01d9afcd495c870f3ae9d8362cd0257a7de2057055058183596719285cae6101",
     )
     val genesisStateRootHash: ByteArray,
     @param:ConfigDoc(
-      description = "Genesis shnarf (starting shnarf) of the Linea chain (hex).",
+      description = "Genesis shnarf (starting shnarf) of the Lineth chain (hex).",
       example = "0xc286ff42414401ccdc23ea8e738775378e8f6c6f7b2966eb2747798d45571b79",
     )
     val genesisShnarf: ByteArray,
@@ -48,7 +48,7 @@ data class ProtocolToml(
 
   data class Layer1Config(
     @param:ConfigDoc(
-      description = "Address of the Linea rollup contract on L1.",
+      description = "Address of the Lineth rollup contract on L1.",
       example = "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",
     )
     val contractAddress: String,
@@ -63,7 +63,7 @@ data class ProtocolToml(
 
   data class Layer2Config(
     @param:ConfigDoc(
-      description = "Address of the Linea contract on L2.",
+      description = "Address of the Lineth contract on L2.",
       example = "0xe537D669CA013d86EBeF1D64e40fC74CADC91987",
     )
     val contractAddress: String,

--- a/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/MessageAnchoringConfigParsingTest.kt
+++ b/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/MessageAnchoringConfigParsingTest.kt
@@ -25,7 +25,7 @@ class MessageAnchoringConfigParsingTest {
       l1-endpoint = "http://l1-el-node:8545"
       l2-endpoint = "http://sequencer:8545"
       l1-highest-block-tag="FINALIZED"
-      l2-highest-block-tag="LATEST" # optional, default to LATEST it shall not be necessary as Lineth has instant finality
+      l2-highest-block-tag="LATEST" # optional, defaults to LATEST; not strictly necessary since Lineth has instant finality
 
       [message-anchoring.l1-request-retries]
       max-retries = 4

--- a/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/MessageAnchoringConfigParsingTest.kt
+++ b/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/MessageAnchoringConfigParsingTest.kt
@@ -25,7 +25,7 @@ class MessageAnchoringConfigParsingTest {
       l1-endpoint = "http://l1-el-node:8545"
       l2-endpoint = "http://sequencer:8545"
       l1-highest-block-tag="FINALIZED"
-      l2-highest-block-tag="LATEST" # optional, default to LATEST it shall not be necessary as Linea has instant finality
+      l2-highest-block-tag="LATEST" # optional, default to LATEST it shall not be necessary as Lineth has instant finality
 
       [message-anchoring.l1-request-retries]
       max-retries = 4

--- a/coordinator/core-interfaces/src/main/kotlin/linea/persistence/ForcedTransactionsDao.kt
+++ b/coordinator/core-interfaces/src/main/kotlin/linea/persistence/ForcedTransactionsDao.kt
@@ -36,7 +36,7 @@ interface ForcedTransactionsDao {
 }
 
 /**
- * Forced transactions are an Opt-in feature in Lineth stack,
+ * Forced transactions are an opt-in feature in the Lineth stack,
  * so we provide a no-op implementation of the DAO that can be used when the feature is disabled.
  *
  * Also, until this feature is fully implemented and integrated, this no-op implementation can be used

--- a/coordinator/core-interfaces/src/main/kotlin/linea/persistence/ForcedTransactionsDao.kt
+++ b/coordinator/core-interfaces/src/main/kotlin/linea/persistence/ForcedTransactionsDao.kt
@@ -36,7 +36,7 @@ interface ForcedTransactionsDao {
 }
 
 /**
- * Forced transactions are an Opt-in feature in Linea stack,
+ * Forced transactions are an Opt-in feature in Lineth stack,
  * so we provide a no-op implementation of the DAO that can be used when the feature is disabled.
  *
  * Also, until this feature is fully implemented and integrated, this no-op implementation can be used

--- a/coordinator/core/src/main/kotlin/linea/conflation/calculators/GlobalBlobAwareConflationCalculator.kt
+++ b/coordinator/core/src/main/kotlin/linea/conflation/calculators/GlobalBlobAwareConflationCalculator.kt
@@ -206,8 +206,8 @@ class GlobalBlobAwareConflationCalculator(
     val triggerName =
       if (numberOfBatches >= batchesLimit) {
         // we must trigger an alert when BATCHES_LIMIT is reached because blobs
-        // won't be used to max capacity and affects Lineth profitability
-        // please do not change the name of this trigger, it is used in the log's based alert
+        // won't be used to max capacity and affects Lineth's profitability
+        // please do not change the name of this trigger, it is used in the logs-based alert
         "BATCHES_LIMIT"
       } else {
         trigger.name

--- a/coordinator/core/src/main/kotlin/linea/conflation/calculators/GlobalBlobAwareConflationCalculator.kt
+++ b/coordinator/core/src/main/kotlin/linea/conflation/calculators/GlobalBlobAwareConflationCalculator.kt
@@ -206,7 +206,7 @@ class GlobalBlobAwareConflationCalculator(
     val triggerName =
       if (numberOfBatches >= batchesLimit) {
         // we must trigger an alert when BATCHES_LIMIT is reached because blobs
-        // won't be used to max capacity and affects Linea profitability
+        // won't be used to max capacity and affects Lineth profitability
         // please do not change the name of this trigger, it is used in the log's based alert
         "BATCHES_LIMIT"
       } else {

--- a/coordinator/ethereum/blob-submitter/src/main/kotlin/linea/finalization/AggregationSubmitter.kt
+++ b/coordinator/ethereum/blob-submitter/src/main/kotlin/linea/finalization/AggregationSubmitter.kt
@@ -14,8 +14,8 @@ import kotlin.time.Clock
 
 interface AggregationSubmitter {
   /**
-   * Validates if the aggregation proof is valid and submits it to the Linea contract.
-   * If eth_call is successful, the aggregation is submitted to the Linea contract
+   * Validates if the aggregation proof is valid and submits it to the Lineth contract.
+   * If eth_call is successful, the aggregation is submitted to the Lineth contract
    * and the transaction hash is returned.
    */
   fun submitAggregationAfterEthCall(

--- a/docker/config/blockscout/l2-blockscout.env
+++ b/docker/config/blockscout/l2-blockscout.env
@@ -2,7 +2,7 @@
 # DOCKER_TAG=
 ETHEREUM_JSONRPC_VARIANT=besu
 NETWORK=Ethereum
-SUBNETWORK="Local Linea"
+SUBNETWORK="Local Lineth"
 LOGO=/images/blockscout_logo.svg
 LOGO_FOOTER=/images/blockscout_logo.svg
 # ETHEREUM_JSONRPC_WS_URL=

--- a/docker/config/coordinator/coordinator-config-v2.toml
+++ b/docker/config/coordinator/coordinator-config-v2.toml
@@ -221,7 +221,7 @@ trust-store-password = "changeit"
 [message-anchoring]
 disabled = false
 l1-highest-block-tag="LATEST"
-l2-highest-block-tag="LATEST" # optional, default to LATEST it shall not be necessary as Linea has instant finality
+l2-highest-block-tag="LATEST" # optional, default to LATEST it shall not be necessary as Lineth has instant finality
 anchoring-tick-interval = "PT2S"
 
 [message-anchoring.l1-event-scraping]

--- a/docker/config/coordinator/coordinator-config-v2.toml
+++ b/docker/config/coordinator/coordinator-config-v2.toml
@@ -221,7 +221,7 @@ trust-store-password = "changeit"
 [message-anchoring]
 disabled = false
 l1-highest-block-tag="LATEST"
-l2-highest-block-tag="LATEST" # optional, default to LATEST it shall not be necessary as Lineth has instant finality
+l2-highest-block-tag="LATEST" # optional, defaults to LATEST; not strictly necessary since Lineth has instant finality
 anchoring-tick-interval = "PT2S"
 
 [message-anchoring.l1-event-scraping]

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-The coordinator is the central backend service that drives the Linea proving and submission pipeline. It is a Kotlin/Vert.x application that:
+The coordinator is the central backend service that drives the Lineth proving and submission pipeline. It is a Kotlin/Vert.x application that:
 
 1. Pulls blocks from the sequencer
 2. Decides batch boundaries (conflation)

--- a/docs/getting-started/lineth-stack/config/services/coordinator/coordinator-config.toml.template
+++ b/docs/getting-started/lineth-stack/config/services/coordinator/coordinator-config.toml.template
@@ -233,7 +233,7 @@ trust-store-password = "changeit"
 [message-anchoring]
 disabled = false
 l1-highest-block-tag="LATEST"
-l2-highest-block-tag="LATEST" # optional, default to LATEST it shall not be necessary as Linea has instant finality
+l2-highest-block-tag="LATEST" # optional, default to LATEST it shall not be necessary as Lineth has instant finality
 anchoring-tick-interval = "PT2S"
 
 [message-anchoring.l1-event-scraping]

--- a/docs/getting-started/lineth-stack/config/services/coordinator/coordinator-config.toml.template
+++ b/docs/getting-started/lineth-stack/config/services/coordinator/coordinator-config.toml.template
@@ -233,7 +233,7 @@ trust-store-password = "changeit"
 [message-anchoring]
 disabled = false
 l1-highest-block-tag="LATEST"
-l2-highest-block-tag="LATEST" # optional, default to LATEST it shall not be necessary as Lineth has instant finality
+l2-highest-block-tag="LATEST" # optional, defaults to LATEST; not strictly necessary since Lineth has instant finality
 anchoring-tick-interval = "PT2S"
 
 [message-anchoring.l1-event-scraping]

--- a/docs/tech/components/coordinator-config-reference.md
+++ b/docs/tech/components/coordinator-config-reference.md
@@ -328,16 +328,16 @@ L1 to L2 message anchoring settings.
 
 ### `protocol`
 
-Linea protocol contract addresses and genesis settings.
+Lineth protocol contract addresses and genesis settings.
 
 | Key | Type | Required | Default | Status | Description |
 | --- | --- | --- | --- | --- | --- |
-| `protocol.genesis.genesis-shnarf` | `ByteArray` | yes | - | active | Genesis shnarf (starting shnarf) of the Linea chain (hex). Example: `0xc286ff42414401ccdc23ea8e738775378e8f6c6f7b2966eb2747798d45571b79`. |
-| `protocol.genesis.genesis-state-root-hash` | `ByteArray` | yes | - | active | Genesis state root hash of the Linea chain (hex). Example: `0x01d9afcd495c870f3ae9d8362cd0257a7de2057055058183596719285cae6101`. |
+| `protocol.genesis.genesis-shnarf` | `ByteArray` | yes | - | active | Genesis shnarf (starting shnarf) of the Lineth chain (hex). Example: `0xc286ff42414401ccdc23ea8e738775378e8f6c6f7b2966eb2747798d45571b79`. |
+| `protocol.genesis.genesis-state-root-hash` | `ByteArray` | yes | - | active | Genesis state root hash of the Lineth chain (hex). Example: `0x01d9afcd495c870f3ae9d8362cd0257a7de2057055058183596719285cae6101`. |
 | `protocol.l1.block-time` | `Duration` | no | `PT12S` | active | Average L1 block time, used for timing estimates. |
-| `protocol.l1.contract-address` | `String` | yes | - | active | Address of the Linea rollup contract on L1. Example: `0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9`. |
+| `protocol.l1.contract-address` | `String` | yes | - | active | Address of the Lineth rollup contract on L1. Example: `0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9`. |
 | `protocol.l1.contract-deployment-block-number` | `ULong?` | no | - | active | L1 block number at which the rollup contract was deployed. Omit if not applicable. Example: `3`. |
-| `protocol.l2.contract-address` | `String` | yes | - | active | Address of the Linea contract on L2. Example: `0xe537D669CA013d86EBeF1D64e40fC74CADC91987`. |
+| `protocol.l2.contract-address` | `String` | yes | - | active | Address of the Lineth contract on L2. Example: `0xe537D669CA013d86EBeF1D64e40fC74CADC91987`. |
 | `protocol.l2.contract-deployment-block-number` | `ULong?` | no | - | active | L2 block number at which the contract was deployed. Omit if not applicable. Example: `3`. |
 
 ### `prover`
@@ -493,11 +493,11 @@ L1 dynamic gas price cap time-of-day multipliers.
 
 ## smart-contract-errors
 
-Mapping of Linea smart-contract revert error codes to messages.
+Mapping of Lineth smart-contract revert error codes to messages.
 
 | Key | Type | Required | Default | Status | Description |
 | --- | --- | --- | --- | --- | --- |
-| `smart-contract-errors` | `Map<String, String>` | yes | - | active | Mapping of Linea smart-contract revert error codes to human-readable messages, used to decode on-chain rejection reasons. |
+| `smart-contract-errors` | `Map<String, String>` | yes | - | active | Mapping of Lineth smart-contract revert error codes to human-readable messages, used to decode on-chain rejection reasons. |
 
 ## Deprecated Keys
 

--- a/docs/tech/components/coordinator-config-schema.json
+++ b/docs/tech/components/coordinator-config-schema.json
@@ -3157,7 +3157,7 @@
         "section": true,
         "required": true,
         "default": null,
-        "description": "Linea protocol contract addresses and genesis settings.",
+        "description": "Lineth protocol contract addresses and genesis settings.",
         "example": null,
         "deprecated": false,
         "replacement": null
@@ -3167,7 +3167,7 @@
         "section": true,
         "required": true,
         "default": null,
-        "description": "Linea genesis state root and shnarf.",
+        "description": "Lineth genesis state root and shnarf.",
         "example": null,
         "deprecated": false,
         "replacement": null
@@ -3177,7 +3177,7 @@
         "section": false,
         "required": true,
         "default": null,
-        "description": "Genesis shnarf (starting shnarf) of the Linea chain (hex).",
+        "description": "Genesis shnarf (starting shnarf) of the Lineth chain (hex).",
         "example": "0xc286ff42414401ccdc23ea8e738775378e8f6c6f7b2966eb2747798d45571b79",
         "deprecated": false,
         "replacement": null
@@ -3187,7 +3187,7 @@
         "section": false,
         "required": true,
         "default": null,
-        "description": "Genesis state root hash of the Linea chain (hex).",
+        "description": "Genesis state root hash of the Lineth chain (hex).",
         "example": "0x01d9afcd495c870f3ae9d8362cd0257a7de2057055058183596719285cae6101",
         "deprecated": false,
         "replacement": null
@@ -3217,7 +3217,7 @@
         "section": false,
         "required": true,
         "default": null,
-        "description": "Address of the Linea rollup contract on L1.",
+        "description": "Address of the Lineth rollup contract on L1.",
         "example": "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",
         "deprecated": false,
         "replacement": null
@@ -3247,7 +3247,7 @@
         "section": false,
         "required": true,
         "default": null,
-        "description": "Address of the Linea contract on L2.",
+        "description": "Address of the Lineth contract on L2.",
         "example": "0xe537D669CA013d86EBeF1D64e40fC74CADC91987",
         "deprecated": false,
         "replacement": null
@@ -4580,14 +4580,14 @@
     }
   },
   "smart-contract-errors": {
-    "description": "Mapping of Linea smart-contract revert error codes to messages.",
+    "description": "Mapping of Lineth smart-contract revert error codes to messages.",
     "keys": {
       "smart-contract-errors": {
         "type": "Map<String, String>",
         "section": false,
         "required": true,
         "default": null,
-        "description": "Mapping of Linea smart-contract revert error codes to human-readable messages, used to decode on-chain rejection reasons.",
+        "description": "Mapping of Lineth smart-contract revert error codes to human-readable messages, used to decode on-chain rejection reasons.",
         "example": null,
         "deprecated": false,
         "replacement": null

--- a/docs/tech/components/coordinator.md
+++ b/docs/tech/components/coordinator.md
@@ -1,6 +1,6 @@
 # Coordinator
 
-> Kotlin service that orchestrates the Linea rollup proving and submission pipeline.
+> Kotlin service that orchestrates the Lineth rollup proving and submission pipeline.
 
 > **Diagram:** [Coordinator Architecture](../diagrams/coordinator-architecture.mmd) (Mermaid source)
 


### PR DESCRIPTION
## Summary
- Completes a missed piece of the Linea→Lineth rename: CLI `--help` text, KDoc/config-doc description strings, docker config values, and the generated coordinator config docs (kept in sync with the Kotlin source changes).
- No class/function/package names changed (`net.consensys.linea.*` / `linea.*` packages stay, per the backwards-compatibility requirement).
- `./gradlew :coordinator:app:checkConfigDocs` passes (457 keys, all documented).

## Test plan
- [x] `checkConfigDocs` passes locally
- [ ] Coordinator unit tests pass in CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and display-string only; no logic, config keys, or alert trigger names changed.
> 
> **Overview**
> Finishes the **Linea → Lineth** rebrand in coordinator-facing **copy only**: CLI help, config-doc annotations, KDoc/comments, Docker labels, Blockscout subnetwork name, sample TOML comments, and generated config reference/schema.
> 
> **No runtime behavior, APIs, or identifiers change** — `linea.*` / `net.consensys.linea.*` packages and symbols such as `LineaSmartContractClient` are untouched.
> 
> Touched areas include protocol/genesis and smart-contract error descriptions, message-anchoring comments about L2 finality, aggregation submitter docs, conflation `BATCHES_LIMIT` alert wording (trigger name unchanged), and coordinator feature/tech docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25980fa3c0c2e34bf3222c5beb04138a9626f18a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->