### PR TITLE
chore(coordinator): rename Linea to Lineth in JVM components

### DIFF
--- a/jvm-libs/linea/blob-compressor/build.gradle
+++ b/jvm-libs/linea/blob-compressor/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'java-test-fixtures'
 }
 
-description = 'Java JNA wrapper for Linea Blob Compressor Library implemented in GO Lang'
+description = 'Java JNA wrapper for Lineth Blob Compressor Library implemented in GO Lang'
 
 dependencies {
   compileOnly "net.java.dev.jna:jna:${libs.versions.jna.get()}"

--- a/jvm-libs/linea/blob-decompressor/build.gradle
+++ b/jvm-libs/linea/blob-decompressor/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'java-test-fixtures'
 }
 
-description = 'Java JNA wrapper for Linea Blob Decompressor Library implemented in GO Lang'
+description = 'Java JNA wrapper for Lineth Blob Decompressor Library implemented in GO Lang'
 
 dependencies {
   compileOnly "net.java.dev.jna:jna:${libs.versions.jna.get()}"

--- a/jvm-libs/linea/blob-decompressor/src/main/kotlin/net/consensys/linea/blob/GoNativeBlobDecompressor.kt
+++ b/jvm-libs/linea/blob-decompressor/src/main/kotlin/net/consensys/linea/blob/GoNativeBlobDecompressor.kt
@@ -56,7 +56,7 @@ internal interface GoNativeBlobDecompressorJnaBinding {
 
   /**
 
-   * Decompress processes a Linea blob and outputs an RLP encoded list of blocks.
+   * Decompress processes a Lineth blob and outputs an RLP encoded list of blocks.
    * Due to information loss during pre-compression encoding, two pieces of information are represented "hackily":
    * The block hash is in the ParentHash field.
    * The transaction from address is in the signature.R field.

--- a/jvm-libs/linea/blob-decompressor/src/test/kotlin/net/consensys/linea/blob/GoNativeBlobDecompressorTest.kt
+++ b/jvm-libs/linea/blob-decompressor/src/test/kotlin/net/consensys/linea/blob/GoNativeBlobDecompressorTest.kt
@@ -194,7 +194,7 @@ class GoNativeBlobDecompressorTest {
   }
 
   fun CodeDelegation.toLinaDomain(): AuthorizationTuple {
-    // Besu does CodeDelegation class not implement equals/hashcode so we convert to Linea Domain model to compare
+    // Besu does CodeDelegation class not implement equals/hashcode so we convert to Lineth Domain model to compare
     return AuthorizationTuple(
       address = this.address().bytes.toArray(),
       chainId = this.chainId().toULong(),

--- a/jvm-libs/linea/blob-decompressor/src/test/kotlin/net/consensys/linea/blob/GoNativeBlobDecompressorTest.kt
+++ b/jvm-libs/linea/blob-decompressor/src/test/kotlin/net/consensys/linea/blob/GoNativeBlobDecompressorTest.kt
@@ -194,7 +194,7 @@ class GoNativeBlobDecompressorTest {
   }
 
   fun CodeDelegation.toLinaDomain(): AuthorizationTuple {
-    // Besu does CodeDelegation class not implement equals/hashcode so we convert to Lineth Domain model to compare
+    // Besu's CodeDelegation class does not implement equals/hashCode, so we convert to the Lineth domain model to compare
     return AuthorizationTuple(
       address = this.address().bytes.toArray(),
       chainId = this.chainId().toULong(),

--- a/jvm-libs/linea/blob-shnarf-calculator/build.gradle
+++ b/jvm-libs/linea/blob-shnarf-calculator/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id 'linea.download-native-libs'
 }
 
-description = 'Java JNA wrapper for Linea Blob Shnarf Calculator implemented in GO Lang'
+description = 'Java JNA wrapper for Lineth Blob Shnarf Calculator implemented in GO Lang'
 
 dependencies {
   compileOnly "net.java.dev.jna:jna:${libs.versions.jna.get()}"

--- a/jvm-libs/linea/clients/interfaces/build.gradle
+++ b/jvm-libs/linea/clients/interfaces/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id 'java-test-fixtures'
 }
 
-description="Interfaces for interaction with Linea Smart Contract"
+description="Interfaces for interaction with Lineth Smart Contract"
 
 dependencies {
   api project(':jvm-libs:linea:core:domain-models')

--- a/jvm-libs/linea/clients/interfaces/src/main/kotlin/linea/contract/l1/LineaSmartContractClient.kt
+++ b/jvm-libs/linea/clients/interfaces/src/main/kotlin/linea/contract/l1/LineaSmartContractClient.kt
@@ -46,7 +46,7 @@ interface LineaSmartContractClientReadOnly {
   ): SafeFuture<Boolean>
 
   /**
-   * Gets Type 2 StateRootHash for Linea Block
+   * Gets Type 2 StateRootHash for Lineth Block
    */
   fun blockStateRootHash(blockParameter: BlockParameter, lineaL2BlockNumber: ULong): SafeFuture<ByteArray>
 }
@@ -65,7 +65,7 @@ data class LinethRollupFinalizedState(
 interface LinethRollupSmartContractClientReadOnlyFinalizedStateProvider {
   /**
    * Provides the latest finalized state.
-   * It relies on Linea contract V8 FinalizedStateUpdated event
+   * It relies on Lineth contract V8 FinalizedStateUpdated event
    *
    * @throws UnsupportedOperationException when contract is not yet upgraded to V8 or when 1st event was not emitted yet
    */

--- a/jvm-libs/linea/clients/interfaces/src/main/kotlin/linea/contract/l1/LineaSmartContractClient.kt
+++ b/jvm-libs/linea/clients/interfaces/src/main/kotlin/linea/contract/l1/LineaSmartContractClient.kt
@@ -46,7 +46,8 @@ interface LineaSmartContractClientReadOnly {
   ): SafeFuture<Boolean>
 
   /**
-   * Gets Type 2 StateRootHash for Lineth Block
+   * Gets Type 2 StateRootHash for a Lineth block.
+   * The [lineaL2BlockNumber] parameter name is kept for backwards compatibility.
    */
   fun blockStateRootHash(blockParameter: BlockParameter, lineaL2BlockNumber: ULong): SafeFuture<ByteArray>
 }

--- a/jvm-libs/linea/clients/linea-contract-clients/build.gradle
+++ b/jvm-libs/linea/clients/linea-contract-clients/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id 'java-test-fixtures'
 }
 
-description = "Linea L1 smart contract client"
+description = "Lineth L1 smart contract client"
 
 dependencies {
   api project(':jvm-libs:linea:core:domain-models')

--- a/jvm-libs/linea/clients/linea-state-manager/build.gradle
+++ b/jvm-libs/linea/clients/linea-state-manager/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'net.consensys.zkevm.kotlin-library-conventions'
 }
 
-description="Linea state manager client"
+description="Lineth state manager client"
 
 dependencies {
   api project(':jvm-libs:linea:core:domain-models')

--- a/jvm-libs/linea/core/client-interface/build.gradle
+++ b/jvm-libs/linea/core/client-interface/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'net.consensys.zkevm.kotlin-library-conventions'
 }
 
-description="Linea Client interface"
+description="Lineth Client interface"
 
 dependencies {
   implementation(project(':jvm-libs:generic:extensions:kotlin'))

--- a/jvm-libs/linea/core/domain-models/build.gradle
+++ b/jvm-libs/linea/core/domain-models/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id 'java-test-fixtures'
 }
 
-description="Linea domain models"
+description="Lineth domain models"
 
 dependencies {
   implementation project(":jvm-libs:generic:extensions:kotlin")

--- a/jvm-libs/linea/core/domain-models/src/main/kotlin/linea/domain/Transaction.kt
+++ b/jvm-libs/linea/core/domain-models/src/main/kotlin/linea/domain/Transaction.kt
@@ -8,8 +8,8 @@ enum class TransactionType(private val typeValue: Int) {
   FRONTIER(248),
   ACCESS_LIST(1),
   EIP1559(2),
-  BLOB(3), // Not supported by Linea atm, but here for completeness
-  DELEGATE_CODE(4), // Not supported by Linea atm, but here for completeness
+  BLOB(3), // Not supported by Lineth atm, but here for completeness
+  DELEGATE_CODE(4), // Not supported by Lineth atm, but here for completeness
   ;
 
   val serializedType: Byte

--- a/jvm-libs/linea/core/domain-models/src/main/kotlin/linea/domain/Transaction.kt
+++ b/jvm-libs/linea/core/domain-models/src/main/kotlin/linea/domain/Transaction.kt
@@ -8,8 +8,8 @@ enum class TransactionType(private val typeValue: Int) {
   FRONTIER(248),
   ACCESS_LIST(1),
   EIP1559(2),
-  BLOB(3), // Not supported by Lineth atm, but here for completeness
-  DELEGATE_CODE(4), // Not supported by Lineth atm, but here for completeness
+  BLOB(3), // Not supported by Lineth at the moment, but here for completeness
+  DELEGATE_CODE(4), // Not supported by Lineth at the moment, but here for completeness
   ;
 
   val serializedType: Byte

--- a/jvm-libs/linea/core/domain-models/src/main/kotlin/linea/domain/Transaction.kt
+++ b/jvm-libs/linea/core/domain-models/src/main/kotlin/linea/domain/Transaction.kt
@@ -9,7 +9,7 @@ enum class TransactionType(private val typeValue: Int) {
   ACCESS_LIST(1),
   EIP1559(2),
   BLOB(3), // Not supported by Lineth at the moment, but here for completeness
-  DELEGATE_CODE(4), // Not supported by Lineth at the moment, but here for completeness
+  DELEGATE_CODE(4),
   ;
 
   val serializedType: Byte

--- a/jvm-libs/linea/core/long-running-service/build.gradle
+++ b/jvm-libs/linea/core/long-running-service/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id 'java-test-fixtures'
 }
 
-description="Linea long running service implementation"
+description="Lineth long running service implementation"
 
 dependencies {
   implementation "io.vertx:vertx-core"

--- a/jvm-libs/linea/core/metrics/build.gradle
+++ b/jvm-libs/linea/core/metrics/build.gradle
@@ -2,4 +2,4 @@ plugins {
   id 'net.consensys.zkevm.kotlin-library-conventions'
 }
 
-description="Linea metrics facade"
+description="Lineth metrics facade"

--- a/jvm-libs/linea/core/traces/build.gradle
+++ b/jvm-libs/linea/core/traces/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id 'java-test-fixtures'
 }
 
-description="Linea Tracing utilities"
+description="Lineth Tracing utilities"
 
 dependencies {
   implementation "io.consensys.tuweni:tuweni-units:${libs.versions.tuweni.get()}"

--- a/jvm-libs/linea/linea-contracts/l1-rollup/build.gradle
+++ b/jvm-libs/linea/linea-contracts/l1-rollup/build.gradle
@@ -7,7 +7,7 @@ java {
     languageVersion = JavaLanguageVersion.of(25)
   }
 }
-description = 'Web3J Java client for Linea L1 Rollup Smart Contract'
+description = 'Web3J Java client for Lineth L1 Rollup Smart Contract'
 ext.artifactId = 'l1-rollup-contract-client'
 
 dependencies {

--- a/jvm-libs/linea/linea-contracts/l1-validium/build.gradle
+++ b/jvm-libs/linea/linea-contracts/l1-validium/build.gradle
@@ -7,7 +7,7 @@ java {
     languageVersion = JavaLanguageVersion.of(25)
   }
 }
-description = 'Web3J Java client for Linea L1 Validium Smart Contract'
+description = 'Web3J Java client for Lineth L1 Validium Smart Contract'
 ext.artifactId = 'l1-validium-contract-client'
 
 dependencies {

--- a/jvm-libs/linea/linea-contracts/l2-message-service/build.gradle
+++ b/jvm-libs/linea/linea-contracts/l2-message-service/build.gradle
@@ -8,7 +8,7 @@ java {
   }
 }
 
-description = 'Web3J Java client for Linea L2 Message Service Contract'
+description = 'Web3J Java client for Lineth L2 Message Service Contract'
 ext.artifactId = 'l2-message-service-contract-client'
 
 dependencies {

--- a/jvm-libs/linea/metrics/micrometer/build.gradle
+++ b/jvm-libs/linea/metrics/micrometer/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'net.consensys.zkevm.kotlin-library-conventions'
 }
 
-description="Micrometer metrics implementation for Linea"
+description="Micrometer metrics implementation for Lineth"
 
 dependencies {
   api "io.micrometer:micrometer-registry-prometheus:${libs.versions.micrometer.get()}"

--- a/jvm-libs/linea/testing/besu/build.gradle
+++ b/jvm-libs/linea/testing/besu/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'net.consensys.zkevm.kotlin-library-conventions'
 }
 
-description = "Linea test utilities for Besu"
+description = "Lineth test utilities for Besu"
 
 dependencies {
   implementation project(':jvm-libs:generic:extensions:kotlin')

--- a/jvm-libs/linea/testing/file-system/build.gradle
+++ b/jvm-libs/linea/testing/file-system/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'net.consensys.zkevm.kotlin-library-conventions'
 }
 
-description="Linea test utilities for file system interactions"
+description="Lineth test utilities for file system interactions"
 
 dependencies {
   testImplementation(project(':jvm-libs:generic:extensions:kotlin'))

--- a/jvm-libs/linea/testing/l1-blob-and-proof-submission/build.gradle
+++ b/jvm-libs/linea/testing/l1-blob-and-proof-submission/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'net.consensys.zkevm.kotlin-library-conventions'
 }
 
-description="Linea test utilities for L1 blob submission and Finalization"
+description="Lineth test utilities for L1 blob submission and Finalization"
 
 dependencies {
   api(project(':jvm-libs:linea:core:domain-models'))

--- a/jvm-libs/linea/testing/web3j/build.gradle
+++ b/jvm-libs/linea/testing/web3j/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'net.consensys.zkevm.kotlin-library-conventions'
 }
 
-description = "Linea test utilities for Web3j"
+description = "Lineth test utilities for Web3j"
 
 dependencies {
   implementation "org.web3j:core:${libs.versions.web3j.get()}"

--- a/jvm-libs/linea/web3j-extensions/build.gradle
+++ b/jvm-libs/linea/web3j-extensions/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'java-test-fixtures'
 }
 
-description="Web3j extensions for Linea"
+description="Web3j extensions for Lineth"
 
 dependencies {
   api "org.web3j:core:${libs.versions.web3j.get()}"

--- a/linea-besu/plugins/AGENTS.md
+++ b/linea-besu/plugins/AGENTS.md
@@ -8,7 +8,7 @@
 
 ## Package Overview
 
-Besu blockchain client plugins for Linea: the sequencer plugin (transaction ordering, profitability, tracing integration), finalized-tag-updater, and state-recovery modules. Built as Gradle distributions that extend Hyperledger Besu.
+Besu blockchain client plugins for Lineth: the sequencer plugin (transaction ordering, profitability, tracing integration), finalized-tag-updater, and state-recovery modules. Built as Gradle distributions that extend Hyperledger Besu.
 
 ## How to Run
 

--- a/linea-besu/plugins/sequencer-interfaces/build.gradle
+++ b/linea-besu/plugins/sequencer-interfaces/build.gradle
@@ -23,7 +23,7 @@ java {
 }
 
 group = 'build.linea'
-description = 'Linea chain security interfaces'
+description = 'Lineth chain security interfaces'
 // publishing.gradle uses project.artifactId when set (or else falling back to project.name)
 ext.artifactId = 'sequencer-interfaces'
 

--- a/linea-besu/plugins/state-recovery/besu-plugin/jreleaser.yml
+++ b/linea-besu/plugins/state-recovery/besu-plugin/jreleaser.yml
@@ -1,7 +1,7 @@
 project:
   name: staterecovery
-  description: Linea State Recovery Besu Plugin
-  longDescription: Besu Plugin to allow Linea rollup state recovery from L1 Blob data
+  description: Lineth State Recovery Besu Plugin
+  longDescription: Besu Plugin to allow Lineth rollup state recovery from L1 Blob data
   links:
     homepage: https://github.com/LFDT-Lineth/lineth-monorepo
   authors:

--- a/linea-besu/plugins/state-recovery/besu-plugin/src/main/kotlin/linea/staterecovery/plugin/PluginOptions.kt
+++ b/linea-besu/plugins/state-recovery/besu-plugin/src/main/kotlin/linea/staterecovery/plugin/PluginOptions.kt
@@ -41,7 +41,7 @@ class PluginCliOptions {
 
   @CommandLine.Option(
     names = ["--$cliOptionsPrefix-linea-sequencer-beneficiary-address"],
-    description = ["Linea sequencer beneficiary address"],
+    description = ["Lineth sequencer beneficiary address"],
     required = true,
     converter = [AddressConverter::class],
     defaultValue = "\${env:LINEA_SEQUENCER_BENEFICIARY_ADDRESS}",
@@ -50,7 +50,7 @@ class PluginCliOptions {
 
   @CommandLine.Option(
     names = ["--$cliOptionsPrefix-linea-block-gas-limit"],
-    description = ["Linea Block gas limit. Default 2B (2_000_000_000)"],
+    description = ["Lineth Block gas limit. Default 2B (2_000_000_000)"],
     required = false,
     defaultValue = "\${env:LINEA_BLOCK_GAS_LIMIT}",
   )
@@ -58,7 +58,7 @@ class PluginCliOptions {
 
   @CommandLine.Option(
     names = ["--$cliOptionsPrefix-linea-block-difficulty"],
-    description = ["Linea Block difficulty. Default 2"],
+    description = ["Lineth Block difficulty. Default 2"],
     required = false,
     defaultValue = "\${env:LINEA_BLOCK_DIFFICULTY}",
   )

--- a/linea-besu/plugins/state-recovery/besu-plugin/src/main/kotlin/linea/staterecovery/plugin/PluginOptions.kt
+++ b/linea-besu/plugins/state-recovery/besu-plugin/src/main/kotlin/linea/staterecovery/plugin/PluginOptions.kt
@@ -50,7 +50,7 @@ class PluginCliOptions {
 
   @CommandLine.Option(
     names = ["--$cliOptionsPrefix-linea-block-gas-limit"],
-    description = ["Lineth Block gas limit. Default 2B (2_000_000_000)"],
+    description = ["Lineth block gas limit. Default 2B (2_000_000_000)"],
     required = false,
     defaultValue = "\${env:LINEA_BLOCK_GAS_LIMIT}",
   )
@@ -58,7 +58,7 @@ class PluginCliOptions {
 
   @CommandLine.Option(
     names = ["--$cliOptionsPrefix-linea-block-difficulty"],
-    description = ["Lineth Block difficulty. Default 2"],
+    description = ["Lineth block difficulty. Default 2"],
     required = false,
     defaultValue = "\${env:LINEA_BLOCK_DIFFICULTY}",
   )


### PR DESCRIPTION
## Summary
- Completes a missed piece of the Linea→Lineth rename: KDoc/comments in `jvm-libs/linea/*` and `linea-besu/plugins/*` describing this project's own chain/contract/blob, plus Gradle module `description` strings.
- Class/interface/package names (`net.consensys.linea.*`, `linea.*`) are unchanged, per the backwards-compatibility requirement — this is prose only.

## Test plan
- [ ] JVM unit tests pass in CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and Gradle description-only changes with no runtime or API behavior impact.
> 
> **Overview**
> Finishes the **Linea → Lineth** branding pass in `jvm-libs/linea/*` and `linea-besu/plugins/*` by updating human-readable text only: Gradle `description` strings, KDoc, comments, `AGENTS.md`, JReleaser metadata, and state-recovery CLI help text.
> 
> Notable doc tweaks include **Lineth** wording for blob decompress/compress/shnarf wrappers, smart-contract client KDoc (including a note that `lineaL2BlockNumber` stays for backwards compatibility), and `TransactionType` comments. A test comment in blob-decompressor is clarified; **identifiers** (`net.consensys.linea.*`, `LineaSmartContractClient`, CLI flag names) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29a52619b60303bc8bdf23830b01605424665483. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->