### PR TITLE
chore(prover): rename Linea to Lineth in prover

### DIFF
--- a/prover/AGENTS.md
+++ b/prover/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## Package Overview
 
-This is the ZK prover for Linea, written in Go and built on top of gnark.
+This is the ZK prover for Lineth, written in Go and built on top of gnark.
 It implements the Vortex polynomial commitment scheme and the Consensys zkEVM.
 The proving pipeline works as follows. The `go-corset` library supplies the
 circuit description and witness assignments for the zkEVM arithmetization.

--- a/prover/README.md
+++ b/prover/README.md
@@ -1,6 +1,6 @@
 # lineth-monorepo/prover
 
-This directory contains the implementation of the prover of Linea. As part of it,
+This directory contains the implementation of the prover of Lineth. As part of it,
 it contains an implementation of the Vortex polynomial commitment, of the
 Arcane compiler, the instantiation of the zkEVM using the arithmetization and
 the server implementation.
@@ -15,7 +15,7 @@ The prover has the following build dependencies
 The repository counts 2 main binaries:
 
 - `bin/prover` : `bin/prover setup` generate the assets (setup / preprocessing) `bin/prover prove` run process a request, create a proof and outputs a response.
-- `bin/controller` : a file-system based server to run Linea's prover
+- `bin/controller` : a file-system based server to run Lineth's prover
 
 ### Building and running the setup generator
 

--- a/prover/README.md
+++ b/prover/README.md
@@ -1,6 +1,6 @@
 # lineth-monorepo/prover
 
-This directory contains the implementation of the prover of Lineth. As part of it,
+This directory contains the implementation of the Lineth prover. As part of it,
 it contains an implementation of the Vortex polynomial commitment, of the
 Arcane compiler, the instantiation of the zkEVM using the arithmetization and
 the server implementation.
@@ -15,7 +15,7 @@ The prover has the following build dependencies
 The repository counts 2 main binaries:
 
 - `bin/prover` : `bin/prover setup` generate the assets (setup / preprocessing) `bin/prover prove` run process a request, create a proof and outputs a response.
-- `bin/controller` : a file-system based server to run Lineth's prover
+- `bin/controller` : a file-system based server to run the Lineth prover
 
 ### Building and running the setup generator
 

--- a/prover/backend/execution/craft.go
+++ b/prover/backend/execution/craft.go
@@ -198,7 +198,7 @@ func (req *Request) collectSignatures() ([]ethereum.Signature, [][32]byte) {
 // FuncInput are all the relevant fields parsed by the prover that
 // are functionally useful to contextualize what the proof is proving. This
 // is used by the aggregation circuit to ensure that the execution proofs
-// relate to consecutive Linea block execution.
+// relate to consecutive Lineth block execution.
 func (rsp *Response) FuncInput() *public_input.Execution {
 
 	var (

--- a/prover/backend/invalidity/craft.go
+++ b/prover/backend/invalidity/craft.go
@@ -12,7 +12,7 @@ import (
 // FuncInput are all the relevant fields parsed by the prover that
 // are functionally useful to contextualize what the proof is proving. This
 // is used by the aggregation circuit to ensure that the invalidity proofs
-// relate to consecutive Linea forced transactions.
+// relate to consecutive Lineth forced transactions.
 func FuncInput(req *Request, cfg *config.Config) *public_input.Invalidity {
 
 	tx, err := ethereum.RlpDecodeWithSignature(req.RlpEncodedTx)

--- a/prover/circuits/pi-interconnection/keccak/prover/protocol/internal/plonkinternal/doc.go
+++ b/prover/circuits/pi-interconnection/keccak/prover/protocol/internal/plonkinternal/doc.go
@@ -15,7 +15,7 @@ circuit's satisfiability within the currently compiled IOP.
 
 This comes in handy in situation where we wish to prove complex relations that
 are difficult to express directly in the form of a Wizard-IOP but easier to
-express in a language that is more expressive. In the case, of Linea's zkEVM,
+express in a language that is more expressive. In the case, of Lineth's zkEVM,
 this is used for the ECDSA verification and the precompiles.
 
 The package optionally offers optimization when,

--- a/prover/circuits/pi-interconnection/keccak/prover/protocol/internal/plonkinternal/doc.go
+++ b/prover/circuits/pi-interconnection/keccak/prover/protocol/internal/plonkinternal/doc.go
@@ -13,9 +13,9 @@ circuit alongside a [wizard.CompiledIOP] object. The utility will build all the
 necessary columns and declare all the necessary constraints to emulate the
 circuit's satisfiability within the currently compiled IOP.
 
-This comes in handy in situation where we wish to prove complex relations that
+This comes in handy in situations where we wish to prove complex relations that
 are difficult to express directly in the form of a Wizard-IOP but easier to
-express in a language that is more expressive. In the case, of Lineth's zkEVM,
+express in a language that is more expressive. In the case of Lineth's zkEVM,
 this is used for the ECDSA verification and the precompiles.
 
 The package optionally offers optimization when,

--- a/prover/circuits/solidity_options.go
+++ b/prover/circuits/solidity_options.go
@@ -8,10 +8,10 @@ import (
 
 const (
 	// lineaVerifierConstants contains additional constant declarations for the
-	// Linea verifier contract.
+	// Lineth verifier contract.
 	lineaVerifierConstants = `  bytes32 private immutable CHAIN_CONFIGURATION;`
 
-	// lineaVerifierConstructor contains the constructor for the Linea verifier contract.
+	// lineaVerifierConstructor contains the constructor for the Lineth verifier contract.
 	lineaVerifierConstructor = `  /// @notice Constructor.
   /// @param _chainConfiguration The chain configuration parameters.
   constructor(ChainConfigurationParameter[] memory _chainConfiguration) {
@@ -26,7 +26,7 @@ const (
     emit ChainConfigurationSet(chainConfigurationHash, _chainConfiguration);
   }`
 
-	// lineaVerifierFunctions contains additional functions for the Linea verifier contract.
+	// lineaVerifierFunctions contains additional functions for the Lineth verifier contract.
 	lineaVerifierFunctions = `  /// @notice Compute the chain configuration hash.
   /// @param _chainConfiguration The chain configuration parameters.
   /// @return chainConfigurationHash The hash of the chain configuration.
@@ -68,7 +68,7 @@ const (
 )
 
 // LineaVerifierExportOptions returns the Solidity export options for generating
-// the Linea verifier contract with chain configuration support. These options
+// the Lineth verifier contract with chain configuration support. These options
 // configure gnark's Solidity template with:
 //   - Pragma version 0.8.33
 //   - Imports for Mimc library and IPlonkVerifier interface

--- a/prover/cmd/prover/main.go
+++ b/prover/cmd/prover/main.go
@@ -15,14 +15,14 @@ var (
 	// rootCmd represents the base command when called without any subcommands
 	rootCmd = &cobra.Command{
 		Use:   "prover",
-		Short: "run pre-compute or compute proofs for Linea circuits",
+		Short: "run pre-compute or compute proofs for Lineth circuits",
 	}
 	fConfigFile string
 
 	// setupCmd represents the setup command
 	setupCmd = &cobra.Command{
 		Use:   "setup",
-		Short: "pre-compute assets for Linea circuits",
+		Short: "pre-compute assets for Lineth circuits",
 		RunE:  cmdSetup,
 	}
 	setupArgs cmd.SetupArgs

--- a/prover/config/config.go
+++ b/prover/config/config.go
@@ -155,7 +155,7 @@ type Config struct {
 	Debug                      Debug       `mapstructure:"debug"`
 
 	Layer2 struct {
-		// ChainID stores the ID of the Linea L2 network to consider.
+		// ChainID stores the ID of the Lineth L2 network to consider.
 		ChainID uint `mapstructure:"chain_id" validate:"required"`
 		// No validator tag: presence is enforced in newConfigFromFile via
 		// viper.IsSet. `required` would reject 0, which is valid on gasless
@@ -171,7 +171,7 @@ type Config struct {
 		// MsgSvcContract stores the unique ID of the Service Contract (SC), as a common.Address.
 		MsgSvcContract common.Address `mapstructure:"-"`
 
-		// CoinBaseStr stores the coinbase address of Linea as a string.
+		// CoinBaseStr stores the coinbase address of Lineth as a string.
 		CoinBaseStr string         `mapstructure:"coin_base" validate:"required,eth_addr"`
 		CoinBase    common.Address `mapstructure:"-"`
 	}

--- a/prover/crypto/state-management/smt_koalabear/tree.go
+++ b/prover/crypto/state-management/smt_koalabear/tree.go
@@ -11,7 +11,7 @@ import (
 	"github.com/consensys/linea-monorepo/prover/utils/parallel"
 )
 
-// DefaultDepth is the default depth of the Linea state Merkle tree.
+// DefaultDepth is the default depth of the Lineth state Merkle tree.
 // This value should not be changed as it would modify the state structure.
 const DefaultDepth = 40
 

--- a/prover/lib/compressor/blob/blob.go
+++ b/prover/lib/compressor/blob/blob.go
@@ -30,7 +30,7 @@ func LoadDict(dictPath string) ([]byte, error) {
 	return os.ReadFile(dictPath)
 }
 
-// DecompressBlob takes in a Linea blob and outputs an RLP encoded list of RLP encoded blocks.
+// DecompressBlob takes in a Lineth blob and outputs an RLP encoded list of RLP encoded blocks.
 // Due to information loss during pre-compression encoding, two pieces of information are represented "hackily":
 // The block hash is in the ParentHash field.
 // The transaction from address is in the signature.R field.

--- a/prover/lib/compressor/blob/v0/blob_maker.go
+++ b/prover/lib/compressor/blob/v0/blob_maker.go
@@ -470,7 +470,7 @@ func (bm *BlobMaker) WorstCompressedBlockSize(rlpBlock []byte) (bool, int, error
 		return false, -1, fmt.Errorf("failed to decode RLP block: %w", err)
 	}
 
-	// encode the block in Linea format.
+	// encode the block in Lineth format.
 	var buf bytes.Buffer
 	if err := EncodeBlockForCompression(&block, &buf); err != nil {
 		return false, -1, fmt.Errorf("failed to encode block: %w", err)
@@ -512,7 +512,7 @@ func (bm *BlobMaker) WorstCompressedTxSize(rlpTx []byte) (int, error) {
 		return -1, err
 	}
 
-	// encode the transaction in Linea format.
+	// encode the transaction in Lineth format.
 	var buf bytes.Buffer
 	if err := EncodeTxForCompression(&tx, &buf); err != nil {
 		return -1, fmt.Errorf("failed to encode transaction: %w", err)

--- a/prover/lib/compressor/blob/v0/blob_spec.md
+++ b/prover/lib/compressor/blob/v0/blob_spec.md
@@ -1,6 +1,6 @@
-# Linea Blob Format Specification
+# Lineth Blob Format Specification
 
-This document provides a detailed explanation of the structure of a blob in the context of Linea prover. A blob contains essential information that allows the Linea prover to validate the execution of several blocks of transactions. The blob's content is compressed and structured to facilitate cryptographic operations within zkSNARK circuits.
+This document provides a detailed explanation of the structure of a blob in the context of Lineth prover. A blob contains essential information that allows the Lineth prover to validate the execution of several blocks of transactions. The blob's content is compressed and structured to facilitate cryptographic operations within zkSNARK circuits.
 
 ## Content
 
@@ -39,12 +39,12 @@ The header contains the following elements:
 
 ### Body
 
-The body contains a list of "~RLP encoded" Linea blocks. For each block, the raw data includes:
+The body contains a list of "~RLP encoded" Lineth blocks. For each block, the raw data includes:
 
 - Block Timestamp (uint64, little endian)
 - List of RLP encoded Transactions (refer to EncodeTxForCompression for more details)
 
-The raw data is compressed using [compress/lzss](https://github.com/consensys/compress), a snark-friendly compression algorithm. This allows the Linea prover to "prove correct decompression of the blob".
+The raw data is compressed using [compress/lzss](https://github.com/consensys/compress), a snark-friendly compression algorithm. This allows the Lineth prover to "prove correct decompression of the blob".
 
 ### Final Blob: Byte Alignment
 

--- a/prover/lib/compressor/blob/v0/blob_spec.md
+++ b/prover/lib/compressor/blob/v0/blob_spec.md
@@ -1,6 +1,6 @@
 # Lineth Blob Format Specification
 
-This document provides a detailed explanation of the structure of a blob in the context of Lineth prover. A blob contains essential information that allows the Lineth prover to validate the execution of several blocks of transactions. The blob's content is compressed and structured to facilitate cryptographic operations within zkSNARK circuits.
+This document provides a detailed explanation of the structure of a blob in the context of the Lineth prover. A blob contains essential information that allows the Lineth prover to validate the execution of several blocks of transactions. The blob's content is compressed and structured to facilitate cryptographic operations within zkSNARK circuits.
 
 ## Content
 

--- a/prover/lib/compressor/blob/v1/blob_maker.go
+++ b/prover/lib/compressor/blob/v1/blob_maker.go
@@ -388,7 +388,7 @@ func (bm *BlobMaker) WorstCompressedBlockSize(rlpBlock []byte) (bool, int, error
 		return false, -1, fmt.Errorf("failed to decode RLP block: %w", err)
 	}
 
-	// encode the block in Linea format.
+	// encode the block in Lineth format.
 	var buf bytes.Buffer
 	if err := EncodeBlockForCompression(&block, &buf); err != nil {
 		return false, -1, fmt.Errorf("failed to encode block: %w", err)
@@ -430,7 +430,7 @@ func (bm *BlobMaker) WorstCompressedTxSize(rlpTx []byte) (int, error) {
 		return -1, err
 	}
 
-	// encode the transaction in Linea format.
+	// encode the transaction in Lineth format.
 	var buf bytes.Buffer
 	if err := EncodeTxForCompression(&tx, &buf); err != nil {
 		return -1, fmt.Errorf("failed to encode transaction: %w", err)

--- a/prover/lib/compressor/blob/v1/blob_spec.md
+++ b/prover/lib/compressor/blob/v1/blob_spec.md
@@ -1,6 +1,6 @@
-# Linea Blob Format Specification
+# Lineth Blob Format Specification
 
-This document provides a detailed explanation of the structure of a blob in the context of Linea prover. A blob contains essential information that allows the Linea prover to validate the execution of several blocks of transactions. The blob's content is compressed and structured to facilitate cryptographic operations within zkSNARK circuits.
+This document provides a detailed explanation of the structure of a blob in the context of Lineth prover. A blob contains essential information that allows the Lineth prover to validate the execution of several blocks of transactions. The blob's content is compressed and structured to facilitate cryptographic operations within zkSNARK circuits.
 
 ## Content
 
@@ -38,12 +38,12 @@ The header contains the following elements:
 
 ### Body
 
-The body contains a list of RLP encoded Linea blocks. For each block, the raw data includes:
+The body contains a list of RLP encoded Lineth blocks. For each block, the raw data includes:
 
 - Block Timestamp uint64
 - Transactions (refer to EncodeTxForCompression for more details)
 
-The raw data is compressed using [compress/lzss](https://github.com/consensys/compress), a snark-friendly compression algorithm. This allows the Linea prover to "prove correct decompression of the blob".
+The raw data is compressed using [compress/lzss](https://github.com/consensys/compress), a snark-friendly compression algorithm. This allows the Lineth prover to "prove correct decompression of the blob".
 
 ### Final Blob: Byte Alignment
 

--- a/prover/lib/compressor/blob/v1/blob_spec.md
+++ b/prover/lib/compressor/blob/v1/blob_spec.md
@@ -1,6 +1,6 @@
 # Lineth Blob Format Specification
 
-This document provides a detailed explanation of the structure of a blob in the context of Lineth prover. A blob contains essential information that allows the Lineth prover to validate the execution of several blocks of transactions. The blob's content is compressed and structured to facilitate cryptographic operations within zkSNARK circuits.
+This document provides a detailed explanation of the structure of a blob in the context of the Lineth prover. A blob contains essential information that allows the Lineth prover to validate the execution of several blocks of transactions. The blob's content is compressed and structured to facilitate cryptographic operations within zkSNARK circuits.
 
 ## Content
 

--- a/prover/lib/compressor/blob/v2/blob_spec.md
+++ b/prover/lib/compressor/blob/v2/blob_spec.md
@@ -1,6 +1,6 @@
-# Linea Blob Format Specification
+# Lineth Blob Format Specification
 
-This document provides a detailed explanation of the structure of a blob in the context of Linea prover. A blob contains essential information that allows the Linea prover to validate the execution of several blocks of transactions. The blob's content is compressed and structured to facilitate cryptographic operations within zkSNARK circuits.
+This document provides a detailed explanation of the structure of a blob in the context of Lineth prover. A blob contains essential information that allows the Lineth prover to validate the execution of several blocks of transactions. The blob's content is compressed and structured to facilitate cryptographic operations within zkSNARK circuits.
 
 ## Content
 
@@ -38,12 +38,12 @@ The header contains the following elements:
 
 ### Body
 
-The body contains a list of RLP encoded Linea blocks. For each block, the raw data includes:
+The body contains a list of RLP encoded Lineth blocks. For each block, the raw data includes:
 
 - Block Timestamp uint64
 - Transactions (refer to EncodeTxForCompression for more details)
 
-The raw data is compressed using [compress/lzss](https://github.com/consensys/compress), a snark-friendly compression algorithm. This allows the Linea prover to "prove correct decompression of the blob".
+The raw data is compressed using [compress/lzss](https://github.com/consensys/compress), a snark-friendly compression algorithm. This allows the Lineth prover to "prove correct decompression of the blob".
 
 ### Final Blob: Byte Alignment
 

--- a/prover/lib/compressor/blob/v2/blob_spec.md
+++ b/prover/lib/compressor/blob/v2/blob_spec.md
@@ -1,6 +1,6 @@
 # Lineth Blob Format Specification
 
-This document provides a detailed explanation of the structure of a blob in the context of Lineth prover. A blob contains essential information that allows the Lineth prover to validate the execution of several blocks of transactions. The blob's content is compressed and structured to facilitate cryptographic operations within zkSNARK circuits.
+This document provides a detailed explanation of the structure of a blob in the context of the Lineth prover. A blob contains essential information that allows the Lineth prover to validate the execution of several blocks of transactions. The blob's content is compressed and structured to facilitate cryptographic operations within zkSNARK circuits.
 
 ## Content
 

--- a/prover/lib/compressor/dictionary-update-guide.md
+++ b/prover/lib/compressor/dictionary-update-guide.md
@@ -3,7 +3,7 @@
 The process is simple. The only subtle point is that support for new dictionaries should be added downstream-first (i.e. first in the prover and the decompressor, and then in the blob compressor,) and that conversely retiring a dictionary should be done upstream-first (i.e. first in the blob compressor, and then in the prover, and never in a decompressor used for state reconstruction.)
 
 ## Updating the Prover
-Download the dictionary file on the machine running the prover. Add its path relative to the prover root, to the prover configuration `.toml` file, in the `dict_paths` property, under `blob_decompression`. Normally the dictionary would already be available in the Linea repository, its path looking like `"lib/compressor/dict/yy-mm-dd.bin"`.
+Download the dictionary file on the machine running the prover. Add its path relative to the prover root, to the prover configuration `.toml` file, in the `dict_paths` property, under `blob_decompression`. Normally the dictionary would already be available in the Lineth repository, its path looking like `"lib/compressor/dict/yy-mm-dd.bin"`.
 The next time the prover is started, it will (also) load the new dictionary. Note that there is no need to recompile the decompression circuit.
 
 Example:

--- a/prover/lib/compressor/libdecompressor/libdecompressor.go
+++ b/prover/lib/compressor/libdecompressor/libdecompressor.go
@@ -50,7 +50,7 @@ func LoadDictionaries(dictPaths *C.char) C.int {
 	return C.int(len(paths))
 }
 
-// Decompress processes a Linea blob and outputs an RLP encoded list of RLP encoded blocks.
+// Decompress processes a Lineth blob and outputs an RLP encoded list of RLP encoded blocks.
 // Due to information loss during pre-compression encoding, two pieces of information are represented "hackily":
 // The block hash is in the ParentHash field.
 // The transaction from address is in the signature.R field.

--- a/prover/protocol/plonkinternal/doc.go
+++ b/prover/protocol/plonkinternal/doc.go
@@ -15,7 +15,7 @@ circuit's satisfiability within the currently compiled IOP.
 
 This comes in handy in situation where we wish to prove complex relations that
 are difficult to express directly in the form of a Wizard-IOP but easier to
-express in a language that is more expressive. In the case, of Linea's zkEVM,
+express in a language that is more expressive. In the case, of Lineth's zkEVM,
 this is used for the ECDSA verification and the precompiles.
 
 The package optionally offers optimization when,

--- a/prover/protocol/plonkinternal/doc.go
+++ b/prover/protocol/plonkinternal/doc.go
@@ -13,9 +13,9 @@ circuit alongside a [wizard.CompiledIOP] object. The utility will build all the
 necessary columns and declare all the necessary constraints to emulate the
 circuit's satisfiability within the currently compiled IOP.
 
-This comes in handy in situation where we wish to prove complex relations that
+This comes in handy in situations where we wish to prove complex relations that
 are difficult to express directly in the form of a Wizard-IOP but easier to
-express in a language that is more expressive. In the case, of Lineth's zkEVM,
+express in a language that is more expressive. In the case of Lineth's zkEVM,
 this is used for the ECDSA verification and the precompiles.
 
 The package optionally offers optimization when,

--- a/prover/sis_estimation/Readme.md
+++ b/prover/sis_estimation/Readme.md
@@ -24,7 +24,7 @@ These were the original parameters of the original pre-print of Vortex
 
 ## Current parameters
 
-The current parameters that are used in Linea
+The current parameters that are used in Lineth
 
 |$log_2(q)$        |$log_2(beta)$     |$n$               |SVP (L2)          |SVP (Loo)         |BKZ attack        |CPW attack        |#limbs            |pi                |
 |------------------|------------------|------------------|------------------|------------------|------------------|------------------|------------------|------------------|

--- a/prover/zkevm/prover/hash/sha2/sha2.go
+++ b/prover/zkevm/prover/hash/sha2/sha2.go
@@ -1,5 +1,5 @@
 // The sha2 package provides all the necessary tools to verify the calls to the
-// sha2 precompiles in the Lineth's zkevm.
+// sha2 precompiles in Lineth's zkEVM.
 package sha2
 
 import (

--- a/prover/zkevm/prover/hash/sha2/sha2.go
+++ b/prover/zkevm/prover/hash/sha2/sha2.go
@@ -1,5 +1,5 @@
 // The sha2 package provides all the necessary tools to verify the calls to the
-// sha2 precompiles in the Linea's zkevm.
+// sha2 precompiles in the Lineth's zkevm.
 package sha2
 
 import (
@@ -41,7 +41,7 @@ type Sha2SingleProvider struct {
 	Pa_cSha2     *sha2BlockModule
 }
 
-// NewSha2ZkEvm constructs the Sha2 module as used in Linea's zkEVM.
+// NewSha2ZkEvm constructs the Sha2 module as used in Lineth's zkEVM.
 func NewSha2ZkEvm(comp *wizard.CompiledIOP, s Settings, arith *arithmetization.Arithmetization) *Sha2SingleProvider {
 
 	sha2ProviderInput := Sha2SingleProviderInput{

--- a/prover/zkevm/prover/statemanager/accumulator/define.go
+++ b/prover/zkevm/prover/statemanager/accumulator/define.go
@@ -18,7 +18,7 @@ import (
 
 /*
 Below, we give a high level overview of the Accumulator module. The inputs of the
-Accumulator module are the Shomei traces. Shomei is the state manager of Linea zkEVM.
+Accumulator module are the Shomei traces. Shomei is the state manager of Lineth zkEVM.
 It stores the various states of the account and storage trie in many sparse Merkle trees. As described in
 https://docs.google.com/document/d/12oRcoDDql-2FpmRjcrBa8n7c_X41bZFO5leBzMcehlQ/edit#heading=h.9ssjg7avtkms,
 Shomei generates traces for five operations on the Merkle trees, namely INSERT, UPDATE, DELETE, READ-ZERO,
@@ -229,7 +229,7 @@ type Module struct {
 }
 
 // NewModule generates and constraints the accumulator module. The accumulator
-// module is entrusted to check all individual Linea's state accumulator traces.
+// module is entrusted to check all individual Lineth's state accumulator traces.
 func NewModule(comp *wizard.CompiledIOP, s Settings) Module {
 	am := Module{}
 	am.define(comp, s)

--- a/prover/zkevm/prover/statemanager/common/state_diff.go
+++ b/prover/zkevm/prover/statemanager/common/state_diff.go
@@ -11,7 +11,7 @@ import (
 )
 
 // StateDiff is a collection of column that appears in several of the modules
-// of the state-manager of Linea.
+// of the state-manager of Lineth.
 //
 // In state summary, we have a unique tuple of (hKey, initialHVal, finalHVal,
 // initialRoot, finalRoot) for each of the state operations (e.g. INSERT,

--- a/prover/zkevm/prover/statemanager/common/state_diff.go
+++ b/prover/zkevm/prover/statemanager/common/state_diff.go
@@ -10,7 +10,7 @@ import (
 	"github.com/consensys/linea-monorepo/prover/zkevm/prover/common"
 )
 
-// StateDiff is a collection of column that appears in several of the modules
+// StateDiff is a collection of columns that appear in several of the modules
 // of the state-manager of Lineth.
 //
 // In state summary, we have a unique tuple of (hKey, initialHVal, finalHVal,

--- a/prover/zkevm/prover/statemanager/state_manager.go
+++ b/prover/zkevm/prover/statemanager/state_manager.go
@@ -14,7 +14,7 @@ import (
 )
 
 // StateManager is a collection of modules responsible for attesting the
-// correctness of the state-transitions occuring in Lineth w.r.t. to the
+// correctness of the state transitions occurring in Lineth with respect to the
 // arithmetization.
 type StateManager struct {
 	Accumulator                 accumulator.Module

--- a/prover/zkevm/prover/statemanager/state_manager.go
+++ b/prover/zkevm/prover/statemanager/state_manager.go
@@ -14,7 +14,7 @@ import (
 )
 
 // StateManager is a collection of modules responsible for attesting the
-// correctness of the state-transitions occuring in Linea w.r.t. to the
+// correctness of the state-transitions occuring in Lineth w.r.t. to the
 // arithmetization.
 type StateManager struct {
 	Accumulator                 accumulator.Module


### PR DESCRIPTION
## Summary
- Completes a missed piece of the Linea→Lineth rename: Go comments, blob-format specs, and READMEs in `prover/` describing this project's own prover/blob format/state manager.
- Go package names and the module path (`github.com/consensys/linea-monorepo/prover`) are unchanged. Real external references (Linea mainnet chain ID, a real Linea Sepolia transaction hash in a regression test comment, the historical CHANGELOG rename entry) were left untouched.

## Test plan
- [ ] `go build ./...` and `go test ./...` pass in CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and documentation-only renames with no logic, config keys, or API surface changes.
> 
> **Overview**
> Finishes the **Linea → Lineth** naming pass in `prover/` by updating user-facing text only: **README** / **AGENTS.md**, blob format specs (v0–v2), dictionary guide, and Go **comments** across CLI, config, execution/invalidity public-input helpers, blob compress/decompress paths, zkEVM/state-manager modules, and Solidity verifier export docs.
> 
> **Identifiers and behavior are unchanged**—e.g. `lineaVerifierConstants`, `LineaCodeHash`, and the module path stay as-is; external/historical **Linea** references called out in the PR description were not touched.
> 
> A few **comment/doc grammar** tweaks ride along (e.g. “situation” → “situations”, “occuring” → “occurring”, “column that appears” → “columns that appear”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d769e5fa8c6a5d8b46a2110b676ad0adfb89114d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->