### PR TITLE
chore(prover): rename Linea to Lineth in zkVM and RISC-V tooling

### DIFF
--- a/prover-ray/AGENTS.md
+++ b/prover-ray/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## Package Overview
 
-This is the ZK prover for Linea, written in Go and built on top of gnark.
+This is the ZK prover for Lineth, written in Go and built on top of gnark.
 It implements the Vortex polynomial commitment scheme and the Consensys zkEVM.
 The proving pipeline works as follows. The `go-corset` library supplies the
 circuit description and witness assignments for the zkEVM arithmetization.

--- a/prover-ray/README.md
+++ b/prover-ray/README.md
@@ -1,6 +1,6 @@
 # linea-monorepo/prover
 
-This directory contains the implementation of the prover of Linea. As part of it,
+This directory contains the implementation of the prover of Lineth. As part of it,
 it contains an implementation of the Vortex polynomial commitment, of the
 Arcane compiler, the instantiation of the zkEVM using the arithmetization and
 the server implementation.
@@ -15,7 +15,7 @@ The prover has the following build dependencies
 The repository counts 2 main binaries:
 
 - `bin/prover` : `bin/prover setup` generate the assets (setup / preprocessing) `bin/prover prove` run process a request, create a proof and outputs a response.
-- `bin/controller` : a file-system based server to run Linea's prover
+- `bin/controller` : a file-system based server to run Lineth's prover
 
 ### Building and running the setup generator
 

--- a/prover-ray/README.md
+++ b/prover-ray/README.md
@@ -1,6 +1,6 @@
-# linea-monorepo/prover
+# lineth-monorepo/prover
 
-This directory contains the implementation of the prover of Lineth. As part of it,
+This directory contains the implementation of the Lineth prover. As part of it,
 it contains an implementation of the Vortex polynomial commitment, of the
 Arcane compiler, the instantiation of the zkEVM using the arithmetization and
 the server implementation.

--- a/prover-ray/backend/zkc-r5/const.go
+++ b/prover-ray/backend/zkc-r5/const.go
@@ -1,6 +1,6 @@
 package zkcr5
 
-// DefaultINOrigin is the canonical _in_start RAM address for all Linea guest
+// DefaultINOrigin is the canonical _in_start RAM address for all Lineth guest
 // programs: the address where the input data is mapped before the VM starts
 // executing.
 //

--- a/prover-ray/docs/section2_arithmetization.md
+++ b/prover-ray/docs/section2_arithmetization.md
@@ -137,7 +137,7 @@ arithmetization source for the exact per-opcode constraint definitions (§2.9).
 ## 2.5 Relationship to ZkC and the Proving Boundary
 
 The arithmetization is written in **ZkC**, a small imperative language for
-programs whose executions can be proved, maintained by the Linea arithmetization
+programs whose executions can be proved, maintained by the Lineth arithmetization
 team. ZkC's relevant characteristics:
 
 - **Fixed-width unsigned integers of arbitrary bitwidth** (`u1`, `u25`, `u160`,

--- a/riscv-guests/README.md
+++ b/riscv-guests/README.md
@@ -1,6 +1,6 @@
 # RISC-V Guest Programs
 
-This directory holds the RISC-V guest programs that target the Linea ZKC interpreter. Each guest is a **self-contained Zig package** — its own `build.zig`, `build.zig.zon` (its dependencies), `Makefile` (its compile/test lifecycle) and `src/`. A thin top-level `Makefile` orchestrates them all, and shared build logic lives in `build_common/`. They share one Zig toolchain (`.zigversion`).
+This directory holds the RISC-V guest programs that target the Lineth ZKC interpreter. Each guest is a **self-contained Zig package** — its own `build.zig`, `build.zig.zon` (its dependencies), `Makefile` (its compile/test lifecycle) and `src/`. A thin top-level `Makefile` orchestrates them all, and shared build logic lives in `build_common/`. They share one Zig toolchain (`.zigversion`).
 
 ## Layout
 

--- a/riscv-guests/build_common/build.zig
+++ b/riscv-guests/build_common/build.zig
@@ -28,7 +28,7 @@ pub fn requireZigVersion() void {
     }
 }
 
-/// The freestanding rv64im target every guest builds for (the Linea ZkC interpreter profile:
+/// The freestanding rv64im target every guest builds for (the Lineth ZkC interpreter profile:
 /// base RV64I + M, soft-float, no A/C/D/F/Zicsr). Overridable on the CLI like any standard target.
 pub fn standardGuestTarget(b: *std.Build) std.Build.ResolvedTarget {
     return b.standardTargetOptions(.{

--- a/riscv-guests/l2-execution/build.zig.zon
+++ b/riscv-guests/l2-execution/build.zig.zon
@@ -28,7 +28,7 @@
         },
         // Shared build helpers for all riscv-guests packages (sibling path dependency).
         .build_common = .{ .path = "../build_common" },
-        // Linea zkVM accelerator wrappers (sibling path dependency).
+        // Lineth zkVM accelerator wrappers (sibling path dependency).
         .lineth_accelerators = .{ .path = "../lineth-accelerators" },
     },
     .paths = .{

--- a/riscv-guests/l2-execution/src/evm_execution_guest.zig
+++ b/riscv-guests/l2-execution/src/evm_execution_guest.zig
@@ -6,7 +6,7 @@ const ssz_decode = @import("zesu_ssz_decode");
 const ssz_output = @import("zesu_ssz_output");
 const zesu_allocator = @import("zesu_allocator");
 
-// Heap start from the linker script (canonical Linea layout: `_heap_start` = 0x48800000, grows up).
+// Heap start from the linker script (canonical Lineth layout: `_heap_start` = 0x48800000, grows up).
 extern var _heap_start: u8;
 // Linker script does not actually constraint the heap to 256 MiB, but this is a reasonable upper bound
 const GUEST_HEAP_SIZE: usize = 256 * 1024 * 1024;
@@ -76,7 +76,7 @@ comptime {
     if (builtin.cpu.arch == .riscv64) {
         @export(&guestMain, .{ .name = "main" });
         // Pull in the precompile providers (zkvm_provide.zig): it DEFINES every zkvm_* symbol zesu
-        // references — keccak from the Linea wrapper, the rest from zesu-zkvm's stdlibs_accel.
+        // references — keccak from the Lineth wrapper, the rest from zesu-zkvm's stdlibs_accel.
         // Freestanding only — the native build uses Zesu's C backend and never references zkvm_*.
         _ = @import("zkvm_provide.zig");
     }

--- a/riscv-guests/l2-execution/src/evm_execution_guest.zig
+++ b/riscv-guests/l2-execution/src/evm_execution_guest.zig
@@ -6,7 +6,7 @@ const ssz_decode = @import("zesu_ssz_decode");
 const ssz_output = @import("zesu_ssz_output");
 const zesu_allocator = @import("zesu_allocator");
 
-// Heap start from the linker script (canonical Lineth layout: `_heap_start` = 0x48800000, grows up).
+// Heap starts at the address defined by the linker script (canonical Lineth layout: `_heap_start` = 0x48800000, grows up).
 extern var _heap_start: u8;
 // Linker script does not actually constraint the heap to 256 MiB, but this is a reasonable upper bound
 const GUEST_HEAP_SIZE: usize = 256 * 1024 * 1024;

--- a/riscv-guests/lineth-accelerators/include/lineth_accelerators.h
+++ b/riscv-guests/lineth-accelerators/include/lineth_accelerators.h
@@ -1,5 +1,5 @@
 /**
- * Lineth (Linea zkVM) Cryptographic Accelerators C Interface
+ * Lineth Cryptographic Accelerators C Interface
  *
  * This header defines Lineth-specific accelerators that are NOT part of the
  * upstream zkVM accelerator standard. They live in the `lineth_zkvm_` namespace

--- a/riscv-guests/lineth-accelerators/include/lineth_accelerators.h
+++ b/riscv-guests/lineth-accelerators/include/lineth_accelerators.h
@@ -1,7 +1,7 @@
 /**
  * Lineth (Linea zkVM) Cryptographic Accelerators C Interface
  *
- * This header defines Linea-specific accelerators that are NOT part of the
+ * This header defines Lineth-specific accelerators that are NOT part of the
  * upstream zkVM accelerator standard. They live in the `lineth_zkvm_` namespace
  * to keep them distinct from the standard `zkvm_` accelerators.
  *

--- a/scripts/prover-options/lib.js
+++ b/scripts/prover-options/lib.js
@@ -1,5 +1,5 @@
 /**
- * Linea prover config MDX renderer.
+ * Lineth prover config MDX renderer.
  * Extraction is done by parse-go.js; this file turns the extract into MDX partials + wrapper.
  */
 
@@ -113,9 +113,9 @@ function renderPartials(manifest, tracesNote) {
 function renderStarterWrapper(partials) {
   const lines = [];
   lines.push("---");
-  lines.push("title: Linea prover configuration");
+  lines.push("title: Lineth prover configuration");
   lines.push("slug: /stack/reference/linea-prover-options");
-  lines.push("description: Auto-generated reference of Linea prover TOML configuration keys, grouped by section.");
+  lines.push("description: Auto-generated reference of Lineth prover TOML configuration keys, grouped by section.");
   lines.push("draft: false");
   lines.push("---");
   lines.push("");
@@ -132,7 +132,7 @@ function renderStarterWrapper(partials) {
   lines.push("");
 
   lines.push(
-    "This reference lists Linea prover TOML configuration keys, grouped by section. " +
+    "This reference lists Lineth prover TOML configuration keys, grouped by section. " +
       "Descriptions come from Go doc comments on the config structs; defaults come from " +
       "`config_default.go` (never from sample `config-*.toml` files).",
   );

--- a/scripts/prover-options/package.json
+++ b/scripts/prover-options/package.json
@@ -2,7 +2,7 @@
   "name": "prover-options-docs",
   "version": "0.0.0",
   "private": true,
-  "description": "Generate ephemeral Linea prover TOML config MDX partials from Go sources and validate fresh temporary output.",
+  "description": "Generate ephemeral Lineth prover TOML config MDX partials from Go sources and validate fresh temporary output.",
   "scripts": {
     "generate": "node generate.js",
     "generate:seed-wrapper": "node seed-wrapper.js",

--- a/scripts/prover-options/templates/linea-prover-options.mdx
+++ b/scripts/prover-options/templates/linea-prover-options.mdx
@@ -1,7 +1,7 @@
 ---
-title: Linea prover configuration
+title: Lineth prover configuration
 slug: /stack/reference/linea-prover-options
-description: Auto-generated reference of Linea prover TOML configuration keys, grouped by section.
+description: Auto-generated reference of Lineth prover TOML configuration keys, grouped by section.
 draft: false
 ---
 
@@ -19,7 +19,7 @@ import Debug from "./_generated/prover/debug.mdx";
 import Layer2 from "./_generated/prover/layer2.mdx";
 import TracesLimits from "./_generated/prover/traces-limits.mdx";
 
-This reference lists Linea prover TOML configuration keys, grouped by section. Descriptions come from Go doc comments on the config structs; defaults come from `config_default.go` (never from sample `config-*.toml` files).
+This reference lists Lineth prover TOML configuration keys, grouped by section. Descriptions come from Go doc comments on the config structs; defaults come from `config_default.go` (never from sample `config-*.toml` files).
 
 <Provenance />
 

--- a/verifier-ray/README.md
+++ b/verifier-ray/README.md
@@ -67,7 +67,7 @@ Build the native optimized executable:
 make build-release
 ```
 
-Build the Linea R5 zkVM executable:
+Build the Lineth R5 zkVM executable:
 
 ```bash
 make build-r5

--- a/verifier-ray/build.zig
+++ b/verifier-ray/build.zig
@@ -12,9 +12,9 @@ const EmbeddedInputType = enum {
 pub fn build(b: *std.Build) void {
     common.requireZigVersion();
 
-    const r5 = b.option(bool, "r5", "Build for the Linea R5 zkVM target") orelse false;
-    // Allow disabling the Linea zkVM accelerators wrappers for testing purposes. However, we only have them for the R5 target, so it is disabled by default.
-    const disable_accelerators = (b.option(bool, "disable-accelerators", "Disable Linea zkVM accelerator wrappers") orelse false) or !r5;
+    const r5 = b.option(bool, "r5", "Build for the Lineth R5 zkVM target") orelse false;
+    // Allow disabling the Lineth zkVM accelerators wrappers for testing purposes. However, we only have them for the R5 target, so it is disabled by default.
+    const disable_accelerators = (b.option(bool, "disable-accelerators", "Disable Lineth zkVM accelerator wrappers") orelse false) or !r5;
     const verifier_profiling = b.option(
         bool,
         "verifier-profiling",
@@ -42,7 +42,7 @@ pub fn build(b: *std.Build) void {
         b.standardOptimizeOption(.{});
     const strip = b.option(bool, "strip", "Omit debug symbols") orelse (r5 or optimize == .ReleaseSmall);
 
-    // Linea zkVM accelerator - zkvm_exit and precompile accelerators etc.
+    // Lineth zkVM accelerator - zkvm_exit and precompile accelerators etc.
     const lineth_mod = b.dependency("lineth_accelerators", .{ .target = target, .optimize = optimize }).module("lineth_accelerators");
 
     const verifier_mod = b.addModule("verifier_ray", .{
@@ -51,7 +51,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .strip = strip,
     });
-    // conditionally import the Linea zkVM accelerator module for supported target and when requested
+    // conditionally import the Lineth zkVM accelerator module for supported target and when requested
     if (!disable_accelerators) {
         verifier_mod.addImport("lineth_accelerators", lineth_mod);
     }

--- a/verifier-ray/build.zig
+++ b/verifier-ray/build.zig
@@ -13,7 +13,7 @@ pub fn build(b: *std.Build) void {
     common.requireZigVersion();
 
     const r5 = b.option(bool, "r5", "Build for the Lineth R5 zkVM target") orelse false;
-    // Allow disabling the Lineth zkVM accelerators wrappers for testing purposes. However, we only have them for the R5 target, so it is disabled by default.
+    // Allow disabling the Lineth zkVM accelerator wrappers for testing purposes. We only have them for the R5 target, so they are disabled by default unless the r5 option is set.
     const disable_accelerators = (b.option(bool, "disable-accelerators", "Disable Lineth zkVM accelerator wrappers") orelse false) or !r5;
     const verifier_profiling = b.option(
         bool,

--- a/verifier-ray/build.zig.zon
+++ b/verifier-ray/build.zig.zon
@@ -6,7 +6,7 @@
     .dependencies = .{
         // shared build utilities for Zig build to R5 target
         .build_common = .{ .path = "../riscv-guests/build_common" },
-        // Linea zkVM accelerator wrappers — used by the R5 entry point (main.zig) for zkvm_exit and precompile acceleration. Only used when building for the R5 target.
+        // Lineth zkVM accelerator wrappers — used by the R5 entry point (main.zig) for zkvm_exit and precompile acceleration. Only used when building for the R5 target.
         .lineth_accelerators = .{ .path = "../riscv-guests/lineth-accelerators" },
     },
     .paths = .{

--- a/verifier-ray/src/crypto/poseidon2.zig
+++ b/verifier-ray/src/crypto/poseidon2.zig
@@ -175,7 +175,7 @@ fn permutationNative(comptime width: usize, state: *[width]field.Element) void {
     }
 }
 
-// Delegate the width-16 permutation to the Linea Poseidon2 accelerator opcode.
+// Delegate the width-16 permutation to the Lineth Poseidon2 accelerator opcode.
 //
 // `field.Element` is `extern struct { value: u32 }`, so `[16]Element` is exactly
 // 16 little-endian canonical 32-bit words — the same layout the accelerator

--- a/verifier-ray/src/main.zig
+++ b/verifier-ray/src/main.zig
@@ -144,6 +144,6 @@ fn exitR5(code: u8) noreturn {
     if (comptime !is_r5_zkvm) {
         @compileError("R5 exit currently supports only R5 zkVM target");
     }
-    // Delegate to the Linea accelerator package's standard zkVM exit (zkvm_std.h).
+    // Delegate to the Lineth accelerator package's standard zkVM exit (zkvm_std.h).
     lineth_accel.zkvm_exit(@intCast(code));
 }


### PR DESCRIPTION
## Summary
- Completes a missed piece of the Linea→Lineth rename: Go/Zig comments and READMEs in `prover-ray/`, `riscv-guests/`, and `verifier-ray/` describing this project's own zkVM accelerators and RISC-V guest programs.
- Identifiers, external dependency paths (e.g. `Consensys/zesu-zkvm`'s internal `linea/` path), and the real Linea mainnet chain ID references were left untouched.

## Test plan
- [ ] Zig/Go builds pass in CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and documentation-only renames with no logic or config key changes.
> 
> **Overview**
> Finishes the **Linea → Lineth** branding pass in `prover-ray/`, `riscv-guests/`, `verifier-ray/`, and the prover-options doc generator: READMEs, `AGENTS.md`, Go/Zig/C header comments, and generated MDX wrapper copy now say **Lineth** for this repo’s prover, zkVM accelerators, and RISC-V guest tooling.
> 
> **No runtime behavior changes**—identifiers, dependency paths (e.g. zesu’s internal `linea/`), and URLs like `linea-prover-options` are unchanged. `verifier-ray/build.zig` only tightens comments around the R5 accelerator option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 644ffda34788e2a97a36271f89866a0e7afcd4ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->