### PR TITLE
chore(misc): rename Linea to Lineth in native-yield operations

### DIFF
--- a/operations/native-yield/automation-service/README.md
+++ b/operations/native-yield/automation-service/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Automates native yield operations on Linea by monitoring the YieldManager contract and executing the appropriate operation mode (yield reporting, ossification pending, or ossification complete). See [docs/architecture.md](./docs/architecture.md) for design details.
+Automates native yield operations on Lineth by monitoring the YieldManager contract and executing the appropriate operation mode (yield reporting, ossification pending, or ossification complete). See [docs/architecture.md](./docs/architecture.md) for design details.
 
 ## Folder Structure
 

--- a/operations/native-yield/automation-service/README.md
+++ b/operations/native-yield/automation-service/README.md
@@ -1,4 +1,4 @@
-# Linea Native Yield Automation Service
+# Lineth Native Yield Automation Service
 
 ## Overview
 

--- a/operations/native-yield/automation-service/src/application/main/config/config.schema.ts
+++ b/operations/native-yield/automation-service/src/application/main/config/config.schema.ts
@@ -67,7 +67,7 @@ export const configSchema = z
     LAZY_ORACLE_ADDRESS: Address,
     // Address of the Lido VaultHub contract.
     VAULT_HUB_ADDRESS: Address,
-    // Address of the Linea YieldManager contract.
+    // Address of the Lineth YieldManager contract.
     YIELD_MANAGER_ADDRESS: Address,
     // Address of the LidoStVaultYieldProvider contract.
     LIDO_YIELD_PROVIDER_ADDRESS: Address,

--- a/operations/native-yield/automation-service/src/clients/contracts/LinethRollupYieldExtensionContractClient.ts
+++ b/operations/native-yield/automation-service/src/clients/contracts/LinethRollupYieldExtensionContractClient.ts
@@ -13,7 +13,7 @@ import { ILinethRollupYieldExtension } from "../../core/clients/contracts/ILinet
 
 /**
  * Client for interacting with LinethRollupYieldExtension smart contracts.
- * Provides methods for transferring funds for native yield operations on the Linea rollup.
+ * Provides methods for transferring funds for native yield operations on the Lineth rollup.
  */
 export class LinethRollupYieldExtensionContractClient implements ILinethRollupYieldExtension<TransactionReceipt> {
   private readonly contract: GetContractReturnType<typeof LinethRollupYieldExtensionABI, PublicClient, Address>;
@@ -65,7 +65,7 @@ export class LinethRollupYieldExtensionContractClient implements ILinethRollupYi
   }
 
   /**
-   * Transfers funds for native yield operations on the Linea rollup.
+   * Transfers funds for native yield operations on the Lineth rollup.
    * Encodes the function call and sends a signed transaction via the blockchain client.
    *
    * @param {bigint} amount - The amount to transfer in wei.

--- a/operations/native-yield/lido-governance-monitor/README.md
+++ b/operations/native-yield/lido-governance-monitor/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Lido Governance Monitor is a cronjob that checks Lido governance proposals and alerts the Security Council when high-risk proposals may impact Linea's Native Yield system.
+The Lido Governance Monitor is a cronjob that checks Lido governance proposals and alerts the Security Council when high-risk proposals may impact Lineth's Native Yield system.
 
 Each run executes three sequential steps:
 

--- a/operations/native-yield/lido-governance-monitor/docs/architecture.md
+++ b/operations/native-yield/lido-governance-monitor/docs/architecture.md
@@ -1,8 +1,8 @@
 # Context & Goals
 
-Linea's Yield Boost depends on Lido V3 StakingVaults, which are governed by **Lido's on-chain governance process**. Governance decisions - particularly contract upgrades, parameter changes, or governance process changes - represent a primary external risk vector for Yield Boost.
+Lineth's Yield Boost depends on Lido V3 StakingVaults, which are governed by **Lido's on-chain governance process**. Governance decisions - particularly contract upgrades, parameter changes, or governance process changes - represent a primary external risk vector for Yield Boost.
 
-A malicious, compromised, or poorly designed governance change affecting the StakingVault or closely related contracts could materially impact Yield Boost operations, including withdrawal liveness or yield accounting. Linea must gain early visibility into governance proposals *before execution*, with sufficient time for the Security Council to evaluate risk and take protective actions such as ossifying the vault.
+A malicious, compromised, or poorly designed governance change affecting the StakingVault or closely related contracts could materially impact Yield Boost operations, including withdrawal liveness or yield accounting. Lineth must gain early visibility into governance proposals *before execution*, with sufficient time for the Security Council to evaluate risk and take protective actions such as ossifying the vault.
 
 The **Lido Governance Monitor** is an off-chain service that provides this early warning. It regularly checks the Lido governance proposal pipeline, evaluates proposals for risk to Yield Boost using an AI-assisted judge, and escalates proposals that may pose a material risk to the Security Council.
 

--- a/operations/native-yield/lido-governance-monitor/scripts/test-proposal-processor.ts
+++ b/operations/native-yield/lido-governance-monitor/scripts/test-proposal-processor.ts
@@ -30,7 +30,7 @@ import { ProposalSource } from "../src/core/entities/ProposalSource.js";
 import { ProposalState } from "../src/core/entities/ProposalState.js";
 import { ProposalProcessor } from "../src/services/ProposalProcessor.js";
 
-const TEST_SYSTEM_PROMPT = `You are a security analyst for Linea's Native Yield integration with Lido.
+const TEST_SYSTEM_PROMPT = `You are a security analyst for Lineth's Native Yield integration with Lido.
 
 Analyze the governance proposal and respond with a JSON object containing:
 - riskScore (0-100): Overall risk score

--- a/operations/native-yield/lido-governance-monitor/src/prompts/risk-assessment-system.md
+++ b/operations/native-yield/lido-governance-monitor/src/prompts/risk-assessment-system.md
@@ -1,6 +1,6 @@
 You are the Native Yield Governance Risk Judge.
 
-Your job: evaluate Lido governance proposals for their potential to break or degrade Linea Native Yield’s safety/liveness properties, or to invalidate assumptions relied on by the YieldManager + Lido stVault integration.
+Your job: evaluate Lido governance proposals for their potential to break or degrade Lineth Native Yield’s safety/liveness properties, or to invalidate assumptions relied on by the YieldManager + Lido stVault integration.
 
 You MUST be conservative: false negatives are worse than false positives.
 
@@ -18,7 +18,7 @@ WHAT COUNTS AS “IMPACT” (scope)
 
 Any proposal that can:
 
-1) Change trust assumptions, upgrade surfaces, or admin control of contracts used by Linea:
+1) Change trust assumptions, upgrade surfaces, or admin control of contracts used by Lineth:
    - StakingVault, VaultFactory, VaultHub, LazyOracle, AccountingOracle, Accounting, OracleReportSanityChecker, HashConsensus, stETH, OperatorGrid, PredepositGuarantee (PDG), Dashboard, or tightly coupled components.
    - Includes proxy/admin changes, ownership changes, privileged roles, emergency controls, or any code upgrade/migration.
    - Also applies to any other Lido protocol contract change that directly alters
@@ -49,7 +49,7 @@ Any proposal that can:
    - node operator policy changes affecting StakingVault (eligibility, performance requirements, penalties, exits)
    - incident response disclosures or postmortems that reveal new failure modes, ongoing incidents, compromise indicators, or degraded controls.
 
-7) Increase probability/severity of negative-yield events or create permissionless pathways that bypass Linea automation:
+7) Increase probability/severity of negative-yield events or create permissionless pathways that bypass Lineth automation:
    - e.g., permissionless obligation settlement triggers, permissionless rebalances/withdraw pathways, or external actions that can force liabilities.
 
 ──────────────────────────────────────────────────────────────────────────────
@@ -164,7 +164,7 @@ M1. Native Yield invariant threatened: +10 to +25 EACH
 
 M2. Permissionless bypass introduced/expanded: +10 to +20
 - If proposal increases permissionless settlement/withdraw/fee mechanisms or
-  allows external actors to trigger actions that bypass Linea controls.
+  allows external actors to trigger actions that bypass Lineth controls.
 
 M3. Reversibility / rollback difficulty: +5 to +15
 - Irreversible migrations, hard-to-revert governance changes, sticky parameters.


### PR DESCRIPTION
## Summary
- Completes a missed piece of the Linea→Lineth rename: READMEs, architecture docs, and the risk-assessment prompt for `operations/native-yield/*` (automation-service and lido-governance-monitor).
- Native Yield / Yield Boost are this project's own features (their contracts are recorded in this repo's own `mainnet.json`, not the real Linea `linea_mainnet.json`), so this is prose describing Lineth's own product, not the real Linea network.
- Scope is `misc` rather than `native-yield`/`operations` since neither is in the repo's allowed commit-scope list.

## Test plan
- [ ] TS build/lint passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and prompt wording only; no executable or configuration behavior changes.
> 
> **Overview**
> Finishes the **Linea → Lineth** naming pass in `operations/native-yield/*` prose only: automation-service and lido-governance-monitor READMEs, architecture docs, config schema comments, TypeScript JSDoc, the governance risk-assessment system prompt, and a test script’s analyst prompt.
> 
> All edits are **documentation and prompt text** so Native Yield / Yield Boost are described as **Lineth’s** product (this repo’s contracts), not the public Linea network. **No runtime logic, env keys, or contract identifiers** change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcae6ee2e01308e752fb1cf557c23307a7ad4909. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->