### PR TITLE
chore(misc): rename Linea to Lineth in docs and CI

### DIFF
--- a/.cursor/rules/documentation.mdc
+++ b/.cursor/rules/documentation.mdc
@@ -1,5 +1,5 @@
 ---
-description: Documentation discovery index for Linea monorepo
+description: Documentation discovery index for Lineth monorepo
 globs: ["**/*"]
 alwaysApply: true
 ---

--- a/.github/workflows/claude-coordinator-review.yml
+++ b/.github/workflows/claude-coordinator-review.yml
@@ -56,9 +56,9 @@ jobs:
             appears in that file — do not re-report it even if the issue is still present.
 
             You are reviewing the full Kotlin/JVM codebase in the `coordinator/` and
-            `jvm-libs/` modules of the Linea monorepo.
+            `jvm-libs/` modules of the Lineth monorepo.
 
-            The coordinator is the central orchestration service for the Linea rollup — it
+            The coordinator is the central orchestration service for the Lineth rollup — it
             conflates L2 blocks into batches, requests ZK proofs from the prover, submits
             EIP-4844 blobs to L1, and finalizes batches with aggregated proofs.
             The jvm-libs/ modules provide shared libraries used by the coordinator and other

--- a/.github/workflows/slack-notify-failed-jobs.yml
+++ b/.github/workflows/slack-notify-failed-jobs.yml
@@ -100,10 +100,10 @@ jobs:
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
           settings: '{"permissions":{"allow":["Bash(*)","Read(*)","Edit(./e2e-failure-analysis.md)","Edit(./e2e-failure-summary.txt)"],"deny":[]}}'
           prompt: |
-            You are analyzing a CI failure in the Linea monorepo's E2E test suite.
+            You are analyzing a CI failure in the Lineth monorepo's E2E test suite.
 
             ## Context
-            - Repository: Linea zkEVM monorepo (L2 zero-knowledge rollup)
+            - Repository: Lineth zkEVM monorepo (L2 zero-knowledge rollup)
             - E2E tests: Jest + Viem, run against a local Docker stack (coordinator,
               prover, sequencer, shomei, postman, L1/L2 nodes)
             - Tests cover: bridge tokens, messaging, submission/finalization, transaction

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The milestone workflow defaults to running a **dry run on a temporary branch for
 
 ## Looking for the Lineth code?
 
-Lineth's stack is made up of multiple repositories, these include:
+Lineth's stack is made up of multiple repositories. These include:
 
 - This repo, [lineth-monorepo](https://github.com/LFDT-Lineth/lineth-monorepo): The main repository for the Lineth stack & Linea network
 > Also maintains a set of Linea-Besu plugins for the sequencer and RPC nodes.

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The milestone workflow defaults to running a **dry run on a temporary branch for
 
 ## Looking for the Lineth code?
 
-Linea's stack is made up of multiple repositories, these include:
+Lineth's stack is made up of multiple repositories, these include:
 
 - This repo, [lineth-monorepo](https://github.com/LFDT-Lineth/lineth-monorepo): The main repository for the Lineth stack & Linea network
 > Also maintains a set of Linea-Besu plugins for the sequencer and RPC nodes.

--- a/docs/architecture-description.md
+++ b/docs/architecture-description.md
@@ -1,4 +1,4 @@
-# Linea architecture alpha v3
+# Lineth architecture alpha v3
 
 > For per-feature documentation covering contracts, backend services, test coverage, and configuration, see the [Feature Documentation](features/README.md).
 
@@ -9,7 +9,7 @@ B) IntelliJ - https://www.jetbrains.com/help/idea/markdown.html#table-of-content
 -->
 
 <!-- TOC -->
-* [Linea architecture - alpha v3](#linea-architecture---alpha-v3)
+* [Lineth architecture - alpha v3](#lineth-architecture---alpha-v3)
 * [Transaction execution and management](#transaction-execution-and-management)
   * [File system](#file-system)
   * [Sequencer](#sequencer)
@@ -46,14 +46,14 @@ B) IntelliJ - https://www.jetbrains.com/help/idea/markdown.html#table-of-content
 
 # Transaction execution and management
 
-The objective of the Linea network is to provide the functionality of Ethereum network at a fraction of the cost of Ethereum mainnet while providing guarantees on the correctness of its state.
+The objective of the Lineth network is to provide the functionality of Ethereum network at a fraction of the cost of Ethereum mainnet while providing guarantees on the correctness of its state.
 
 Transaction execution is done using the [Clique consensus protocol](https://besu.hyperledger.org/23.4.0/private-networks/how-to/configure/consensus/clique) and correctness is guaranteed by providing proof of validity using zk-proofs.
 
-The main components of Linea are:
+The main components of Lineth are:
 
 * The sequencer which plays the role of the signer of the Clique protocol and creates blocks.
-* The state manager for all L2 states which is used to store Linea state in a way that makes it easy to generate data used as inputs for zk-proof creation.
+* The state manager for all L2 states which is used to store Lineth state in a way that makes it easy to generate data used as inputs for zk-proof creation.
 * The coordinator which orchestrates the different steps to create zk-proofs and persists them in the L1 Ethereum network. In particular, it's responsible for conflated batch creation, blob creation and aggregation
 * The traces-APIs which provide trace counts and generate conflated trace files to be used for zk-proof creation
 * The provers which generate zk-proof for conflated blocks, kzg commitment and compression proof of the blobs, as well as aggregated proof for multiple conflation and compression proofs.
@@ -111,7 +111,7 @@ Blocks produced by the sequencer, in addition to common verifications, must fulf
 
 Transactions exceeding trace limits are added to an unexecutableTxList in-memory to avoid reconsidering them. Similarly transactions that take too long to be processed by the sequencer are added to the unexecutable list. Transactions from the unexecutable lists are removed from the pool.
 
-Priority transactions are prioritized over normal ones. Priority transactions are those sent by a user whose address is in a predefined list. It typically corresponds to transactions triggered by the Linea system.
+Priority transactions are prioritized over normal ones. Priority transactions are those sent by a user whose address is in a predefined list. It typically corresponds to transactions triggered by the Lineth system.
 
 Note that if no transactions are received within the block window, no block is generated. This behavior differs from Ethereum mainnet, where empty blocks are still produced to maintain chain continuity and prevent certain attacks.
 
@@ -141,12 +141,12 @@ The state manager is configured differently based on the role it serves. The nod
 
 The publicly exposed method linea_getProof is served by the state manager. We have a single instance of state manager.
 
-The state manager keeps its representation of the Linea state by applying the block transactions computed by the sequencer, which it receives through P2P. It is composed of two parts:
+The state manager keeps its representation of the Lineth state by applying the block transactions computed by the sequencer, which it receives through P2P. It is composed of two parts:
 
 1. a Besu node with a Shomei plugin
 2. and a Shomei node.
 
-The Besu node is connected to the other Ethereum nodes using P2P, and from the blocks it receives, it generates a trielog which it sends to the Shomei node. The trielog is a list of state modifications that occurred during the execution of the block. As soon as Shomei receives this trielog it will apply these changes to his state. The Shomei nodes use Sparse Merkle trees to represent Linea’s state.
+The Besu node is connected to the other Ethereum nodes using P2P, and from the blocks it receives, it generates a trielog which it sends to the Shomei node. The trielog is a list of state modifications that occurred during the execution of the block. As soon as Shomei receives this trielog it will apply these changes to his state. The Shomei nodes use Sparse Merkle trees to represent Lineth’s state.
 
 Besu and Shomei nodes know each other's IP and port for direct communication.
 
@@ -450,7 +450,7 @@ There are three types of proofs: execution, compression and aggregation. The pro
 
 The number of instances of prover is dynamic and driven by the number of proof requests in the file system. There is also one instance of a large prover running to handle requests that could not be handled by the regular prover instance.
 
-In testnet, but not in the main Linea Layer, there are instances of provers that generate shorter proofs. The regular provers generate full proofs with standard memory settings. The large prover also generates full proof, the difference is that it is configured to have 1TB of memory. They are used to deal with proofs that unexpectedly cannot be handled by the default full prover (oom, too many constraints, …).
+In testnet, but not in the main Lineth Layer, there are instances of provers that generate shorter proofs. The regular provers generate full proofs with standard memory settings. The large prover also generates full proof, the difference is that it is configured to have 1TB of memory. They are used to deal with proofs that unexpectedly cannot be handled by the default full prover (oom, too many constraints, …).
 
 The proof sizes are estimated to be in the order of 2MB to 15MB.
 
@@ -620,7 +620,7 @@ BlobCompressionProofJsonResponse
 
 ### Aggregation proof
 
-Serves as the cornerstone of Linea's proof system, recursively verifying proofs from N execution circuits and M compression circuit instances. This circuit encapsulates the primary statement of Linea's prover and is the sole circuit subjected to external verification. The proof system used is a combination of several PLONK circuits on BW6, BLS12-377 and BN254 which tactically profits from the 2-chained curves BLS12-377 and BW6 to efficiently recurse the proofs. The final proof takes the form of a BN254 curve that can be efficiently verified on Ethereum thanks to the available precompiles.
+Serves as the cornerstone of Lineth's proof system, recursively verifying proofs from N execution circuits and M compression circuit instances. This circuit encapsulates the primary statement of Lineth's prover and is the sole circuit subjected to external verification. The proof system used is a combination of several PLONK circuits on BW6, BLS12-377 and BN254 which tactically profits from the 2-chained curves BLS12-377 and BW6 to efficiently recurse the proofs. The final proof takes the form of a BN254 curve that can be efficiently verified on Ethereum thanks to the available precompiles.
 
 File name
 
@@ -714,17 +714,17 @@ l1RollingHashes(
 
 # Gas price setting
 
-Gas pricing on Linea is designed to ensure the following three properties:
-* Sequencer's inclusion logic is aligned to the L1 fee market. This is to avoid exploiting Linea to execute
+Gas pricing on Lineth is designed to ensure the following three properties:
+* Sequencer's inclusion logic is aligned to the L1 fee market. This is to avoid exploiting Lineth to execute
 transactions for unsustainably low fees
-* The fees charged to Linea's user represent their fair usage of the network. Unlike the vanilla Ethereum
-protocol, the gas price on Linea and other rollups is not 2-dimensional (base fee, priority fee). There are at least L1 fees
+* The fees charged to Lineth's user represent their fair usage of the network. Unlike the vanilla Ethereum
+protocol, the gas price on Lineth and other rollups is not 2-dimensional (base fee, priority fee). There are at least L1 fees
 (execution fees and blob fees), infrastructural costs (mostly proving, but not only), and a potential priority fee
 (only when there is high congestion and competition for L2 block space). This is an issue for interoperability,
 because vanilla Ethreum API isn't tailored for this. That's why there is a Besu plugin addressing this issue and
 providing gas price depending on input transaction
-* Linea remains compatible with users running vanilla nodes. Namely, `eth_gasPrice` returns fees guaranteeing that
-99.9% of transactions are includable on Linea.
+* Lineth remains compatible with users running vanilla nodes. Namely, `eth_gasPrice` returns fees guaranteeing that
+99.9% of transactions are includable on Lineth.
 
 This is how these challenges were solved technically:
 
@@ -733,7 +733,7 @@ This is how these challenges were solved technically:
 The Coordinator fetches L1 fees data, based on which it will compute gas pricing components. There are 3 of them:
 * Fixed cost. Represents infrastructural cost per unit of L2 gas. Doesn't really depend on the L1, and it's just a
 configuration in the Coordinator
-* Variable cost. Cost of 1 byte of compressed data on L2, which is finalized on L1 contract. Depends on the fees Linea
+* Variable cost. Cost of 1 byte of compressed data on L2, which is finalized on L1 contract. Depends on the fees Lineth
 pays for finalization, which in turn depends on the L1 blob and execution fee market
 * Legacy cost. Recommended gas price for the vanilla Ethereum API (`eth_gasPrice`)
 
@@ -743,7 +743,7 @@ This information is delivered to nodes in 2 ways:
 * via RPC calls (only Geth and Besu are supported and tested)
 
 ### ExtraData
-The Coordinator sends extraData to the Sequencer via `miner_setExtraData`. ExtraData contains all 3 fields mentioned above (fixed cost, variable cost and legacy cost). The Sequencer in turn uses this information for inclusion logic, to include only profitable transactions, and it adds the last received extraData to the next block it seals. This ensures that pricing information is propagated to all the nodes on Linea via P2P as a block header's field. And since this info is on all the nodes, they can use this information to figure out, what the gas price is for a given transaction that would make it includable on Linea. This currently is possible with Besu + Linea plugin with a custom `linea_estimateGas` method.
+The Coordinator sends extraData to the Sequencer via `miner_setExtraData`. ExtraData contains all 3 fields mentioned above (fixed cost, variable cost and legacy cost). The Sequencer in turn uses this information for inclusion logic, to include only profitable transactions, and it adds the last received extraData to the next block it seals. This ensures that pricing information is propagated to all the nodes on Lineth via P2P as a block header's field. And since this info is on all the nodes, they can use this information to figure out, what the gas price is for a given transaction that would make it includable on Lineth. This currently is possible with Besu + Linea plugin with a custom `linea_estimateGas` method.
 
 ### Direct RPC calls
 For nodes that are reachable from the Coordinator directly, it's possible to set legacy cost via `miner_setGasPrice` (Geth) and `miner_setMinGasPrice` (Besu). Later isn't really used, because extraData driven approach is superior and is supported by Besu nodes with Linea plugin
@@ -751,13 +751,13 @@ For nodes that are reachable from the Coordinator directly, it's possible to set
 ### Ways to compute Legacy cost
 In the Coordinator 2 ways are supported:
 * So called "naive" way. Based on raw L1 fees processed by some formula
-* So called "sample transaction" way. The idea is to take some relatively unprofitable transaction, and estimate its profitable gas price in the same way the Sequencer would. The resulting value would be used as a legacy cost. This is configured by 2 arguments to a profitability function: execution gas and tx compressed size and it may be changed depending on what load is there on Linea.
+* So called "sample transaction" way. The idea is to take some relatively unprofitable transaction, and estimate its profitable gas price in the same way the Sequencer would. The resulting value would be used as a legacy cost. This is configured by 2 arguments to a profitability function: execution gas and tx compressed size and it may be changed depending on what load is there on Lineth.
 
 # L1 &lt;-> L2 interactions
 
 There are three types of integration:
 
-* Block finalization, specific to Linea, is used to persist on L1 the state changes happening on L2. This happens in two steps, first blob data and KZG proofs are persisted on L1, and then aggregation proofs are sent to L1
+* Block finalization, specific to Lineth, is used to persist on L1 the state changes happening on L2. This happens in two steps, first blob data and KZG proofs are persisted on L1, and then aggregation proofs are sent to L1
 * L1 -> L2, typically used to transfer funds from L1 to L2.
 * L2 -> L1, to retrieve funds from L2 back to L1.
 
@@ -843,7 +843,7 @@ When such a transaction is executed on L1, it triggers the publication of a mess
 
 Internally, the message service computes a rolling hash. It’s computed recursively as the hash of the previous rolling hash and the new message hash.
 
-Linea’s coordinator, which is subscribing to L1 events, detects the L1 finalized (2 epochs to avoid reorgs) cross-chain MessageSent event and anchors it on L2. The coordinator anchors the messages by batches.
+Lineth’s coordinator, which is subscribing to L1 events, detects the L1 finalized (2 epochs to avoid reorgs) cross-chain MessageSent event and anchors it on L2. The coordinator anchors the messages by batches.
 
 Anchoring (Anchoring is the process for placing a "cross-chain validity reference", that must exist for any message to be claimed) of messages is done through the executed via [anchorL1L2MessageHashes](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/contracts/src/messaging/l2/L2MessageManager.sol#L41) which is inherited by the [L2MessageService](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/contracts/src/messaging/l2/L2MessageService.sol) smart contract.
 

--- a/docs/architecture-description.md
+++ b/docs/architecture-description.md
@@ -9,7 +9,7 @@ B) IntelliJ - https://www.jetbrains.com/help/idea/markdown.html#table-of-content
 -->
 
 <!-- TOC -->
-* [Lineth architecture - alpha v3](#lineth-architecture---alpha-v3)
+* [Lineth architecture alpha v3](#lineth-architecture-alpha-v3)
 * [Transaction execution and management](#transaction-execution-and-management)
   * [File system](#file-system)
   * [Sequencer](#sequencer)

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-Thank you for your interest in contributing to Linea's zkEVM monorepo. This document provides guidelines and instructions on how to contribute effectively. We use trunk-based development, and our main languages are Kotlin, Golang, Solidity, and TypeScript. Our releases use GitOps, ArgoCD, Helm, and Kubernetes.
+Thank you for your interest in contributing to Lineth's zkEVM monorepo. This document provides guidelines and instructions on how to contribute effectively. We use trunk-based development, and our main languages are Kotlin, Golang, Solidity, and TypeScript. Our releases use GitOps, ArgoCD, Helm, and Kubernetes.
 
 ## Submit a Contribution
 

--- a/docs/development-guidelines.md
+++ b/docs/development-guidelines.md
@@ -1,4 +1,4 @@
-# Linea developer guidelines <!-- omit in toc -->
+# Lineth developer guidelines <!-- omit in toc -->
 
 <!--
 ToC can be automatically updated with:
@@ -22,7 +22,7 @@ B) IntelliJ - https://www.jetbrains.com/help/idea/markdown.html#table-of-content
 Effective logging is crucial for understanding the behavior of our applications, diagnosing issues, and ensuring that our system is running smoothly. We have established the following logging guidelines, please adhere to these practices to help us keep our logs informative, actionable, and manageable.
 
 ### Log Levels
-- **error** - for errors that compromise application/Linea functionality, may have impact on user experience and should trigger an investigation right away. Consider including stack trace for unknown errors. Examples:
+- **error** - for errors that compromise application/Lineth functionality, may have impact on user experience and should trigger an investigation right away. Consider including stack trace for unknown errors. Examples:
   - Transaction reverted with "Invalid Proof" error.
   - Message anchoring TX reverted
 - **warn** - for error that application can recover/retry from but will compromise the system if the problem persists overtime. e.g. 3 consecutive connection errors to upstream service within 30s period.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,8 +1,8 @@
-# Linea Feature Documentation
+# Lineth Feature Documentation
 
 > Last updated: 2026-02-19
 
-This directory contains per-feature documentation for all major Linea system components. Each document covers architecture, key contracts/services, interfaces, test coverage, and configuration.
+This directory contains per-feature documentation for all major Lineth system components. Each document covers architecture, key contracts/services, interfaces, test coverage, and configuration.
 
 For high-level system architecture see [`docs/architecture-description.md`](../architecture-description.md).
 For technical deep dives by component see [`docs/tech/`](../tech/README.md).

--- a/docs/features/messaging.md
+++ b/docs/features/messaging.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Linea provides a canonical messaging protocol between Ethereum L1 and L2. Messages are sent on the origin chain and claimed on the destination chain after anchoring. Two directions with distinct mechanics:
+Lineth provides a canonical messaging protocol between Ethereum L1 and L2. Messages are sent on the origin chain and claimed on the destination chain after anchoring. Two directions with distinct mechanics:
 
 - **L1→L2**: Messages anchored on L2 via rolling hash; claimed using hash lookup.
 - **L2→L1**: Message hashes grouped into Merkle trees during finalization; claimed on L1 with Merkle proofs.
@@ -110,7 +110,7 @@ The Postman automates claiming for users who prepay a fee. It monitors anchored 
 
 Key behaviors:
 - **Sponsorship**: When enabled, the Postman pays gas from its own funds for zero-fee or underpriced messages (up to `MAX_POSTMAN_SPONSOR_GAS_LIMIT`)
-- **L1→L2 difference**: Includes an extra transaction-size computation step for Linea's variable gas pricing model
+- **L1→L2 difference**: Includes an extra transaction-size computation step for Lineth's variable gas pricing model
 - **Retry logic**: Rate-limited claims reset to `SENT`; timed-out transactions retry with gas escalation
 
 See [Postman Feature](postman.md) for the full message lifecycle, sponsorship model, and retry details.

--- a/docs/features/operational.md
+++ b/docs/features/operational.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Linea includes several operational contracts that support protocol revenue capture, token management, and monitoring. These are ancillary to the core rollup protocol but essential for production operations.
+Lineth includes several operational contracts that support protocol revenue capture, token management, and monitoring. These are ancillary to the core rollup protocol but essential for production operations.
 
 ## Components
 

--- a/docs/features/pause-and-security.md
+++ b/docs/features/pause-and-security.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Linea's security model combines three independent mechanisms enforced at the smart contract layer:
+Lineth's security model combines three independent mechanisms enforced at the smart contract layer:
 
 1. **Type-based pausing** — Granular pause/unpause per operation type with time-based expiry and security council override.
 2. **Rate limiting** — Period-based ETH throughput caps on messaging operations.

--- a/docs/features/postman.md
+++ b/docs/features/postman.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-The Postman is a TypeScript/Express service that automates the claiming step of Linea's messaging protocol. When a user sends a cross-chain message, someone must call `claimMessage` (or `claimMessageWithProof`) on the destination chain. The Postman monitors anchored messages and submits claim transactions automatically.
+The Postman is a TypeScript/Express service that automates the claiming step of Lineth's messaging protocol. When a user sends a cross-chain message, someone must call `claimMessage` (or `claimMessageWithProof`) on the destination chain. The Postman monitors anchored messages and submits claim transactions automatically.
 
 ## Message Lifecycle
 
@@ -48,7 +48,7 @@ When sponsorship is enabled (`L1_L2_ENABLE_POSTMAN_SPONSORING` / `L2_L1_ENABLE_P
 
 ## L1→L2 vs L2→L1 Differences
 
-**L1→L2** includes an extra `TRANSACTION_SIZE_COMPUTED` step. Linea's variable gas pricing depends on compressed transaction size, so the Postman pre-computes this via `@lfdt-lineth/native-libs` before estimating gas.
+**L1→L2** includes an extra `TRANSACTION_SIZE_COMPUTED` step. Lineth's variable gas pricing depends on compressed transaction size, so the Postman pre-computes this via `@lfdt-lineth/native-libs` before estimating gas.
 
 **L2→L1** uses standard EIP-1559 gas estimation and requires Merkle proofs (retrieved from Shomei) for claiming on L1.
 

--- a/docs/features/rollup.md
+++ b/docs/features/rollup.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Linea operates as a zk-rollup where L2 state transitions are posted to and verified on Ethereum L1. The pipeline has three phases:
+Lineth operates as a zk-rollup where L2 state transitions are posted to and verified on Ethereum L1. The pipeline has three phases:
 
 1. **Submission** — Compressed L2 block data posted to L1 via EIP-4844 blobs or calldata.
 2. **Shnarf chaining** — Each submission extends a rolling commitment (`shnarf`) linking all prior submissions.

--- a/docs/features/sdk.md
+++ b/docs/features/sdk.md
@@ -1,10 +1,10 @@
 # SDK
 
-> TypeScript SDKs for programmatic interaction with Linea messaging and bridging.
+> TypeScript SDKs for programmatic interaction with Lineth messaging and bridging.
 
 ## Overview
 
-The Linea SDK is split into three packages providing different integration paths:
+The Lineth SDK is split into three packages providing different integration paths:
 
 | Package | npm | Dependency |
 |---------|-----|------------|
@@ -21,7 +21,7 @@ Provides framework-agnostic types, utilities, and the sparse Merkle tree impleme
 | Export | Description |
 |--------|-------------|
 | `SparseMerkleTree` | SMT implementation for Merkle proof construction |
-| `parseBlockExtraData` | Parse Linea gas pricing from block `extraData` |
+| `parseBlockExtraData` | Parse Lineth gas pricing from block `extraData` |
 | `formatMessageStatus` | Human-readable message status |
 | `getContractsAddressesByChainId` | Contract address lookup by chain ID |
 | `isLineaMainnet`, `isLineaSepolia`, `isMainnet`, `isSepolia` | Chain identification helpers |

--- a/docs/features/sdk.md
+++ b/docs/features/sdk.md
@@ -21,7 +21,7 @@ Provides framework-agnostic types, utilities, and the sparse Merkle tree impleme
 | Export | Description |
 |--------|-------------|
 | `SparseMerkleTree` | SMT implementation for Merkle proof construction |
-| `parseBlockExtraData` | Parse Lineth gas pricing from block `extraData` |
+| `parseBlockExtraData` | Parse Linea-specific block extra data |
 | `formatMessageStatus` | Human-readable message status |
 | `getContractsAddressesByChainId` | Contract address lookup by chain ID |
 | `isLineaMainnet`, `isLineaSepolia`, `isMainnet`, `isSepolia` | Chain identification helpers |

--- a/docs/features/sequencer.md
+++ b/docs/features/sequencer.md
@@ -1,6 +1,6 @@
 # Sequencer
 
-> Lineth's block-producing Besu plugin with transaction selection, validation, and gas estimation.
+> The block-producing Besu plugin with transaction selection, validation, and gas estimation.
 
 ## Overview
 

--- a/docs/features/sequencer.md
+++ b/docs/features/sequencer.md
@@ -1,6 +1,6 @@
 # Sequencer
 
-> Linea's block-producing Besu plugin with transaction selection, validation, and gas estimation.
+> Lineth's block-producing Besu plugin with transaction selection, validation, and gas estimation.
 
 ## Overview
 
@@ -50,7 +50,7 @@ Before entering the mempool, transactions pass through:
 
 ## Priority Transactions
 
-Transactions from addresses in a predefined priority list are processed before normal transactions. These typically correspond to Linea system transactions (message anchoring, forced transactions).
+Transactions from addresses in a predefined priority list are processed before normal transactions. These typically correspond to Lineth system transactions (message anchoring, forced transactions).
 
 ## Gas Estimation
 
@@ -58,7 +58,7 @@ The sequencer exposes `linea_estimateGas` via the Besu plugin, which accounts fo
 
 ## Transaction Bundles
 
-Linea supports atomic transaction bundles via two custom JSON-RPC methods:
+Lineth supports atomic transaction bundles via two custom JSON-RPC methods:
 
 - `linea_sendBundle` — Submit a bundle of raw signed transactions targeting a specific block number. All transactions must be individually valid; if any fails, the entire bundle is reverted.
 - `linea_cancelBundle` — Cancel a previously submitted bundle by its bundle hash.

--- a/docs/features/token-bridge.md
+++ b/docs/features/token-bridge.md
@@ -1,6 +1,6 @@
 # Token Bridge
 
-> Canonical ERC20 bridging between Ethereum L1 and Linea L2.
+> Canonical ERC20 bridging between Ethereum L1 and Lineth L2.
 
 ## Overview
 

--- a/docs/features/yield-management.md
+++ b/docs/features/yield-management.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-Users bridge ETH from Ethereum L1 into Linea. Instead of letting it sit idle, Linea stakes the surplus in Lido V3 stVaults and reports the earned yield to L2 for distribution. The ETH kept on L1 - held by the `L1MessageService` contract - is the withdrawal reserve that pays out bridge redemptions. Under normal operation an automation service rebalances the reserve between configured minimum and target levels; if it falls into deficit, anyone can permissionlessly trigger replenishment, and a last-resort LST withdrawal path remains available to users.
+Users bridge ETH from Ethereum L1 into Lineth. Instead of letting it sit idle, Lineth stakes the surplus in Lido V3 stVaults and reports the earned yield to L2 for distribution. The ETH kept on L1 - held by the `L1MessageService` contract - is the withdrawal reserve that pays out bridge redemptions. Under normal operation an automation service rebalances the reserve between configured minimum and target levels; if it falls into deficit, anyone can permissionlessly trigger replenishment, and a last-resort LST withdrawal path remains available to users.
 
 ### Safety and liveness
 
@@ -129,7 +129,7 @@ The service interacts with: `YieldManager`, `LinethRollupYieldExtension`, `Vault
 
 ### Overview
 
-A standalone TypeScript service (`operations/native-yield/lido-governance-monitor/`) that monitors Lido governance activity and alerts on proposals that may affect Linea's yield infrastructure.
+A standalone TypeScript service (`operations/native-yield/lido-governance-monitor/`) that monitors Lido governance activity and alerts on proposals that may affect Lineth's yield infrastructure.
 
 ### Pipeline
 

--- a/docs/forced-transactions-architecture.md
+++ b/docs/forced-transactions-architecture.md
@@ -1,6 +1,6 @@
-# Linea Forced Transactions Architecture
+# Lineth Forced Transactions Architecture
 
-This document provides a comprehensive view of the Forced Transaction system in the Linea rollup, including contract architecture, data flows, and the processing guarantee mechanism.
+This document provides a comprehensive view of the Forced Transaction system in the Lineth rollup, including contract architecture, data flows, and the processing guarantee mechanism.
 
 ## Table of Contents
 
@@ -18,7 +18,7 @@ This document provides a comprehensive view of the Forced Transaction system in 
 
 ## System Overview
 
-The Forced Transaction system provides **processing guarantees** for Linea L2. It allows users to submit transactions directly to L1 that **must** be processed (attempted) by the sequencer **by** a specified block deadline. The sequencer will typically process the transaction well before the deadline - the deadline represents the **latest acceptable block**, not the target block. If the sequencer fails to process a forced transaction by its deadline, finalization will revert.
+The Forced Transaction system provides **processing guarantees** for Lineth L2. It allows users to submit transactions directly to L1 that **must** be processed (attempted) by the sequencer **by** a specified block deadline. The sequencer will typically process the transaction well before the deadline - the deadline represents the **latest acceptable block**, not the target block. If the sequencer fails to process a forced transaction by its deadline, finalization will revert.
 
 **Important:** A processing guarantee means the transaction will be **attempted** by the deadline. It does NOT guarantee successful execution - the transaction may still fail on L2 due to invalid nonce, insufficient gas, insufficient balance. See [Processing vs Successful Execution](#important-processing-vs-successful-execution) for details.
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -87,6 +87,6 @@ For **target block / timestamp checkpoints**, L1 finalization and API **resume**
 
 ## Next steps
 
-Consider reviewing the [Linea architecture](architecture-description.md) description.
+Consider reviewing the [Lineth architecture](architecture-description.md) description.
 
 For detailed instructions on local development and building services locally, see the [Local Development Guide](local-development-guide.md).

--- a/docs/getting-started/lineth-stack/.agents/skills/lineth-quickstart/SKILL.md
+++ b/docs/getting-started/lineth-stack/.agents/skills/lineth-quickstart/SKILL.md
@@ -2,7 +2,7 @@
 name: lineth-quickstart
 description: >-
   Operating manual for the Lineth Stack quickstart — the Docker-Compose dev/demo stack at
-  docs/getting-started/lineth-stack in the linea-monorepo that boots a local Linea/Lineth L2 with
+  docs/getting-started/lineth-stack in the lineth-monorepo that boots a local Linea/Lineth L2 with
   Sepolia or local L1 finality. Use whenever you are working inside the lineth-stack quickstart and
   need to boot or run the stack, choose between local and Sepolia L1 mode, get past the Sepolia
   deployer-funding step, read the finality/success signals, run traffic or bridge smoke tests, reset

--- a/docs/local-development-guide.md
+++ b/docs/local-development-guide.md
@@ -1,6 +1,6 @@
 # Local Development Guide
 
-This guide provides instructions for setting up and running Linea services locally, with a specific focus on the coordinator service.
+This guide provides instructions for setting up and running Lineth services locally, with a specific focus on the coordinator service.
 
 ## Prerequisites
 

--- a/docs/tech/architecture/OVERVIEW.md
+++ b/docs/tech/architecture/OVERVIEW.md
@@ -4,7 +4,7 @@
 
 ## System Architecture
 
-Linea is a zkEVM Layer 2 rollup that inherits Ethereum's security through zero-knowledge proofs.
+Lineth is a zkEVM Layer 2 rollup that inherits Ethereum's security through zero-knowledge proofs.
 
 ```
 ┌────────────────────────────────────────────────────────────────────────┐
@@ -308,7 +308,7 @@ Linea is a zkEVM Layer 2 rollup that inherits Ethereum's security through zero-k
 
 ## Data Availability Modes
 
-Linea supports two data availability modes:
+Lineth supports two data availability modes:
 
 ### Rollup Mode (Default)
 - Data submitted via EIP-4844 blobs

--- a/docs/tech/components/contracts.md
+++ b/docs/tech/components/contracts.md
@@ -1,6 +1,6 @@
 # Smart Contracts
 
-> Solidity contracts for the Linea rollup, messaging, and bridging protocols.
+> Solidity contracts for the Lineth rollup, messaging, and bridging protocols.
 
 > **Diagram:** [Contracts Architecture](../diagrams/contracts-architecture.mmd) (Mermaid source)
 

--- a/docs/tech/components/corset.md
+++ b/docs/tech/components/corset.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-Corset is the constraint compilation toolchain for Linea's zkEVM. It:
+Corset is the constraint compilation toolchain for Lineth's zkEVM. It:
 
 - Parses arithmetic constraint definitions written in the Corset DSL (a Lisp-like language)
 - Compiles them into binary formats for the prover

--- a/docs/tech/components/postman.md
+++ b/docs/tech/components/postman.md
@@ -1,12 +1,12 @@
 # Postman
 
-> Cross-chain message relay service that automates message delivery between L1 (Ethereum) and L2 (Linea).
+> Cross-chain message relay service that automates message delivery between L1 (Ethereum) and L2 (Lineth).
 
 > **Diagrams:** [Postman Architecture](../diagrams/postman-architecture.mmd) | [Message Lifecycle](../diagrams/message-lifecycle.mmd)
 
 ## Overview
 
-The Postman service implements the relay component of Linea's [Canonical Message Service](https://docs.linea.build/protocol/architecture/interoperability/canonical-message-service). It monitors `MessageSent` events on both chains, tracks when messages become claimable (anchored), and automatically submits claim transactions on the destination chain.
+The Postman service implements the relay component of Lineth's [Canonical Message Service](https://docs.linea.build/protocol/architecture/interoperability/canonical-message-service). It monitors `MessageSent` events on both chains, tracks when messages become claimable (anchored), and automatically submits claim transactions on the destination chain.
 
 **Problem it solves**: When a user sends a cross-chain message (L1→L2 or L2→L1), someone must call the `claimMessage` function on the destination chain to finalize delivery. The Postman automates this process, removing the need for users to manually claim messages.
 
@@ -52,7 +52,7 @@ The Postman service implements the relay component of Linea's [Canonical Message
         ▼                       ▼                       ▼
 ┌───────────────┐       ┌───────────────┐       ┌───────────────┐
 │   L1 RPC      │       │   L2 RPC      │       │  PostgreSQL   │
-│  (Ethereum)   │       │   (Linea)     │       │   Database    │
+│  (Ethereum)   │       │   (Lineth)    │       │   Database    │
 └───────────────┘       └───────────────┘       └───────────────┘
 ```
 
@@ -136,7 +136,7 @@ The `MAX_POSTMAN_SPONSOR_GAS_LIMIT` configuration caps the gas the Postman will 
 
 ### Why TRANSACTION_SIZE_COMPUTED? (L1→L2 only)
 
-Linea uses a [variable gas pricing model](https://docs.linea.build/network/how-to/gas-fees#variable-cost-and-linea_estimategas) where the priority fee depends on the **compressed transaction size**:
+Lineth uses a [variable gas pricing model](https://docs.linea.build/network/how-to/gas-fees#variable-cost-and-linea_estimategas) where the priority fee depends on the **compressed transaction size**:
 
 ```
 priorityFeePerGas = MINIMUM_MARGIN * (min-gas-price * L2_compressed_tx_size_in_bytes / L2_tx_gas_used + fixed_cost)

--- a/docs/tech/components/sdk.md
+++ b/docs/tech/components/sdk.md
@@ -1,12 +1,12 @@
 # SDK
 
-> TypeScript SDK for bridging and cross-chain messaging between Ethereum and Linea.
+> TypeScript SDK for bridging and cross-chain messaging between Ethereum and Lineth.
 
 > **Diagrams:** [SDK Architecture](../diagrams/sdk-architecture.mmd) | [L1→L2 Deposit Flow](../diagrams/l1-to-l2-deposit-flow.mmd) | [L2→L1 Withdrawal Flow](../diagrams/l2-to-l1-withdrawal-flow.mmd)
 
 ## Overview
 
-The Linea SDK enables developers to:
+The Lineth SDK enables developers to:
 - Bridge ETH and ERC20 tokens between L1 and L2
 - Send cross-chain messages
 - Track message and bridge transaction status

--- a/docs/tech/components/tracer-constraints.md
+++ b/docs/tech/components/tracer-constraints.md
@@ -1,6 +1,6 @@
 # Tracer Constraints
 
-> Lisp-based constraint definitions for Linea's zkEVM proof system.
+> Lisp-based constraint definitions for Lineth's zkEVM proof system.
 
 > **Diagrams:** [Constraint System](../diagrams/constraint-system.mmd) | [Module Interactions](../diagrams/module-interactions.mmd)
 

--- a/docs/tech/diagrams/README.md
+++ b/docs/tech/diagrams/README.md
@@ -1,6 +1,6 @@
 # Diagrams
 
-This directory contains Mermaid diagram source files (`.mmd`) for the Linea architecture documentation.
+This directory contains Mermaid diagram source files (`.mmd`) for the Lineth architecture documentation.
 
 ## Files
 

--- a/docs/tech/diagrams/system-architecture.mmd
+++ b/docs/tech/diagrams/system-architecture.mmd
@@ -1,4 +1,4 @@
-%% Linea System Architecture
+%% Lineth System Architecture
 flowchart TB
     subgraph L1["ETHEREUM L1"]
         LinethRollup["LinethRollup<br/>- Submit blobs<br/>- Finalize<br/>- Anchor msgs"]

--- a/docs/tech/operations/README.md
+++ b/docs/tech/operations/README.md
@@ -2,7 +2,7 @@
 
 ## Operational Tools
 
-The monorepo includes several operational utilities for managing the Linea network.
+The monorepo includes several operational utilities for managing the Lineth network.
 
 ## Operations CLI (`operations/cli/`)
 

--- a/ts-libs/eslint-config/package.json
+++ b/ts-libs/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lfdt-lineth/eslint-config",
   "version": "1.0.0",
-  "description": "Shared ESLint v9 flat config for Linea monorepo",
+  "description": "Shared ESLint v9 flat config for Lineth monorepo",
   "author": "Consensys Software Inc.",
   "license": "(MIT OR Apache-2.0)",
   "type": "module",

--- a/ts-libs/linea-shared-utils/README.md
+++ b/ts-libs/linea-shared-utils/README.md
@@ -1,8 +1,8 @@
-# Linea Shared Utils
+# Lineth Shared Utils
 
 ## Overview
 
-The linea-shared-utils package is a shared TypeScript utilities library for Linea TypeScript projects within the monorepo. This package houses shared TypeScript utilities that don't fit the SDK, which is designed for public external consumers.
+The linea-shared-utils package is a shared TypeScript utilities library for Lineth TypeScript projects within the monorepo. This package houses shared TypeScript utilities that don't fit the SDK, which is designed for public external consumers.
 
 The package may contain some duplication of SDK code to avoid bundling the SDK project in certain monorepo project builds (e.g., linea-native-yield-automation-service).
 


### PR DESCRIPTION
## Summary
- Completes a missed piece of the Linea→Lineth rename: root README, `docs/**` (features, architecture, forced-transactions, diagrams), CI workflow prompt text, Cursor rules/skill docs, and two leftover `ts-libs` package descriptions.
- Real external Linea references (linea.build/lineascan.build URLs, ConsenSys, `linea-besu`/`linea-sequencer` component names, the real Linea Association governance charter) were deliberately left untouched.
- Two draw.io diagram assets (`docs/assets/linea.drawio.svg`, `gasPrice.drawio.svg`) contain matching prose but were left unedited to avoid corrupting the embedded XML — flagged for manual follow-up.

## Test plan
- [ ] Docs lint/build passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and workflow prompt text only; no application logic, contracts, or configuration behavior changes.
> 
> **Overview**
> Finishes a **Linea → Lineth** wording pass across **documentation, agent/CI prompts, and package metadata** so in-repo prose matches the Lineth branding without touching runtime code.
> 
> **README** and **`docs/**`** (architecture, features, tech components, operations, quickstart skill) now refer to the **Lineth** network/stack in narrative text. **`.github/workflows`** Claude review and E2E failure-analysis prompts, **`.cursor/rules/documentation.mdc`**, and **`ts-libs`** package descriptions get the same rename.
> 
> **Intentionally unchanged:** external **Linea** URLs and product names (`linea.build`, `linea-besu`, `linea_estimateGas`, etc.), plus embedded prose in **`docs/assets/*.drawio.svg`** (flagged for manual follow-up).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11f8b410ca1e6c279e70a300be2107e036c0a057. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->