### PR TITLE
fix(arithmetization): split the weekly zkc metrics measurements into separate jobs

### DIFF
--- a/.github/actions/setup-zkc-measurement/action.yml
+++ b/.github/actions/setup-zkc-measurement/action.yml
@@ -73,3 +73,22 @@ runs:
         make -C arithmetization install-zkc-to ZKC_BIN="${RUNNER_TEMP}/zkc-under-test"
         echo "ZKC=${RUNNER_TEMP}/zkc-under-test" >> "$GITHUB_ENV"
         go version -m "${RUNNER_TEMP}/zkc-under-test" | awk '$1=="mod" || $2 ~ /^vcs\./'
+
+        # Verify what actually got built. arithmetization/Makefile's checkout-zkc-repo ends its
+        # fetch/checkout with `|| true`, so a failed fetch leaves the clone on the default branch and
+        # the build silently measures a different compiler than the one reported — the exact confusion
+        # this whole workflow exists to prevent. Only checkable when the ref is a full SHA, which is
+        # what prepare resolves it to.
+        built=$(go version -m "${RUNNER_TEMP}/zkc-under-test" \
+          | awk '$1=="build" && $2 ~ /^vcs\.revision=/{print substr($2,14)}')
+        want='${{ inputs.zkc-ref }}'
+        if printf '%s' "$want" | grep -qE '^[0-9a-f]{40}$'; then
+          if [ -z "$built" ]; then
+            echo "::warning::cannot verify the zkc revision (no vcs.revision stamped); proceeding"
+          elif [ "$built" != "$want" ]; then
+            echo "::error::zkc build is ${built} but ${want} was requested — checkout-zkc-repo ignores fetch failures, so this run would measure the wrong compiler" >&2
+            exit 1
+          else
+            echo "zkc revision verified: ${built}"
+          fi
+        fi

--- a/.github/actions/setup-zkc-measurement/action.yml
+++ b/.github/actions/setup-zkc-measurement/action.yml
@@ -25,6 +25,13 @@ runs:
   steps:
     # The measured tree may predate this tooling entirely, so it is checked out beside it rather than
     # over it: the renderer and the metrics file must stay at the ref the run was started from.
+    #
+    # CodeQL flags this as "checkout of untrusted code in a non-privileged context". It does not apply
+    # here: the workflow has no pull_request trigger, so there is no fork head to check out —
+    # monorepo-ref can only be set by someone dispatching the workflow, which already requires write
+    # access. The mitigation that matters is kept structural: the jobs that build and run the measured
+    # tree never mint the GitHub App token. Only the report job holds it, and it checks out the tooling
+    # ref alone. Do not add a measured checkout to that job.
     - name: Checkout the monorepo commit under measurement
       if: ${{ inputs.monorepo-ref != '' }}
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/actions/setup-zkc-measurement/action.yml
+++ b/.github/actions/setup-zkc-measurement/action.yml
@@ -1,0 +1,68 @@
+# Shared setup for the weekly zkc metrics measurement jobs.
+#
+# Each measurement runs in its own job so that its result survives the others failing, which means each
+# needs the same preamble: the tree under measurement, Go, and the pinned zkc binary. This factors that
+# out. The caller must have checked out the tooling first (a local action cannot run before checkout).
+#
+# Exports, via $GITHUB_ENV:
+#   MEASURE_DIR  the tree whose main.zkc / guest is measured
+#   RUN          the run directory the measurement writes its artifacts into
+#   ZKC          the pinned zkc binary, to pass on as ZKC= (see arithmetization/src/test/Makefile)
+name: 'Setup zkc measurement'
+description: 'Check out the tree under measurement, install Go, and build the pinned zkc.'
+
+inputs:
+  monorepo-ref:
+    description: 'Monorepo commit/branch/tag to measure; empty measures the already checked-out tree.'
+    required: false
+    default: ''
+  zkc-ref:
+    description: 'zkc ref to build, ideally a full SHA so every job measures the same commit.'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # The measured tree may predate this tooling entirely, so it is checked out beside it rather than
+    # over it: the renderer and the metrics file must stay at the ref the run was started from.
+    - name: Checkout the monorepo commit under measurement
+      if: ${{ inputs.monorepo-ref != '' }}
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        ref: ${{ inputs.monorepo-ref }}
+        path: measured
+        submodules: false
+
+    - name: Resolve the tree under measurement
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ -n "${{ inputs.monorepo-ref }}" ]; then
+          echo "MEASURE_DIR=${GITHUB_WORKSPACE}/measured" >> "$GITHUB_ENV"
+        else
+          echo "MEASURE_DIR=${GITHUB_WORKSPACE}" >> "$GITHUB_ENV"
+        fi
+        echo "RUN=${RUNNER_TEMP}/wzm" >> "$GITHUB_ENV"
+        mkdir -p "${RUNNER_TEMP}/wzm"
+
+    # Only Go is needed here: building zkc and, in the report job, running the renderer. The guest ELF
+    # needs Zig and the riscv toolchain, which is why only `prepare` uses setup-arithmetization-riscv.
+    - name: Install Go
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      with:
+        go-version: '1.24.6'
+        cache-dependency-path: "**/*.sum"
+
+    # Built to an explicit path rather than GOBIN so the measured binary is named rather than implicit
+    # on PATH. Building from the checkout also stamps vcs.revision in, which the report reads back as
+    # provenance. The binary is deliberately NOT passed between jobs as an artifact: upload-artifact
+    # drops the executable bit, and nothing in this repo does download-then-execute.
+    - name: Build the pinned zkc
+      shell: bash
+      env:
+        ZKC_REF: ${{ inputs.zkc-ref }}
+      run: |
+        set -euo pipefail
+        make -C arithmetization install-zkc-to ZKC_BIN="${RUNNER_TEMP}/zkc-under-test"
+        echo "ZKC=${RUNNER_TEMP}/zkc-under-test" >> "$GITHUB_ENV"
+        go version -m "${RUNNER_TEMP}/zkc-under-test" | awk '$1=="mod" || $2 ~ /^vcs\./'

--- a/.github/workflows/arithmetization-weekly-zkc-metrics.yml
+++ b/.github/workflows/arithmetization-weekly-zkc-metrics.yml
@@ -1,10 +1,12 @@
-# Weekly metrics for the RISC-V arithmetization. Measures compile stats, the guest build, trace,
-# and trace+check against the committed reference block, then appends one row to each table in
+# Weekly metrics for the RISC-V arithmetization. Measures compile stats, the guest build, trace, and
+# trace+check against the committed reference block, then appends one row to each table in
 # arithmetization/docs/metrics/zkc-weekly-metrics.md — which is the ledger; there is no other store.
 #
-# One job on one runner tier, deliberately: comparability across weeks is the point.
-# The two heavy steps are best-effort and individually capped; a timeout is recorded as that week's
-# data point rather than failing the workflow.
+# Each measurement runs in its OWN job, for three reasons: each shows up separately in the Actions UI
+# with its own status and duration; each persists its result as an artifact as soon as it finishes, so a
+# lost runner cannot destroy work that already completed; and the fast measurements no longer wait on the
+# slow one. The report job assembles whatever artifacts exist, so a missing measurement degrades to
+# "skipped" in the table rather than losing the row.
 #
 # See arithmetization/src/test/scripts/README-weekly-metrics.md.
 name: arithmetization weekly zkc metrics
@@ -26,20 +28,20 @@ on:
         required: false
         type: string
       run-heavy:
-        description: 'Run the trace and trace+check steps'
+        description: 'Run the trace and trace+check jobs'
         required: false
         type: boolean
         default: true
       trace-timeout-min:
-        description: 'Cap for the trace step, minutes'
+        description: 'Cap for the trace measurement, minutes (clamped to the job cap)'
         required: false
         type: number
         default: 30
       check-timeout-min:
-        description: 'Cap for the trace+check step, minutes'
+        description: 'Cap for the trace+check measurement, minutes (clamped to the job cap)'
         required: false
         type: number
-        default: 240
+        default: 90
       commit-results:
         description: 'Commit the updated markdown back to the branch'
         required: false
@@ -56,29 +58,27 @@ concurrency:
 
 env:
   METRICS_FILE: arithmetization/docs/metrics/zkc-weekly-metrics.md
+  # Every measurement runs on this ONE tier. Keeping the tier fixed is what makes the numbers
+  # comparable week to week; which runner instance serves a given job does not matter, and run-to-run
+  # variance on this tier is already large (6m07s vs 4m08s for the same trace).
   RUNNER_TIER: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
-  # Keep in sync with the job's timeout-minutes below (Actions does not let a job read its
-  # own timeout). The prepare step validates the step caps against this.
-  JOB_TIMEOUT_MIN: 360
 
 jobs:
-  weekly-metrics:
-    name: weekly zkc metrics
-    # Keep this tier stable: changing it breaks comparability with earlier rows.
+  # ── build the inputs every measurement shares, and pin the compiler ────────────────────────────
+  prepare:
+    name: prepare (guest + zkc ref)
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
-    timeout-minutes: 360   # keep in sync with JOB_TIMEOUT_MIN above
+    timeout-minutes: 30
     outputs:
-      row_written: ${{ steps.update.outputs.row_written }}
+      # Resolved to a full SHA where possible, so all three measurement jobs build the same commit
+      # even if the branch moves mid-run.
+      zkc_ref: ${{ steps.zkc.outputs.ref }}
     steps:
-      # Two checkouts: this one is the TOOLING (renderer, workflow, metrics file), always from the
-      # ref the run was started from. The measured tree may predate all of it, so measuring in place
-      # would leave no renderer and nowhere to write.
       - name: Checkout tooling
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
-      # The tree UNDER MEASUREMENT, when a monorepo-ref was given.
       - name: Checkout the monorepo commit under measurement
         if: ${{ inputs.monorepo-ref != '' }}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -87,7 +87,6 @@ jobs:
           path: measured
           submodules: false
 
-      # Every measurement step reads MEASURE_DIR. Without a monorepo-ref it is the workspace itself.
       - name: Resolve the tree under measurement
         run: |
           set -euo pipefail
@@ -96,9 +95,10 @@ jobs:
           else
             echo "MEASURE_DIR=${GITHUB_WORKSPACE}" >> "$GITHUB_ENV"
           fi
+          echo "RUN=${RUNNER_TEMP}/wzm" >> "$GITHUB_ENV"
+          mkdir -p "${RUNNER_TEMP}/wzm"
 
-      # Installs Go, the pinned Zig, Rust and the riscv toolchain, and resolves the zkc-ref
-      # input into $ZKC_REF (falling back to arithmetization/Makefile's pin when empty).
+      # The guest ELF needs Zig and the riscv toolchain; the measurement jobs only need Go.
       - name: Setup Environment
         uses: ./.github/actions/setup-arithmetization-riscv
         with:
@@ -107,87 +107,30 @@ jobs:
       # install-zkc does `git fetch --depth=1 origin <ref>`, which cannot fetch an abbreviated SHA,
       # so expand short hashes through the API. Branches and tags pass through untouched.
       - name: Resolve the zkc ref
+        id: zkc
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           requested="${{ inputs.zkc-ref || 'main' }}"
           resolved="$requested"
-          if printf '%s' "$requested" | grep -qE '^[0-9a-f]{7,39}$'; then
-            if full=$(gh api "repos/LFDT-Lineth/zkc/commits/${requested}" -q .sha 2>/dev/null) \
-               && [ -n "$full" ]; then
-              resolved="$full"
-              echo "expanded short hash ${requested} -> ${resolved}"
-            else
-              echo "::warning::could not expand '${requested}' to a full zkc SHA; passing it through as-is (a short hash will fail to fetch)"
-            fi
-          fi
-          # Resolve to a full SHA whatever the form: a checkout on a release tag yields a clean
-          # module version with no commit in it, so provenance needs another source.
-          sha_hint=""
-          if printf '%s' "$resolved" | grep -qE '^[0-9a-f]{40}$'; then
-            sha_hint="$resolved"
+          # Resolve to a full SHA whatever the form. Besides making the ref fetchable, this pins every
+          # measurement job to one commit, and gives provenance a source when the ref is a release tag
+          # (whose module version carries no commit).
+          if full=$(gh api "repos/LFDT-Lineth/zkc/commits/${requested}" -q .sha 2>/dev/null) \
+             && [ -n "$full" ]; then
+            resolved="$full"
           else
-            sha_hint=$(gh api "repos/LFDT-Lineth/zkc/commits/${resolved}" -q .sha 2>/dev/null || true)
+            echo "::warning::could not resolve '${requested}' to a full zkc SHA; passing it through as-is"
           fi
           {
-            echo "ZKC_REF=${resolved}"
-            echo "ZKC_REF_LABEL=${requested}"
-            echo "ZKC_SHA_HINT=${sha_hint}"
-          } >> "$GITHUB_ENV"
-          echo "zkc ref: requested '${requested}', using '${resolved}', sha '${sha_hint:-unknown}'"
+            echo "ref=${resolved}"
+            echo "label=${requested}"
+          } >> "$GITHUB_OUTPUT"
+          echo "zkc ref: requested '${requested}', using '${resolved}'"
 
-      # Build to an explicit path rather than GOBIN, so the measured binary is pinned and named
-      # rather than implicit on PATH, and pass it on with ZKC= (the override src/test/Makefile
-      # documents). Building from the checkout also gets vcs.revision stamped in for provenance.
-      - name: Install zkc
-        run: |
-          set -euo pipefail
-          make -C arithmetization install-zkc-to ZKC_BIN="${RUNNER_TEMP}/zkc-under-test"
-          echo "ZKC=${RUNNER_TEMP}/zkc-under-test" >> "$GITHUB_ENV"
-
-      - name: Prepare run directory and validate the timeout budget
-        run: |
-          set -euo pipefail
-          echo "RUN=${RUNNER_TEMP}/wzm" >> "$GITHUB_ENV"
-          mkdir -p "${RUNNER_TEMP}/wzm"
-
-          # The step caps must fit inside the job cap, or the job cap silently truncates them and
-          # the check appears to time out at a value nobody configured.
-          trace_cap=${{ inputs.trace-timeout-min || 30 }}
-          check_cap=${{ inputs.check-timeout-min || 240 }}
-          job_cap=${{ env.JOB_TIMEOUT_MIN }}
-          overhead=40
-          budget=$(( trace_cap + check_cap + overhead ))
-          if [ "$budget" -gt "$job_cap" ]; then
-            echo "::error::trace ${trace_cap}m + check ${check_cap}m + ${overhead}m overhead = ${budget}m exceeds the job cap of ${job_cap}m. Lower the step caps or raise JOB_TIMEOUT_MIN in the workflow." >&2
-            exit 1
-          fi
-          echo "timeout budget: ${budget}m of ${job_cap}m"
-
-      # ── 1. constraint stats ──
-      # rc is captured explicitly rather than relying on `set -e`, which would abort before rc and
-      # wall_s were written and leave the table unable to name the failure. The step still exits
-      # non-zero; the later steps carry `if: always()` and record the row regardless.
-      - name: zkc compile --stats
-        run: |
-          set -uo pipefail
-          d="$RUN/compile"; mkdir -p "$d"
-          t0=$(date +%s)
-          # --order name (not zkc's default --order total) keeps the table diffable week to week.
-          /usr/bin/time -v -o "$d/rusage" \
-            "$ZKC" compile --stats --order name "$MEASURE_DIR/arithmetization/src/main/riscv/main.zkc" \
-            > "$d/stdout" 2> "$d/stderr"
-          rc=$?
-          echo "$rc" > "$d/rc"
-          echo $(( $(date +%s) - t0 )) > "$d/wall_s"
-          tail -20 "$d/stdout"
-          [ "$rc" -eq 0 ] || { echo "::error::zkc compile --stats failed (rc $rc)"; tail -30 "$d/stderr"; }
-          exit "$rc"
-
-      # ── 2. guest ELF -> zkc JSON ──
       - name: Build l2-execution guest and convert to zkc JSON
-        if: ${{ always() && inputs.run-heavy != false }}
+        if: ${{ inputs.run-heavy != false }}
         run: |
           set -uo pipefail
           d="$RUN/guest"; mkdir -p "$d"
@@ -212,85 +155,12 @@ jobs:
           [ "$rc" -eq 0 ] || { echo "::error::guest build/conversion failed (rc $rc)"; tail -30 "$d/stderr"; }
           exit "$rc"
 
-      # ── 3. trace (best effort) ──
-      # `time` wraps `timeout`, not the reverse: the cap must not kill `time`, or the peak RSS is
-      # lost in exactly the case worth recording. timeout exits 124.
-      - name: zkc trace --stats
-        if: ${{ always() && inputs.run-heavy != false }}
-        continue-on-error: true
-        run: |
-          set -uo pipefail
-          # No JSON means the guest step failed; leave the directory absent so this reads
-          # "skipped" rather than inventing a failure for a task that never ran.
-          [ -s "$RUN/guest.json" ] || { echo "no guest JSON; skipping"; exit 0; }
-          d="$RUN/trace"; mkdir -p "$d"
-          t0=$(date +%s)
-          # Routed through src/test/Makefile's zkc-trace, the repo's single source of truth for
-          # invoking zkc on a guest JSON; ZKC= is the documented override. `time` still sees the
-          # whole subtree, so peak RSS covers zkc itself.
-          /usr/bin/time -v -o "$d/rusage" \
-            timeout -k 30s "${{ inputs.trace-timeout-min || 30 }}m" \
-            make -f "$GITHUB_WORKSPACE/arithmetization/src/test/Makefile" --no-print-directory zkc-trace \
-              JSON="$RUN/guest.json" \
-              ZKC_MAIN="$MEASURE_DIR/arithmetization/src/main/riscv/main.zkc" \
-              ZKC_TRACE_FLAGS="--stats" \
-            > "$d/stdout" 2> "$d/stderr"
-          rc=$?
-          echo "$rc" > "$d/rc"
-          echo $(( $(date +%s) - t0 )) > "$d/wall_s"
-          # timeout signals make, which may not take its recipe's child with it. Reap any zkc left
-          # holding memory, or it contends with the check step that follows.
-          if [ "$rc" -eq 124 ]; then : > "$d/timedout"; pkill -TERM -f 'zkc trace' || true; sleep 5; fi
-          head -30 "$d/stdout"
-          exit 0
-
-      # ── 4. trace + constraint check (best effort, the expensive one) ──
-      - name: zkc trace --stats --check
-        if: ${{ always() && inputs.run-heavy != false }}
-        continue-on-error: true
-        run: |
-          set -uo pipefail
-          [ -s "$RUN/guest.json" ] || { echo "no guest JSON; skipping"; exit 0; }
-          d="$RUN/check"; mkdir -p "$d"
-          t0=$(date +%s)
-          /usr/bin/time -v -o "$d/rusage" \
-            timeout -k 30s "${{ inputs.check-timeout-min || 240 }}m" \
-            make -f "$GITHUB_WORKSPACE/arithmetization/src/test/Makefile" --no-print-directory zkc-trace \
-              JSON="$RUN/guest.json" \
-              ZKC_MAIN="$MEASURE_DIR/arithmetization/src/main/riscv/main.zkc" \
-              ZKC_TRACE_FLAGS="--stats --check" \
-            > "$d/stdout" 2> "$d/stderr"
-          rc=$?
-          echo "$rc" > "$d/rc"
-          echo $(( $(date +%s) - t0 )) > "$d/wall_s"
-          if [ "$rc" -eq 124 ]; then : > "$d/timedout"; pkill -TERM -f 'zkc trace' || true; sleep 5; fi
-          # A constraint failure does not change zkc's exit code, so the renderer greps for the
-          # reported lines. Surface the count here too.
-          grep -c '^failing ' "$d/stdout" || true
-          exit 0
-
-      # ── provenance ──
+      # Provenance is recorded here rather than in the report job, so it describes the tree and
+      # compiler that were actually measured.
       - name: Record run metadata
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           set -euo pipefail
-          zkc_bin="$ZKC"
-          # Three sources, most authoritative first: vcs.revision (stamped when install-zkc builds
-          # from the checkout), the module pseudo-version suffix (for `go install pkg@ref`), then the
-          # API-resolved SHA (for a clean release tag, whose version carries no commit).
-          # sed -n/p matters: without it a non-matching version is echoed back and masquerades as a hash.
-          zkc_commit=$(go version -m "$zkc_bin" \
-            | awk '$1=="build" && $2 ~ /^vcs\.revision=/{print substr($2,14)}')
-          if [ -z "$zkc_commit" ]; then
-            zkc_mod=$(go version -m "$zkc_bin" | awk '$1=="mod"{print $3}')
-            zkc_commit=$(printf '%s' "$zkc_mod" | sed -nE 's/.*-([0-9a-f]{12})$/\1/p')
-          fi
-          [ -n "$zkc_commit" ] || zkc_commit="${ZKC_SHA_HINT:-}"
-          if [ -n "$zkc_commit" ]; then
-            zkc_cell="${ZKC_REF_LABEL}@\`${zkc_commit:0:9}\`"
-          else
-            zkc_cell="${ZKC_REF_LABEL}@–"
-          fi
           cores=$(nproc)
           ram=$(awk '/^MemTotal:/{printf "%.0f GiB", $2/1048576}' /proc/meminfo)
           if [ "${{ github.event_name }}" = "schedule" ]; then
@@ -305,26 +175,280 @@ jobs:
           else
             measured="\`${measured_sha}\` (${GITHUB_REF_NAME})"
           fi
+          zkc_sha="${{ steps.zkc.outputs.ref }}"
           {
             echo "week=$(date -u +%G-W%V)"
             echo "started=$(date -u '+%Y-%m-%d %H:%M')"
             echo "trigger=$trigger"
             echo "runner=\`${RUNNER_TIER##*amd64-}\` ${cores} cores, ${ram}"
             echo "arithmetization=$measured"
-            echo "zkc=${zkc_cell}"
+            echo "zkc=${{ steps.zkc.outputs.label }}@\`${zkc_sha:0:9}\`"
             echo "run_url=[#${GITHUB_RUN_NUMBER}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})"
           } > "$RUN/meta.env"
           cat "$RUN/meta.env"
 
-      - name: Update metrics tables
-        id: update
-        if: always()
+      - name: Upload run metadata
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: zkc-metrics-meta
+          path: ${{ env.RUN }}/meta.env
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload guest build measurement
+        if: ${{ !cancelled() && inputs.run-heavy != false }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: zkc-metrics-guest
+          path: ${{ env.RUN }}/guest
+          retention-days: 7
+
+      # The guest JSON is the input the two heavy measurements share. Data only — the zkc binary is
+      # deliberately not shipped this way, since upload-artifact drops the executable bit.
+      - name: Upload guest JSON
+        if: ${{ !cancelled() && inputs.run-heavy != false }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: zkc-metrics-guest-json
+          path: ${{ env.RUN }}/guest.json
+          if-no-files-found: error
+          retention-days: 7
+
+  # ── measurement 1: the constraint system (cheap, seconds) ──────────────────────────────────────
+  stats:
+    name: stats (compile --stats)
+    needs: prepare
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
+    timeout-minutes: 15
+    steps:
+      - name: Checkout tooling
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: false
+
+      - name: Setup measurement environment
+        uses: ./.github/actions/setup-zkc-measurement
+        with:
+          monorepo-ref: ${{ inputs.monorepo-ref }}
+          zkc-ref: ${{ needs.prepare.outputs.zkc_ref }}
+
+      # rc is captured explicitly rather than relying on `set -e`, which would abort before rc and
+      # wall_s were written and leave the table unable to name the failure.
+      - name: zkc compile --stats
+        run: |
+          set -uo pipefail
+          d="$RUN/compile"; mkdir -p "$d"
+          t0=$(date +%s)
+          # --order name (not zkc's default --order total) keeps the table diffable week to week.
+          /usr/bin/time -v -o "$d/rusage" \
+            "$ZKC" compile --stats --order name "$MEASURE_DIR/arithmetization/src/main/riscv/main.zkc" \
+            > "$d/stdout" 2> "$d/stderr"
+          rc=$?
+          echo "$rc" > "$d/rc"
+          echo $(( $(date +%s) - t0 )) > "$d/wall_s"
+          tail -20 "$d/stdout"
+          [ "$rc" -eq 0 ] || { echo "::error::zkc compile --stats failed (rc $rc)"; tail -30 "$d/stderr"; }
+          exit "$rc"
+
+      - name: Upload measurement
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: zkc-metrics-compile
+          path: ${{ env.RUN }}/compile
+          retention-days: 7
+
+  # ── measurement 2: tracing the guest ──────────────────────────────────────────────────────────
+  trace:
+    name: trace (trace --stats)
+    needs: prepare
+    if: ${{ inputs.run-heavy != false }}
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
+    timeout-minutes: 45
+    steps:
+      - name: Checkout tooling
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: false
+
+      - name: Setup measurement environment
+        uses: ./.github/actions/setup-zkc-measurement
+        with:
+          monorepo-ref: ${{ inputs.monorepo-ref }}
+          zkc-ref: ${{ needs.prepare.outputs.zkc_ref }}
+
+      - name: Download guest JSON
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: zkc-metrics-guest-json
+          path: ${{ env.RUN }}
+
+      # `time` wraps `timeout`, not the reverse: the cap must not kill `time`, or the peak RSS is
+      # lost in exactly the case worth recording. timeout exits 124.
+      - name: zkc trace --stats
+        run: |
+          set -uo pipefail
+          # Clamped below the job's timeout-minutes so the cap fires here and the measurement is
+          # recorded, instead of the job being killed with nothing to show.
+          cap=${{ inputs.trace-timeout-min || 30 }}
+          if [ "$cap" -gt 40 ]; then cap=40; fi
+          d="$RUN/trace"; mkdir -p "$d"
+          t0=$(date +%s)
+          # Routed through src/test/Makefile's zkc-trace, the repo's single source of truth for
+          # invoking zkc on a guest JSON; ZKC= is the documented override.
+          /usr/bin/time -v -o "$d/rusage" \
+            timeout -k 30s "${cap}m" \
+            make -f "$GITHUB_WORKSPACE/arithmetization/src/test/Makefile" --no-print-directory zkc-trace \
+              JSON="$RUN/guest.json" \
+              ZKC_MAIN="$MEASURE_DIR/arithmetization/src/main/riscv/main.zkc" \
+              ZKC_TRACE_FLAGS="--stats" \
+            > "$d/stdout" 2> "$d/stderr"
+          rc=$?
+          echo "$rc" > "$d/rc"
+          echo $(( $(date +%s) - t0 )) > "$d/wall_s"
+          [ "$rc" -eq 124 ] && : > "$d/timedout"
+          head -30 "$d/stdout"
+          # A timeout is this week's data point, not a failure.
+          exit 0
+
+      - name: Upload measurement
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: zkc-metrics-trace
+          path: ${{ env.RUN }}/trace
+          retention-days: 7
+
+  # ── measurement 3: tracing plus constraint checking (the expensive one) ────────────────────────
+  trace-check:
+    name: trace-check (trace --stats --check)
+    needs: prepare
+    if: ${{ inputs.run-heavy != false }}
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
+    timeout-minutes: 120
+    steps:
+      - name: Checkout tooling
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: false
+
+      - name: Setup measurement environment
+        uses: ./.github/actions/setup-zkc-measurement
+        with:
+          monorepo-ref: ${{ inputs.monorepo-ref }}
+          zkc-ref: ${{ needs.prepare.outputs.zkc_ref }}
+
+      - name: Download guest JSON
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: zkc-metrics-guest-json
+          path: ${{ env.RUN }}
+
+      - name: zkc trace --stats --check
+        run: |
+          set -uo pipefail
+          cap=${{ inputs.check-timeout-min || 90 }}
+          if [ "$cap" -gt 110 ]; then cap=110; fi
+          d="$RUN/check"; mkdir -p "$d"
+          t0=$(date +%s)
+          /usr/bin/time -v -o "$d/rusage" \
+            timeout -k 30s "${cap}m" \
+            make -f "$GITHUB_WORKSPACE/arithmetization/src/test/Makefile" --no-print-directory zkc-trace \
+              JSON="$RUN/guest.json" \
+              ZKC_MAIN="$MEASURE_DIR/arithmetization/src/main/riscv/main.zkc" \
+              ZKC_TRACE_FLAGS="--stats --check" \
+            > "$d/stdout" 2> "$d/stderr"
+          rc=$?
+          echo "$rc" > "$d/rc"
+          echo $(( $(date +%s) - t0 )) > "$d/wall_s"
+          [ "$rc" -eq 124 ] && : > "$d/timedout"
+          # A constraint failure does not change zkc's exit code, so the renderer greps for the
+          # reported lines. Surface the count here too.
+          grep -c '^failing ' "$d/stdout" || true
+          exit 0
+
+      - name: Upload measurement
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: zkc-metrics-check
+          path: ${{ env.RUN }}/check
+          retention-days: 7
+
+  # ── assemble whatever completed into one row per table ─────────────────────────────────────────
+  report:
+    name: report
+    needs: [prepare, stats, trace, trace-check]
+    # Not always(): a cancelled run should not commit a row. Runs after a FAILED measurement, which is
+    # the point — a failure or timeout is itself the week's data point.
+    if: ${{ !cancelled() }}
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
+    timeout-minutes: 20
+    steps:
+      - name: Checkout tooling
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: false
+
+      - name: Install Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: '1.24.6'
+          cache-dependency-path: "**/*.sum"
+
+      - name: Prepare run directory
         run: |
           set -euo pipefail
+          echo "RUN=${RUNNER_TEMP}/wzm" >> "$GITHUB_ENV"
+          mkdir -p "${RUNNER_TEMP}/wzm"
+
+      # Every download is best-effort: a measurement job that was evicted uploaded nothing, and the
+      # renderer treats an absent directory as "skipped". Failing here would throw away the
+      # measurements that did complete — the exact failure this split exists to prevent.
+      - name: Download run metadata
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: zkc-metrics-meta
+          path: ${{ env.RUN }}
+
+      - name: Download guest build measurement
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: zkc-metrics-guest
+          path: ${{ env.RUN }}/guest
+
+      - name: Download stats measurement
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: zkc-metrics-compile
+          path: ${{ env.RUN }}/compile
+
+      - name: Download trace measurement
+        if: ${{ needs.trace.result != 'skipped' }}
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: zkc-metrics-trace
+          path: ${{ env.RUN }}/trace
+
+      - name: Download trace-check measurement
+        if: ${{ needs.trace-check.result != 'skipped' }}
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: zkc-metrics-check
+          path: ${{ env.RUN }}/check
+
+      - name: Update metrics tables
+        run: |
+          set -euo pipefail
+          ls -R "$RUN" || true
           GO111MODULE=off go run ./arithmetization/src/test/scripts/weekly_metrics \
             -run-dir "$RUN" -out "$METRICS_FILE" | tee "$RUN/added-rows.txt"
-          # Consumed by record-lost-run: unset means the job died before recording anything.
-          echo "row_written=true" >> "$GITHUB_OUTPUT"
           {
             echo "### Weekly zkc metrics — rows added"
             echo
@@ -334,7 +458,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload raw measurement logs
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: zkc-weekly-metrics-logs
@@ -343,11 +467,12 @@ jobs:
             ${{ env.RUN }}/*/stderr
             ${{ env.RUN }}/*/rusage
             ${{ env.RUN }}/meta.env
+          retention-days: 7
 
       # App token so the push is not blocked by branch protection, mirroring
       # component-changelog-commit.yml. [skip ci] keeps it from re-triggering.
       - name: Generate release bot App token
-        if: ${{ always() && inputs.commit-results != false }}
+        if: ${{ inputs.commit-results != false }}
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
@@ -355,7 +480,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Commit and push metrics
-        if: ${{ always() && inputs.commit-results != false }}
+        if: ${{ inputs.commit-results != false }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
@@ -386,96 +511,15 @@ jobs:
           echo "Failed to push metrics after 3 attempts." >&2
           exit 1
 
-  # `if: always()` survives a failing step but not losing the runner itself (eviction, an
-  # infrastructure fault, the job timeout), where nothing downstream runs and the week would vanish
-  # — indistinguishable from a week nobody ran. Gated on row_written rather than the job result, so
-  # a red-but-recorded run gets no duplicate.
-  record-lost-run:
-    name: record lost run
-    needs: [weekly-metrics]
-    if: ${{ always() && needs.weekly-metrics.outputs.row_written != 'true' && inputs.commit-results != false }}
-    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
-    timeout-minutes: 15
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          submodules: false
-
-      - name: Install Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version: '1.24.6'
-          cache-dependency-path: "**/*.sum"
-
-      # No artifacts exist, so task cells render "skipped"; the runner cell carries the reason.
-      - name: Append a placeholder row
-        run: |
-          set -euo pipefail
-          RUN="${RUNNER_TEMP}/wzm-lost"; mkdir -p "$RUN"
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            trigger="weekly"
-          else
-            trigger="manual (@${{ github.actor }})"
-          fi
-          {
-            echo "week=$(date -u +%G-W%V)"
-            echo "started=$(date -u '+%Y-%m-%d %H:%M')"
-            echo "trigger=$trigger"
-            echo "runner=**run lost** — \`${RUNNER_TIER##*amd64-}\` job did not complete (evicted, cancelled or out of memory)"
-            if [ -n "${{ inputs.monorepo-ref }}" ]; then
-              # Only the request is known here, never a SHA that was not the one measured.
-              echo "arithmetization=${{ inputs.monorepo-ref }} (requested)"
-            else
-              echo "arithmetization=\`$(git rev-parse --short=9 HEAD)\` (${GITHUB_REF_NAME})"
-            fi
-            echo "zkc=${{ inputs.zkc-ref || 'main' }}@–"
-            echo "run_url=[#${GITHUB_RUN_NUMBER}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})"
-          } > "$RUN/meta.env"
-          GO111MODULE=off go run ./arithmetization/src/test/scripts/weekly_metrics \
-            -run-dir "$RUN" -out "$METRICS_FILE" | tee "$RUN/added-rows.txt"
-          {
-            echo "### Weekly zkc metrics — run lost, placeholder row added"
-            echo
-            echo '```'
-            cat "$RUN/added-rows.txt"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Generate release bot App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
-
-      - name: Commit and push the placeholder
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
-        run: |
-          set -euo pipefail
-          if git diff --quiet -- "$METRICS_FILE"; then
-            echo "No change to $METRICS_FILE — nothing to commit."
-            exit 0
-          fi
-          git config user.name "${APP_SLUG}[bot]"
-          git config user.email "$(gh api "/users/${APP_SLUG}[bot]" -q .id)+${APP_SLUG}[bot]@users.noreply.github.com"
-          git remote set-url origin \
-            "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git add "$METRICS_FILE"
-          git commit -m "chore(arithmetization): weekly zkc metrics $(date -u +%G-W%V) — run lost [skip ci]"
-          for attempt in 1 2 3; do
-            git fetch origin "$GITHUB_REF_NAME"
-            if ! git rebase "origin/${GITHUB_REF_NAME}"; then
-              git rebase --abort
-              echo "Rebase conflict on attempt ${attempt}; aborting." >&2
-              exit 1
-            fi
-            if git push origin "HEAD:${GITHUB_REF_NAME}"; then
-              exit 0
-            fi
-            echo "Push rejected on attempt ${attempt}; retrying..."
-          done
-          echo "Failed to push the placeholder after 3 attempts." >&2
-          exit 1
+  # A lost or failed run would otherwise be silent until someone opened the Actions tab. Same reusable
+  # notifier and channel as the tracer nightly/weekly jobs; always() so a cancelled run still reports.
+  notify:
+    needs: [prepare, stats, trace, trace-check, report]
+    if: ${{ always() && github.ref == 'refs/heads/main' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
+    uses: ./.github/workflows/slack-notify-failed-jobs.yml
+    with:
+      title: "Weekly zkc metrics workflow Failed"
+      run_id: ${{ github.run_id }}
+    secrets:
+      channel_id: ${{ secrets.SLACK_ARITHMETIZATION_ALERTS_CHANNEL_ID }}
+      slack_bot_token: ${{ secrets.SLACK_GITHUB_ACTIONS_ALERTS_BOT_TOKEN }}

--- a/.github/workflows/arithmetization-weekly-zkc-metrics.yml
+++ b/.github/workflows/arithmetization-weekly-zkc-metrics.yml
@@ -129,8 +129,12 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "zkc ref: requested '${requested}', using '${resolved}'"
 
+      # Schedule-safe reading of run-heavy. On a cron run the inputs context is empty, and GitHub
+      # coerces null and false both to 0, so `inputs.run-heavy != false` would be FALSE every
+      # Wednesday — skipping the heavy work on exactly the run that matters. Gate on the event.
       - name: Build l2-execution guest and convert to zkc JSON
-        if: ${{ inputs.run-heavy != false }}
+        id: guest
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.run-heavy }}
         run: |
           set -uo pipefail
           d="$RUN/guest"; mkdir -p "$d"
@@ -197,7 +201,7 @@ jobs:
           retention-days: 7
 
       - name: Upload guest build measurement
-        if: ${{ !cancelled() && inputs.run-heavy != false }}
+        if: ${{ !cancelled() && steps.guest.conclusion != 'skipped' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: zkc-metrics-guest
@@ -207,7 +211,7 @@ jobs:
       # The guest JSON is the input the two heavy measurements share. Data only — the zkc binary is
       # deliberately not shipped this way, since upload-artifact drops the executable bit.
       - name: Upload guest JSON
-        if: ${{ !cancelled() && inputs.run-heavy != false }}
+        if: ${{ !cancelled() && steps.guest.outcome == 'success' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: zkc-metrics-guest-json
@@ -219,6 +223,9 @@ jobs:
   stats:
     name: stats (compile --stats)
     needs: prepare
+    # Runs as long as prepare got far enough to pin the compiler: a guest-build failure must not cost
+    # us the cheapest and most-trended measurement.
+    if: ${{ !cancelled() && needs.prepare.outputs.zkc_ref != '' }}
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     timeout-minutes: 15
     steps:
@@ -263,7 +270,9 @@ jobs:
   trace:
     name: trace (trace --stats)
     needs: prepare
-    if: ${{ inputs.run-heavy != false }}
+    # Needs the guest JSON, so prepare must have completed. Without the explicit result check this
+    # would still start (an `if:` overrides the implicit skip-on-failed-need) and die on the download.
+    if: ${{ !cancelled() && needs.prepare.result == 'success' && (github.event_name != 'workflow_dispatch' || inputs.run-heavy) }}
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     timeout-minutes: 45
     steps:
@@ -278,7 +287,10 @@ jobs:
           monorepo-ref: ${{ inputs.monorepo-ref }}
           zkc-ref: ${{ needs.prepare.outputs.zkc_ref }}
 
+      # Best-effort: if the artifact is missing the measurement step below leaves its directory
+      # absent, which the renderer reads as "skipped" — better than failing with nothing recorded.
       - name: Download guest JSON
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: zkc-metrics-guest-json
@@ -291,6 +303,7 @@ jobs:
           set -uo pipefail
           # Clamped below the job's timeout-minutes so the cap fires here and the measurement is
           # recorded, instead of the job being killed with nothing to show.
+          [ -s "$RUN/guest.json" ] || { echo "::warning::no guest JSON; recording nothing"; exit 0; }
           cap=${{ inputs.trace-timeout-min || 30 }}
           if [ "$cap" -gt 40 ]; then cap=40; fi
           d="$RUN/trace"; mkdir -p "$d"
@@ -324,7 +337,7 @@ jobs:
   trace-check:
     name: trace-check (trace --stats --check)
     needs: prepare
-    if: ${{ inputs.run-heavy != false }}
+    if: ${{ !cancelled() && needs.prepare.result == 'success' && (github.event_name != 'workflow_dispatch' || inputs.run-heavy) }}
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     timeout-minutes: 120
     steps:
@@ -339,7 +352,10 @@ jobs:
           monorepo-ref: ${{ inputs.monorepo-ref }}
           zkc-ref: ${{ needs.prepare.outputs.zkc_ref }}
 
+      # Best-effort: if the artifact is missing the measurement step below leaves its directory
+      # absent, which the renderer reads as "skipped" — better than failing with nothing recorded.
       - name: Download guest JSON
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: zkc-metrics-guest-json
@@ -348,6 +364,7 @@ jobs:
       - name: zkc trace --stats --check
         run: |
           set -uo pipefail
+          [ -s "$RUN/guest.json" ] || { echo "::warning::no guest JSON; recording nothing"; exit 0; }
           cap=${{ inputs.check-timeout-min || 90 }}
           if [ "$cap" -gt 110 ]; then cap=110; fi
           d="$RUN/check"; mkdir -p "$d"
@@ -381,15 +398,18 @@ jobs:
     name: report
     needs: [prepare, stats, trace, trace-check]
     # Not always(): a cancelled run should not commit a row. Runs after a FAILED measurement, which is
-    # the point — a failure or timeout is itself the week's data point.
-    if: ${{ !cancelled() }}
+    # the point — a failure or timeout is itself the week's data point. Gated on prepare having
+    # produced provenance, so a run that died before recording anything writes no row of dashes.
+    if: ${{ !cancelled() && needs.prepare.outputs.zkc_ref != '' }}
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     timeout-minutes: 20
     steps:
+      # fetch-depth: 0 because the commit step rebases onto origin/<branch>; a shallow clone cannot.
       - name: Checkout tooling
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
+          fetch-depth: 0
 
       - name: Install Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
@@ -472,7 +492,7 @@ jobs:
       # App token so the push is not blocked by branch protection, mirroring
       # component-changelog-commit.yml. [skip ci] keeps it from re-triggering.
       - name: Generate release bot App token
-        if: ${{ inputs.commit-results != false }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.commit-results }}
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
@@ -480,7 +500,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Commit and push metrics
-        if: ${{ inputs.commit-results != false }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.commit-results }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           APP_SLUG: ${{ steps.app-token.outputs.app-slug }}

--- a/.github/workflows/arithmetization-weekly-zkc-metrics.yml
+++ b/.github/workflows/arithmetization-weekly-zkc-metrics.yml
@@ -467,6 +467,14 @@ jobs:
         run: |
           set -euo pipefail
           ls -R "$RUN" || true
+          # prepare sets its zkc_ref output before it records metadata, so an eviction in between
+          # satisfies this job's condition while leaving no meta.env. Rendering then would append a row
+          # with no week, runner or refs — a permanent, meaningless line in the ledger. Fail instead:
+          # notify reports it, and the table stays clean.
+          if [ ! -s "$RUN/meta.env" ]; then
+            echo "::error::no run metadata (prepare did not get far enough); refusing to append a row without provenance" >&2
+            exit 1
+          fi
           GO111MODULE=off go run ./arithmetization/src/test/scripts/weekly_metrics \
             -run-dir "$RUN" -out "$METRICS_FILE" | tee "$RUN/added-rows.txt"
           {

--- a/.github/workflows/arithmetization-weekly-zkc-metrics.yml
+++ b/.github/workflows/arithmetization-weekly-zkc-metrics.yml
@@ -225,7 +225,7 @@ jobs:
     needs: prepare
     # Runs as long as prepare got far enough to pin the compiler: a guest-build failure must not cost
     # us the cheapest and most-trended measurement.
-    if: ${{ !cancelled() && needs.prepare.outputs.zkc_ref != '' }}
+    if: ${{ always() && !cancelled() && needs.prepare.outputs.zkc_ref != '' }}
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     timeout-minutes: 15
     steps:
@@ -272,7 +272,7 @@ jobs:
     needs: prepare
     # Needs the guest JSON, so prepare must have completed. Without the explicit result check this
     # would still start (an `if:` overrides the implicit skip-on-failed-need) and die on the download.
-    if: ${{ !cancelled() && needs.prepare.result == 'success' && (github.event_name != 'workflow_dispatch' || inputs.run-heavy) }}
+    if: ${{ always() && !cancelled() && needs.prepare.result == 'success' && (github.event_name != 'workflow_dispatch' || inputs.run-heavy) }}
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     timeout-minutes: 45
     steps:
@@ -337,7 +337,7 @@ jobs:
   trace-check:
     name: trace-check (trace --stats --check)
     needs: prepare
-    if: ${{ !cancelled() && needs.prepare.result == 'success' && (github.event_name != 'workflow_dispatch' || inputs.run-heavy) }}
+    if: ${{ always() && !cancelled() && needs.prepare.result == 'success' && (github.event_name != 'workflow_dispatch' || inputs.run-heavy) }}
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     timeout-minutes: 120
     steps:
@@ -400,7 +400,7 @@ jobs:
     # Not always(): a cancelled run should not commit a row. Runs after a FAILED measurement, which is
     # the point — a failure or timeout is itself the week's data point. Gated on prepare having
     # produced provenance, so a run that died before recording anything writes no row of dashes.
-    if: ${{ !cancelled() && needs.prepare.outputs.zkc_ref != '' }}
+    if: ${{ always() && !cancelled() && needs.prepare.outputs.zkc_ref != '' }}
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     timeout-minutes: 20
     steps:

--- a/arithmetization/docs/metrics/zkc-weekly-metrics.md
+++ b/arithmetization/docs/metrics/zkc-weekly-metrics.md
@@ -13,9 +13,8 @@ while nothing has reached degree 8 and closes to `d8-d<max>` once something does
 `max degree` column for the actual maximum. The trace and trace+check steps are best-effort and
 capped, so a `TIMEOUT` cell is a genuine data point — the cost exceeded the cap that week.
 
-A row whose runner cell reads **run lost** means the job never completed — evicted, cancelled or
-out of memory — so no measurement exists for that week. It is recorded deliberately: a missing week
-would otherwise be indistinguishable from a week nobody ran.
+A measurement that did not complete reads `skipped` or `**TIMEOUT**` in the cost table; the reason is
+in the corresponding job on the linked workflow run.
 
 The first row was harvested by hand on a laptop, which is why its runner differs; every later row
 comes from the fixed CI tier.

--- a/arithmetization/src/test/scripts/README-weekly-metrics.md
+++ b/arithmetization/src/test/scripts/README-weekly-metrics.md
@@ -8,7 +8,8 @@ measures four things and appends one row to each markdown table in
 
 | piece | what it is |
 |---|---|
-| `.github/workflows/arithmetization-weekly-zkc-metrics.yml` | the job: Wednesday 03:00 UTC (05:00 Paris CEST), or on demand |
+| `.github/workflows/arithmetization-weekly-zkc-metrics.yml` | the workflow: Wednesday 03:00 UTC (05:00 Paris CEST), or on demand |
+| `.github/actions/setup-zkc-measurement/` | shared preamble for the measurement jobs |
 | `weekly_metrics/` | parses zkc's output and inserts one row per table |
 | `weekly_zkc_metrics.sh` | run the same measurements locally, for testing or an ad-hoc harvest |
 
@@ -32,8 +33,8 @@ point rather than failing the job: knowing the ceiling is the measurement.
 
 ## What a failure looks like
 
-Every step from "Record run metadata" onwards carries `if: always()`, so the row lands whatever
-happened earlier. Cells read:
+The report job runs unless the workflow was cancelled, so a failed or timed-out measurement still
+produces the week's row — that outcome *is* the data point. Cells read:
 
 | situation | cell |
 |---|---|
@@ -47,13 +48,13 @@ happened earlier. Cells read:
 
 The peak RSS survives a kill, which is the point: it tells you what the step died wanting.
 
-If the **runner itself** is lost (eviction, infrastructure fault, job timeout) nothing downstream
-runs, so a second small job appends a placeholder row whose runner cell reads **run lost**. It is
-gated on the main job's `row_written` output, so a red-but-recorded run never gets a duplicate.
+Each measurement runs in its own job and uploads its result as soon as it finishes, so losing one
+runner cannot destroy work that already completed: the report assembles whatever artifacts exist and
+the rest reads `skipped`. The Actions UI shows which job failed and why.
 
-The per-step caps are validated against the job's `timeout-minutes` before any measurement starts:
-raising `check-timeout-min` beyond the job budget fails fast with a clear message instead of having
-the job cap silently truncate the step.
+Per-measurement caps come from the dispatch inputs and are clamped in-step to stay below the job's
+`timeout-minutes`, so the cap always fires where it can be recorded rather than the job being killed
+with nothing to show.
 
 ## Triggering it
 
@@ -68,8 +69,9 @@ Weekly by cron, or by hand from the Actions tab. The manual form takes:
   checked out separately under `measured/` — so you can measure a commit that predates this
   tooling entirely, and the row still lands on the branch you dispatched from.
 - **run-heavy** — off to get just the constraint stats in ~2 minutes.
-- **trace-timeout-min** / **check-timeout-min** — raise the caps when chasing a completion. They
-  are validated against the job's own cap before any measurement starts.
+- **trace-timeout-min** / **check-timeout-min** — raise the caps when chasing a completion; they are
+  clamped to their job's cap (40m and 110m). The check defaults to 90m: these runners get disrupted,
+  and "did not finish in 90m" is a more reliable weekly datum than an occasional heroic completion.
 - **commit-results** — off to measure without writing to the file.
 
 Both refs are recorded in the row, requested form and resolved SHA, so a measurement can always be


### PR DESCRIPTION
The weekly metrics workflow from #3695 failed on both its first runs, both times because everything ran in one job and nothing was persisted until the end. In [run 30952623752](https://github.com/LFDT-Lineth/lineth-monorepo/actions/runs/30952623752) stats and trace **both succeeded** (trace in 4m08s) and were then destroyed when the runner was reclaimed 16 min into the check — steps with `if: always()` never ran and the log was never finalised. In [run 30951692211](https://github.com/LFDT-Lineth/lineth-monorepo/actions/runs/30951692211) the timeout-budget guard skipped the stats step, and cancelling didn't work because `always()` opts out of cancellation.

Each measurement now runs in its own job and uploads its result as it finishes: `prepare` → `stats` | `trace` | `trace-check` → `report` → `notify`. A lost runner costs one measurement instead of all of them, the three tasks show separately in the Actions UI with their own durations, and the fast ones no longer wait on the slow one. The renderer needed no change — it already renders an absent step as `skipped`, verified locally against a run directory with the check withheld.

The guard is deleted rather than fixed: each job carries its own literal cap and the input is clamped in-step to sit just below it, so a cap always fires where the outcome can be recorded. `always()` → `!cancelled()` so cancel works. Check cap 240 → 90, since this infrastructure reclaims pods and "did not finish in 90m" is a more reliable datum than a rare heroic completion. The zkc binary deliberately does not travel as an artifact (`upload-artifact` drops the executable bit); `prepare` exports the resolved SHA and each job builds that commit via `install-zkc-to`.

`record-lost-run` is removed — a partially lost run now yields a real row, and its remaining case is covered by the new Slack notification. That drops a duplicated commit-back block plus the bug that made its own commit fail; the shared preamble moves into a composite action, so the split costs 44 lines of workflow rather than triple the setup.

Verify by dispatching with `run-heavy: false` (~5 min: prepare + stats + report green, heavy jobs skipped, row with real stats and `skipped` cost cells), then with defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)