### PR TITLE
chore(ci): add makefile for git-cliff commands

### DIFF
--- a/.github/actions/run-git-cliff-commands/Makefile
+++ b/.github/actions/run-git-cliff-commands/Makefile
@@ -35,6 +35,13 @@
 MK_DIR      := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 SCRIPTS_DIR := $(MK_DIR)/scripts
 
+# Recipes rely on bash (set -o pipefail, errexit, nounset). /bin/sh is dash on
+# Debian/Ubuntu, which lacks 'pipefail', so pin bash and apply the flags to every
+# recipe here instead of a per-recipe `set -euo pipefail`. bash is already a hard
+# dependency (every scripts/*.sh is a bash script).
+SHELL       := bash
+.SHELLFLAGS := -eu -o pipefail -c
+
 # Overridable inputs (mostly for the *-dry-run targets).
 TEMPLATE               ?= cliff.template.toml
 RELEASE_TAG_SUFFIX     ?=
@@ -86,8 +93,7 @@ version-dry-run:
 	@test -n "$$COMPONENT"    || { echo 'COMPONENT is required (COMPONENT=...)'       >&2; exit 1; }
 	@test -n "$$INCLUDE_PATH" || { echo 'INCLUDE_PATH is required (INCLUDE_PATH=...)' >&2; exit 1; }
 	@test -n "$$SCOPES"       || { echo 'SCOPES is required (SCOPES=...)'             >&2; exit 1; }
-	@set -euo pipefail; \
-	 include_paths="$$($(SCRIPTS_DIR)/paths.sh)"; \
+	@include_paths="$$($(SCRIPTS_DIR)/paths.sh)"; \
 	 config="$$($(SCRIPTS_DIR)/render.sh | sed 's/^config=//')"; \
 	 INCLUDE_PATHS="$$include_paths" CLIFF_CONFIG="$$config" $(SCRIPTS_DIR)/version.sh
 
@@ -95,8 +101,7 @@ changelog-dry-run:
 	@test -n "$$COMPONENT"    || { echo 'COMPONENT is required (COMPONENT=...)'       >&2; exit 1; }
 	@test -n "$$INCLUDE_PATH" || { echo 'INCLUDE_PATH is required (INCLUDE_PATH=...)' >&2; exit 1; }
 	@test -n "$$SCOPES"       || { echo 'SCOPES is required (SCOPES=...)'             >&2; exit 1; }
-	@set -euo pipefail; \
-	 include_paths="$$($(SCRIPTS_DIR)/paths.sh)"; \
+	@include_paths="$$($(SCRIPTS_DIR)/paths.sh)"; \
 	 config="$$($(SCRIPTS_DIR)/render.sh | sed 's/^config=//')"; \
 	 vout="$$(INCLUDE_PATHS="$$include_paths" CLIFF_CONFIG="$$config" $(SCRIPTS_DIR)/version.sh)"; \
 	 changed="$$(printf '%s\n' "$$vout" | sed -n 's/^changed=//p')"; \
@@ -115,8 +120,7 @@ prepend-dry-run:
 	@test -n "$$INCLUDE_PATH" || { echo 'INCLUDE_PATH is required (INCLUDE_PATH=...)' >&2; exit 1; }
 	@test -n "$$SCOPES"       || { echo 'SCOPES is required (SCOPES=...)'             >&2; exit 1; }
 	@test -n "$$FOLDER_NAME"  || { echo 'FOLDER_NAME is required (FOLDER_NAME=...)'   >&2; exit 1; }
-	@set -euo pipefail; \
-	 include_paths="$$($(SCRIPTS_DIR)/paths.sh)"; \
+	@include_paths="$$($(SCRIPTS_DIR)/paths.sh)"; \
 	 config="$$($(SCRIPTS_DIR)/render.sh | sed 's/^config=//')"; \
 	 vout="$$(INCLUDE_PATHS="$$include_paths" CLIFF_CONFIG="$$config" $(SCRIPTS_DIR)/version.sh)"; \
 	 changed="$$(printf '%s\n' "$$vout" | sed -n 's/^changed=//p')"; \

--- a/.github/actions/run-git-cliff-commands/Makefile
+++ b/.github/actions/run-git-cliff-commands/Makefile
@@ -1,0 +1,128 @@
+# Makefile backing the "run-git-cliff-commands" composite action.
+#
+# It exposes the same units of work the action performs as thin targets over
+# scripts/*.sh, and adds *-dry-run targets so you can preview a component's next
+# version and changelog locally before a release.
+#
+# Always run from the repository root (git-cliff --include-path patterns and the
+# template path are relative to it), pointing make at this file:
+#
+#   make -f .github/actions/run-git-cliff-commands/Makefile version-dry-run \
+#       COMPONENT=coordinator \
+#       INCLUDE_PATH='coordinator/**' \
+#       SCOPES=coordinator
+#
+#   make -f .github/actions/run-git-cliff-commands/Makefile changelog-dry-run \
+#       COMPONENT=coordinator \
+#       INCLUDE_PATH='coordinator/**' \
+#       SCOPES=coordinator
+#
+# INCLUDE_PATH may list several paths, one per line. Quote a multi-line value;
+# either a real newline-delimited string or bash/zsh $'a\nb' works, e.g.:
+#
+#   make -f .github/actions/run-git-cliff-commands/Makefile prepend-dry-run \
+#       COMPONENT=linea-besu-package \
+#       FOLDER_NAME=linea-besu/package \
+#       SCOPES='linea-besu|tracer|sequencer|deps|misc' \
+#       INCLUDE_PATH=$'tracer/**\ntracer-constraints/**\nlinea-besu/besu/**'
+#
+# Requires: git-cliff, git, awk, sed on PATH.
+#
+# The action itself calls the plain targets (paths/render/version/changelog);
+# those read their inputs from the environment the action sets and write step
+# outputs to $GITHUB_OUTPUT.
+
+MK_DIR      := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+SCRIPTS_DIR := $(MK_DIR)/scripts
+
+# Overridable inputs (mostly for the *-dry-run targets).
+TEMPLATE               ?= cliff.template.toml
+RELEASE_TAG_SUFFIX     ?=
+# Preview the changelog under the computed next-version header by default.
+GENERATE_WITH_NEXT_TAG ?= true
+
+# Export inputs so recipe sub-shells and the scripts read them from the
+# environment instead of having their values spliced into the recipe text.
+# This is what makes a multi-line INCLUDE_PATH safe — embedded newlines would
+# otherwise break the '\'-continued shell command.
+export INCLUDE_PATH SCOPES TEMPLATE COMPONENT RELEASE_TAG_SUFFIX
+export FOLDER_NAME GENERATE_WITH_NEXT_TAG
+
+.PHONY: help paths render version changelog prepend \
+        version-dry-run changelog-dry-run prepend-dry-run
+
+help:
+	@echo 'Targets:'
+	@echo '  paths            normalize INCLUDE_PATH -> include_paths'
+	@echo '  render           render cliff template with SCOPES -> config path'
+	@echo '  version          compute next version (needs CLIFF_CONFIG, INCLUDE_PATHS)'
+	@echo '  changelog        generate changelog (needs CLIFF_CONFIG, INCLUDE_PATHS)'
+	@echo '  prepend          prepend section into FOLDER_NAME/CHANGELOG.md'
+	@echo '  version-dry-run    preview next version (COMPONENT, INCLUDE_PATH, SCOPES)'
+	@echo '  changelog-dry-run  preview changelog    (COMPONENT, INCLUDE_PATH, SCOPES)'
+	@echo '  prepend-dry-run    preview prepended CHANGELOG.md, file untouched'
+	@echo '                     (COMPONENT, INCLUDE_PATH, SCOPES, FOLDER_NAME)'
+
+# --- thin wrappers used by the composite action (env-driven) --------------
+
+paths:
+	@$(SCRIPTS_DIR)/paths.sh
+
+render:
+	@$(SCRIPTS_DIR)/render.sh
+
+version:
+	@$(SCRIPTS_DIR)/version.sh
+
+changelog:
+	@$(SCRIPTS_DIR)/changelog.sh
+
+prepend:
+	@$(SCRIPTS_DIR)/prepend.sh
+
+# --- local dry-runs (no $GITHUB_OUTPUT; results go to your terminal) ------
+
+version-dry-run:
+	@test -n "$$COMPONENT"    || { echo 'COMPONENT is required (COMPONENT=...)'       >&2; exit 1; }
+	@test -n "$$INCLUDE_PATH" || { echo 'INCLUDE_PATH is required (INCLUDE_PATH=...)' >&2; exit 1; }
+	@test -n "$$SCOPES"       || { echo 'SCOPES is required (SCOPES=...)'             >&2; exit 1; }
+	@set -euo pipefail; \
+	 include_paths="$$($(SCRIPTS_DIR)/paths.sh)"; \
+	 config="$$($(SCRIPTS_DIR)/render.sh | sed 's/^config=//')"; \
+	 INCLUDE_PATHS="$$include_paths" CLIFF_CONFIG="$$config" $(SCRIPTS_DIR)/version.sh
+
+changelog-dry-run:
+	@test -n "$$COMPONENT"    || { echo 'COMPONENT is required (COMPONENT=...)'       >&2; exit 1; }
+	@test -n "$$INCLUDE_PATH" || { echo 'INCLUDE_PATH is required (INCLUDE_PATH=...)' >&2; exit 1; }
+	@test -n "$$SCOPES"       || { echo 'SCOPES is required (SCOPES=...)'             >&2; exit 1; }
+	@set -euo pipefail; \
+	 include_paths="$$($(SCRIPTS_DIR)/paths.sh)"; \
+	 config="$$($(SCRIPTS_DIR)/render.sh | sed 's/^config=//')"; \
+	 vout="$$(INCLUDE_PATHS="$$include_paths" CLIFF_CONFIG="$$config" $(SCRIPTS_DIR)/version.sh)"; \
+	 changed="$$(printf '%s\n' "$$vout" | sed -n 's/^changed=//p')"; \
+	 version="$$(printf '%s\n' "$$vout" | sed -n 's/^version=//p')"; \
+	 if [ "$$changed" != "true" ]; then \
+	   echo 'Nothing to bump; no changelog to preview.' >&2; exit 0; \
+	 fi; \
+	 echo "===== changelog preview ($$COMPONENT $$version) =====" >&2; \
+	 INCLUDE_PATHS="$$include_paths" CLIFF_CONFIG="$$config" NEXT_VERSION="$$version" \
+	   $(SCRIPTS_DIR)/changelog.sh
+
+# Preview the CHANGELOG.md that `prepend` would produce, without writing the
+# file or touching the git remote.
+prepend-dry-run:
+	@test -n "$$COMPONENT"    || { echo 'COMPONENT is required (COMPONENT=...)'       >&2; exit 1; }
+	@test -n "$$INCLUDE_PATH" || { echo 'INCLUDE_PATH is required (INCLUDE_PATH=...)' >&2; exit 1; }
+	@test -n "$$SCOPES"       || { echo 'SCOPES is required (SCOPES=...)'             >&2; exit 1; }
+	@test -n "$$FOLDER_NAME"  || { echo 'FOLDER_NAME is required (FOLDER_NAME=...)'   >&2; exit 1; }
+	@set -euo pipefail; \
+	 include_paths="$$($(SCRIPTS_DIR)/paths.sh)"; \
+	 config="$$($(SCRIPTS_DIR)/render.sh | sed 's/^config=//')"; \
+	 vout="$$(INCLUDE_PATHS="$$include_paths" CLIFF_CONFIG="$$config" $(SCRIPTS_DIR)/version.sh)"; \
+	 changed="$$(printf '%s\n' "$$vout" | sed -n 's/^changed=//p')"; \
+	 version="$$(printf '%s\n' "$$vout" | sed -n 's/^version=//p')"; \
+	 if [ "$$changed" != "true" ]; then \
+	   echo 'Nothing to bump; no changelog to preview.' >&2; exit 0; \
+	 fi; \
+	 INCLUDE_PATHS="$$include_paths" CLIFF_CONFIG="$$config" NEXT_VERSION="$$version" \
+	   DRY_RUN=true $(SCRIPTS_DIR)/prepend.sh

--- a/.github/actions/run-git-cliff-commands/action.yml
+++ b/.github/actions/run-git-cliff-commands/action.yml
@@ -56,6 +56,12 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    # The step bodies live in scripts/*.sh and are driven through the Makefile
+    # (targets: paths, render, version, changelog) so the same logic backs both
+    # this action and local `make *-dry-run` previews. See ./Makefile.
+    # Steps run from the repo root (GITHUB_WORKSPACE); the scripts append their
+    # step outputs to $GITHUB_OUTPUT.
+
     # Normalize inputs.include-path (newline-separated paths) into one
     # trimmed, non-empty path per line so downstream steps can reconstruct a
     # bash array safely.
@@ -64,36 +70,17 @@ runs:
       shell: bash
       env:
         INCLUDE_PATH: ${{ inputs.include-path }}
-      run: |
-        set -euo pipefail
-        {
-          echo 'include_paths<<__PATHS_EOF__'
-          printf '%s\n' "$INCLUDE_PATH" \
-            | awk '{ sub(/^[[:space:]]+/,""); sub(/[[:space:]]+$/,""); if (length) print }'
-          echo '__PATHS_EOF__'
-        } >> "$GITHUB_OUTPUT"
+      run: make -f "${{ github.action_path }}/Makefile" paths
 
     # Render the shared cliff template into a temp config with the caller's
-    # scopes injected into the @@SCOPES@@ placeholder. git-cliff can't inject
-    # scopes into commit_parsers itself, so we substitute at run time and point
-    # every git cliff invocation below at the rendered file.
+    # scopes injected into the @@SCOPES@@ placeholder.
     - name: Render git-cliff config with injected scopes
       id: render
       shell: bash
       env:
         SCOPES: ${{ inputs.scopes }}
         TEMPLATE: ${{ inputs.cliff-template }}
-      run: |
-        set -euo pipefail
-        if [ -z "${SCOPES}" ]; then
-          echo "scopes input must be non-empty" >&2
-          exit 1
-        fi
-        rendered="${RUNNER_TEMP:-/tmp}/cliff.rendered.toml"
-        # '#' delimiter is safe: neither the placeholder nor scope tokens (which
-        # may contain '|') contain '#'.
-        sed "s#@@SCOPES@@#${SCOPES}#g" "${TEMPLATE}" > "${rendered}"
-        echo "config=${rendered}" >> "$GITHUB_OUTPUT"
+      run: make -f "${{ github.action_path }}/Makefile" render
 
     # Compute the next release version
     - name: Compute next ${{ inputs.component-name }} version (semver)
@@ -103,125 +90,31 @@ runs:
         COMPONENT: ${{ inputs.component-name }}
         CLIFF_CONFIG: ${{ steps.render.outputs.config }}
         RELEASE_TAG_SUFFIX: ${{ inputs.release_tag_suffix }}
-      run: |
-        set -euo pipefail
-
-        # Get the latest tag matching the release pattern (newest by semver).
-        latest_tag=$(git tag --list "releases/${COMPONENT}/v*" \
-          | grep -E "^releases/${COMPONENT}/v[0-9]+\.[0-9]+\.[0-9]+$" \
-          | sort -V \
-          | tail -n 1 \
-          || true)
-
-        mapfile -t paths <<< "${{ steps.paths.outputs.include_paths }}"
-        # --unreleased scopes the bump computation to commits since the last
-        # matching tag. Without it, git-cliff walks the full visible history
-        # and can over-bump (e.g. counting feats from prior release windows).
-        cliff_args=(--config "${CLIFF_CONFIG}" --bumped-version --unreleased)
-        for p in "${paths[@]}"; do
-          cliff_args+=(--include-path "${p}")
-        done
-        cliff_args+=(--tag-pattern "releases/${COMPONENT}/v[0-9]+\.[0-9]+\.[0-9]+$")
-        # Capture stdout and stderr separately so we can both surface git-cliff's
-        # logs and detect the "nothing to bump" warning it writes to stderr.
-        stderr_file=$(mktemp)
-        trap 'rm -f "${stderr_file}"' EXIT
-        next_tag=$(git cliff "${cliff_args[@]}" 2> "${stderr_file}")
-        # Re-emit stderr so it's visible in logs
-        cat "${stderr_file}" >&2
-
-        changed=true
-        # Check if git cliff warned "nothing to bump"
-        if grep -q "There is nothing to bump" "${stderr_file}"; then
-          changed=false
-        elif [ "${next_tag}" = "${latest_tag}" ]; then
-          changed=false
-        fi
-        if [ -z "${next_tag}" ] || [ "${changed}" = "false" ]; then
-          echo "git-cliff reports nothing to bump for ${COMPONENT}; nothing to release."
-          {
-            echo "tag="
-            echo "version="
-            echo "changed=false"
-          } >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-        next_semver="${next_tag#releases/${COMPONENT}/v}"
-        if [ -n "${RELEASE_TAG_SUFFIX}" ]; then
-          next_tag="${next_tag}-${RELEASE_TAG_SUFFIX}"
-          next_semver="${next_semver}-${RELEASE_TAG_SUFFIX}"
-        fi
-
-        if git rev-parse -q --verify "refs/tags/${next_tag}" > /dev/null; then
-          echo "The next tag ${next_tag} already exists; exit now."
-          exit 1
-        fi
-
-        echo "latest ${COMPONENT} tag:  ${latest_tag}"
-        echo "next ${COMPONENT} tag:    ${next_tag}"
-        echo "next ${COMPONENT} semver: ${next_semver}"
-        echo "tag changed: ${changed}"
-        {
-          echo "tag=${next_tag}"
-          echo "version=${next_semver}"
-          echo "changed=${changed}"
-        } >> "$GITHUB_OUTPUT"
+        INCLUDE_PATHS: ${{ steps.paths.outputs.include_paths }}
+      run: make -f "${{ github.action_path }}/Makefile" version
 
     - name: Generate ${{ inputs.component-name }} unreleased or latest changelog
       id: changelog
       if: steps.version.outputs.changed == 'true'
+      shell: bash
       env:
         COMPONENT: ${{ inputs.component-name }}
         CLIFF_CONFIG: ${{ steps.render.outputs.config }}
-        TAG_CONFIG: ${{ inputs.generate-changelog-with-next-tag-version == 'true' && format(' --tag {0}', steps.version.outputs.version) || '' }}
-      shell: bash
-      run: |
-        set -euo pipefail
-        mapfile -t paths <<< "${{ steps.paths.outputs.include_paths }}"
-        read -ra tag_config_args <<< "--unreleased${TAG_CONFIG}"
-        cliff_args=(--config "${CLIFF_CONFIG}" "${tag_config_args[@]}")
-        for p in "${paths[@]}"; do
-          cliff_args+=(--include-path "${p}")
-        done
-        cliff_args+=(--tag-pattern "releases/${COMPONENT}/v[0-9]+\.[0-9]+\.[0-9]+$")
-        {
-          echo 'content<<__CLIFF_EOF__'
-          git cliff "${cliff_args[@]}"
-          echo '__CLIFF_EOF__'
-        } >> "$GITHUB_OUTPUT"
+        INCLUDE_PATHS: ${{ steps.paths.outputs.include_paths }}
+        GENERATE_WITH_NEXT_TAG: ${{ inputs.generate-changelog-with-next-tag-version == 'true' }}
+        NEXT_VERSION: ${{ steps.version.outputs.version }}
+      run: make -f "${{ github.action_path }}/Makefile" changelog
 
     - name: Generate and prepend release changelog section
       id: prepend-changelog
       if: inputs.prepend-changelog == 'true' && steps.version.outputs.changed == 'true'
+      shell: bash
       env:
         COMPONENT: ${{ inputs.component-name }}
         FOLDER_NAME: ${{ inputs.folder-name }}
         CLIFF_CONFIG: ${{ steps.render.outputs.config }}
-        TAG_CONFIG: ${{ inputs.generate-changelog-with-next-tag-version == 'true' && format(' --tag {0}', steps.version.outputs.version) || '' }}
+        INCLUDE_PATHS: ${{ steps.paths.outputs.include_paths }}
+        GENERATE_WITH_NEXT_TAG: ${{ inputs.generate-changelog-with-next-tag-version == 'true' }}
+        NEXT_VERSION: ${{ steps.version.outputs.version }}
         TARGET_REF: ${{ github.head_ref || github.ref_name }}
-      shell: bash
-      run: |
-        set -euo pipefail
-
-        # retrieve the latest changes of CHANGELOG.md first to avoid chances
-        # of rebase or merge conflicts later from other workflows
-        git pull --ff-only origin "refs/heads/${TARGET_REF}"
-
-        CHANGELOG_FILE="${FOLDER_NAME}/CHANGELOG.md"
-
-        # Drop existing [unreleased] block if any
-        awk '
-          /^## \[unreleased\]/ { skip=1; next }
-          /^## \[/ && skip       { skip=0 }
-          !skip                  { print }
-        ' "${CHANGELOG_FILE}" > "${CHANGELOG_FILE}.tmp" && mv "${CHANGELOG_FILE}.tmp" "${CHANGELOG_FILE}"
-
-        # Prepend a fresh [unreleased/tag-version] section
-        mapfile -t paths <<< "${{ steps.paths.outputs.include_paths }}"
-        read -ra tag_config_args <<< "--unreleased${TAG_CONFIG}"
-        cliff_args=(--config "${CLIFF_CONFIG}" "${tag_config_args[@]}")
-        for p in "${paths[@]}"; do
-          cliff_args+=(--include-path "${p}")
-        done
-        cliff_args+=(--tag-pattern "releases/${COMPONENT}/v[0-9]+\.[0-9]+\.[0-9]+$" --prepend "${CHANGELOG_FILE}")
-        git cliff "${cliff_args[@]}"
+      run: make -f "${{ github.action_path }}/Makefile" prepend

--- a/.github/actions/run-git-cliff-commands/scripts/changelog.sh
+++ b/.github/actions/run-git-cliff-commands/scripts/changelog.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Generate the unreleased (or next-tag) changelog section for a component.
+#
+# Inputs (env):  COMPONENT, CLIFF_CONFIG, INCLUDE_PATHS (multi-line),
+#                GENERATE_WITH_NEXT_TAG (true|false, default false),
+#                NEXT_VERSION (required when GENERATE_WITH_NEXT_TAG=true)
+# Output:        content  (the changelog markdown, also printed to stdout)
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+: "${COMPONENT:?COMPONENT is required}"
+: "${CLIFF_CONFIG:?CLIFF_CONFIG is required}"
+GENERATE_WITH_NEXT_TAG="${GENERATE_WITH_NEXT_TAG:-false}"
+NEXT_VERSION="${NEXT_VERSION:-}"
+
+# Read INCLUDE_PATHS (one path per line) into an array; portable to bash 3.2.
+paths=()
+while IFS= read -r p; do
+  [ -n "$p" ] && paths+=("$p")
+done <<< "${INCLUDE_PATHS:-}"
+tag_args=(--unreleased)
+if [ "${GENERATE_WITH_NEXT_TAG}" = "true" ]; then
+  if [ -z "${NEXT_VERSION}" ]; then
+    log "GENERATE_WITH_NEXT_TAG=true but NEXT_VERSION is empty"
+    exit 1
+  fi
+  tag_args+=(--tag "${NEXT_VERSION}")
+fi
+cliff_args=(--config "${CLIFF_CONFIG}" "${tag_args[@]}")
+for p in "${paths[@]}"; do
+  [ -n "$p" ] || continue
+  cliff_args+=(--include-path "${p}")
+done
+cliff_args+=(--tag-pattern "releases/${COMPONENT}/v[0-9]+\.[0-9]+\.[0-9]+$")
+
+git cliff "${cliff_args[@]}" | emit_block content

--- a/.github/actions/run-git-cliff-commands/scripts/lib.sh
+++ b/.github/actions/run-git-cliff-commands/scripts/lib.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Shared helpers for the git-cliff step scripts.
+#
+# Contract for every script that sources this file:
+#   - the script's *payload* goes to stdout (a value, or the changelog text),
+#   - human-readable logs go to stderr (via log),
+#   - when running inside GitHub Actions ($GITHUB_OUTPUT set) the step outputs
+#     are also appended to $GITHUB_OUTPUT.
+#
+# This lets the same scripts back both the composite action (which reads
+# $GITHUB_OUTPUT) and local `make` dry-runs (which read stdout).
+
+# log MESSAGE... — write a human-readable line to stderr.
+log() { printf '%s\n' "$*" >&2; }
+
+# emit_kv KEY VALUE — single-line step output.
+# Prints "KEY=VALUE" to stdout and, in CI, appends it to $GITHUB_OUTPUT.
+emit_kv() {
+  local key="$1" value="$2"
+  printf '%s=%s\n' "$key" "$value"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf '%s=%s\n' "$key" "$value" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+# emit_block KEY — multi-line step output; payload is read from stdin.
+# Prints the raw payload to stdout and, in CI, appends a heredoc-delimited
+# block to $GITHUB_OUTPUT.
+emit_block() {
+  local key="$1"
+  local delim="__${key}_EOF__"
+  local payload
+  payload="$(cat)"
+  printf '%s\n' "$payload"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+      printf '%s<<%s\n' "$key" "$delim"
+      printf '%s\n' "$payload"
+      printf '%s\n' "$delim"
+    } >> "$GITHUB_OUTPUT"
+  fi
+}

--- a/.github/actions/run-git-cliff-commands/scripts/paths.sh
+++ b/.github/actions/run-git-cliff-commands/scripts/paths.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Normalize INCLUDE_PATH (newline-separated paths) into one trimmed, non-empty
+# path per line so downstream steps can reconstruct a bash array safely.
+#
+# Inputs (env):  INCLUDE_PATH
+# Output:        include_paths  (multi-line)
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+: "${INCLUDE_PATH:?INCLUDE_PATH is required}"
+
+printf '%s\n' "$INCLUDE_PATH" \
+  | awk '{ sub(/^[[:space:]]+/,""); sub(/[[:space:]]+$/,""); if (length) print }' \
+  | emit_block include_paths

--- a/.github/actions/run-git-cliff-commands/scripts/prepend.sh
+++ b/.github/actions/run-git-cliff-commands/scripts/prepend.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Generate the release changelog section and prepend it to the component's
+# CHANGELOG.md, dropping any stale [unreleased] block first.
+#
+# Inputs (env):  COMPONENT, CLIFF_CONFIG, INCLUDE_PATHS (multi-line),
+#                FOLDER_NAME (dir holding CHANGELOG.md),
+#                GENERATE_WITH_NEXT_TAG (true|false, default false),
+#                NEXT_VERSION (required when GENERATE_WITH_NEXT_TAG=true),
+#                TARGET_REF (branch to fast-forward before writing; CI only),
+#                DRY_RUN (true|false, default false)
+#
+# With DRY_RUN=true it works on a throwaway copy and prints the resulting
+# CHANGELOG.md to stdout without touching the real file or the git remote.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+: "${COMPONENT:?COMPONENT is required}"
+: "${CLIFF_CONFIG:?CLIFF_CONFIG is required}"
+: "${FOLDER_NAME:?FOLDER_NAME is required}"
+GENERATE_WITH_NEXT_TAG="${GENERATE_WITH_NEXT_TAG:-false}"
+NEXT_VERSION="${NEXT_VERSION:-}"
+DRY_RUN="${DRY_RUN:-false}"
+
+CHANGELOG_FILE="${FOLDER_NAME}/CHANGELOG.md"
+if [ ! -f "${CHANGELOG_FILE}" ]; then
+  log "changelog not found: ${CHANGELOG_FILE}"
+  exit 1
+fi
+
+if [ "${DRY_RUN}" = "true" ]; then
+  # Work on a copy so the real file and the git remote are never touched.
+  target="$(mktemp)"
+  trap 'rm -f "${target}"' EXIT
+  cp "${CHANGELOG_FILE}" "${target}"
+else
+  # retrieve the latest changes of CHANGELOG.md first to avoid chances of
+  # rebase or merge conflicts later from other workflows
+  : "${TARGET_REF:?TARGET_REF is required}"
+  git pull --ff-only origin "refs/heads/${TARGET_REF}"
+  target="${CHANGELOG_FILE}"
+fi
+
+# Drop existing [unreleased] block if any
+awk '
+  /^## \[unreleased\]/ { skip=1; next }
+  /^## \[/ && skip       { skip=0 }
+  !skip                  { print }
+' "${target}" > "${target}.tmp" && mv "${target}.tmp" "${target}"
+
+# Build the git-cliff invocation for the fresh [unreleased/tag-version] section.
+# Read INCLUDE_PATHS (one path per line) into an array; portable to bash 3.2.
+paths=()
+while IFS= read -r p; do
+  [ -n "$p" ] && paths+=("$p")
+done <<< "${INCLUDE_PATHS:-}"
+tag_args=(--unreleased)
+if [ "${GENERATE_WITH_NEXT_TAG}" = "true" ]; then
+  if [ -z "${NEXT_VERSION}" ]; then
+    log "GENERATE_WITH_NEXT_TAG=true but NEXT_VERSION is empty"
+    exit 1
+  fi
+  tag_args+=(--tag "${NEXT_VERSION}")
+fi
+cliff_args=(--config "${CLIFF_CONFIG}" "${tag_args[@]}")
+for p in "${paths[@]}"; do
+  cliff_args+=(--include-path "${p}")
+done
+cliff_args+=(--tag-pattern "releases/${COMPONENT}/v[0-9]+\.[0-9]+\.[0-9]+$" --prepend "${target}")
+git cliff "${cliff_args[@]}"
+
+if [ "${DRY_RUN}" = "true" ]; then
+  log "===== prepended ${CHANGELOG_FILE} preview (${COMPONENT}${NEXT_VERSION:+ }${NEXT_VERSION}) ====="
+  cat "${target}"
+fi

--- a/.github/actions/run-git-cliff-commands/scripts/render.sh
+++ b/.github/actions/run-git-cliff-commands/scripts/render.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Render the shared cliff template into a temp config with the caller's scopes
+# injected into the @@SCOPES@@ placeholder. git-cliff can't inject scopes into
+# commit_parsers itself, so we substitute at run time and point every git cliff
+# invocation at the rendered file.
+#
+# Inputs (env):  SCOPES, TEMPLATE (default cliff.template.toml),
+#                RENDERED_CONFIG (default ${RUNNER_TEMP:-/tmp}/cliff.rendered.toml)
+# Output:        config  (path to the rendered toml)
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+: "${SCOPES:?scopes input must be non-empty}"
+TEMPLATE="${TEMPLATE:-cliff.template.toml}"
+rendered="${RENDERED_CONFIG:-${RUNNER_TEMP:-/tmp}/cliff.rendered.toml}"
+
+if [ ! -f "$TEMPLATE" ]; then
+  log "template not found: ${TEMPLATE} (run from the repo root)"
+  exit 1
+fi
+
+# '#' delimiter is safe: neither the placeholder nor scope tokens (which may
+# contain '|') contain '#'.
+sed "s#@@SCOPES@@#${SCOPES}#g" "$TEMPLATE" > "$rendered"
+log "rendered git-cliff config: ${rendered}"
+emit_kv config "$rendered"

--- a/.github/actions/run-git-cliff-commands/scripts/version.sh
+++ b/.github/actions/run-git-cliff-commands/scripts/version.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Compute the next release version for a component using git-cliff.
+#
+# Inputs (env):  COMPONENT, CLIFF_CONFIG, INCLUDE_PATHS (multi-line),
+#                RELEASE_TAG_SUFFIX (optional)
+# Outputs:       tag, version, changed
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+: "${COMPONENT:?COMPONENT is required}"
+: "${CLIFF_CONFIG:?CLIFF_CONFIG is required}"
+RELEASE_TAG_SUFFIX="${RELEASE_TAG_SUFFIX:-}"
+
+# Get the latest tag matching the release pattern (newest by semver).
+latest_tag=$(git tag --list "releases/${COMPONENT}/v*" \
+  | grep -E "^releases/${COMPONENT}/v[0-9]+\.[0-9]+\.[0-9]+$" \
+  | sort -V \
+  | tail -n 1 \
+  || true)
+
+# Read INCLUDE_PATHS (one path per line) into an array. A plain read loop keeps
+# this working on bash 3.2 (macOS) for local dry-runs, not just CI's bash 5.
+paths=()
+while IFS= read -r p; do
+  [ -n "$p" ] && paths+=("$p")
+done <<< "${INCLUDE_PATHS:-}"
+# --unreleased scopes the bump computation to commits since the last matching
+# tag. Without it, git-cliff walks the full visible history and can over-bump
+# (e.g. counting feats from prior release windows).
+cliff_args=(--config "${CLIFF_CONFIG}" --bumped-version --unreleased)
+for p in "${paths[@]}"; do
+  [ -n "$p" ] || continue
+  cliff_args+=(--include-path "${p}")
+done
+cliff_args+=(--tag-pattern "releases/${COMPONENT}/v[0-9]+\.[0-9]+\.[0-9]+$")
+
+# Capture stdout and stderr separately so we can both surface git-cliff's logs
+# and detect the "nothing to bump" warning it writes to stderr.
+stderr_file=$(mktemp)
+trap 'rm -f "${stderr_file}"' EXIT
+next_tag=$(git cliff "${cliff_args[@]}" 2> "${stderr_file}")
+# Re-emit stderr so it's visible in logs
+cat "${stderr_file}" >&2
+
+changed=true
+# Check if git cliff warned "nothing to bump"
+if grep -q "There is nothing to bump" "${stderr_file}"; then
+  changed=false
+elif [ "${next_tag}" = "${latest_tag}" ]; then
+  changed=false
+fi
+if [ -z "${next_tag}" ] || [ "${changed}" = "false" ]; then
+  log "git-cliff reports nothing to bump for ${COMPONENT}; nothing to release."
+  emit_kv tag ""
+  emit_kv version ""
+  emit_kv changed "false"
+  exit 0
+fi
+next_semver="${next_tag#releases/${COMPONENT}/v}"
+if [ -n "${RELEASE_TAG_SUFFIX}" ]; then
+  next_tag="${next_tag}-${RELEASE_TAG_SUFFIX}"
+  next_semver="${next_semver}-${RELEASE_TAG_SUFFIX}"
+fi
+
+if git rev-parse -q --verify "refs/tags/${next_tag}" > /dev/null; then
+  log "The next tag ${next_tag} already exists; exit now."
+  exit 1
+fi
+
+log "latest ${COMPONENT} tag:  ${latest_tag}"
+log "next ${COMPONENT} tag:    ${next_tag}"
+log "next ${COMPONENT} semver: ${next_semver}"
+log "tag changed: ${changed}"
+emit_kv tag "${next_tag}"
+emit_kv version "${next_semver}"
+emit_kv changed "${changed}"

--- a/.github/workflows/linea-besu-build-and-publish.yml
+++ b/.github/workflows/linea-besu-build-and-publish.yml
@@ -92,7 +92,7 @@ jobs:
           if git diff --cached --quiet; then
             echo "No cache updates to commit"
           else
-            git commit -m "chore: refresh linea-besu/besu/.besu-resolved after besuCommit bump"
+            git commit -m "chore(linea-besu): refresh linea-besu/besu/.besu-resolved after besuCommit bump"
             git push origin "$BRANCH"
           fi
 

--- a/README.md
+++ b/README.md
@@ -51,42 +51,61 @@ Release tag of each component is in the format of `releases/[component]/v[semver
 
 The workflows do **not** keep a per-component `cliff.toml`. A single [`cliff.template.toml`](cliff.template.toml) is rendered at run time by substituting the component's conventional-commit scopes into its `@@SCOPES@@` placeholder, then git-cliff is run with that component's `--include-path` filter. A commit therefore counts only when it is **both** in-scope **and** touches a component path (scope-and-path gating).
 
-You can reproduce exactly what a workflow computes. Prerequisites: install git-cliff (`brew install git-cliff` or `cargo install git-cliff`) and fetch tags (`git fetch --tags`). Run from the repo root:
+You can reproduce exactly what a workflow computes using the dry-run targets in the [`run-git-cliff-commands`](.github/actions/run-git-cliff-commands/action.yml) action's `Makefile` — these drive the very same scripts CI runs, so the rendering, scope injection, and gating all match. Prerequisites: install git-cliff (`brew install git-cliff` or `cargo install git-cliff`), have GNU `make`, and fetch tags (`git fetch --tags`). Run everything **from the repo root**:
 
 ```bash
-# 1. Render the template with the component's scopes injected.
-#    (see the per-component table below for SCOPES / tag-pattern / include-paths)
-SCOPES='coordinator|deps|misc'
-sed "s#@@SCOPES@@#${SCOPES}#g" cliff.template.toml > /tmp/cliff.rendered.toml
+MK=.github/actions/run-git-cliff-commands/Makefile
 
-# 2. Show the NEXT bumped version tag for the component.
-git cliff --config /tmp/cliff.rendered.toml --unreleased --bumped-version \
-  --tag-pattern 'releases/coordinator/v[0-9]+\.[0-9]+\.[0-9]+$' \
-  --include-path 'coordinator/**'
+# Preview the NEXT bumped version + tag for a component
+# (prints tag=/version=/changed=; logs "nothing to bump" if no release is due).
+make -f "$MK" version-dry-run \
+  COMPONENT=coordinator \
+  SCOPES='coordinator|deps|misc' \
+  INCLUDE_PATH='coordinator/**'
 
-# 3. Show the [unreleased] changelog for the component.
-git cliff --config /tmp/cliff.rendered.toml --unreleased \
-  --tag-pattern 'releases/coordinator/v[0-9]+\.[0-9]+\.[0-9]+$' \
-  --include-path 'coordinator/**'
+# Preview the component's changelog for the next release.
+make -f "$MK" changelog-dry-run \
+  COMPONENT=coordinator \
+  SCOPES='coordinator|deps|misc' \
+  INCLUDE_PATH='coordinator/**'
+
+# Preview the CHANGELOG.md exactly as a release would rewrite it — WITHOUT
+# writing the file or touching the remote (needs FOLDER_NAME, the directory
+# that holds the component's CHANGELOG.md).
+make -f "$MK" prepend-dry-run \
+  COMPONENT=coordinator \
+  SCOPES='coordinator|deps|misc' \
+  INCLUDE_PATH='coordinator/**' \
+  FOLDER_NAME=coordinator
 ```
 
-Swap `SCOPES`, the `--tag-pattern` component, and the `--include-path` set per component:
+`INCLUDE_PATH` is one path per line, so for a component with several paths pass a multi-line value — bash/zsh `$'a\nb'` or a real newline-quoted string both work:
 
-| Component | `SCOPES` | `--tag-pattern` component | `--include-path`(s) |
+```bash
+make -f "$MK" changelog-dry-run \
+  COMPONENT=linea-besu-package \
+  SCOPES='linea-besu|tracer|sequencer|deps|misc' \
+  INCLUDE_PATH=$'tracer/**\ntracer-constraints/**\nlinea-besu/plugins/linea-sequencer/**\nlinea-besu/besu/**\nlinea-besu/package/**\ngradle/libs.versions.toml'
+```
+
+Fill the arguments per component (`COMPONENT` is also the release tag-pattern component; `FOLDER_NAME` is only needed for `prepend-dry-run`):
+
+| `COMPONENT` | `SCOPES` | `INCLUDE_PATH` (one per line) | `FOLDER_NAME` |
 |---|---|---|---|
-| `coordinator` | `coordinator\|deps\|misc` | `coordinator` | `coordinator/**` |
-| `maru` | `maru\|deps\|misc` | `maru` | `maru/**` |
-| `postman` | `postman\|deps\|misc` | `postman` | `postman/**` |
-| `prover` | `prover\|deps\|misc` | `prover` | `prover/**` |
-| `tx-exclusion-api` | `tx-exclusion-api\|deps\|misc` | `tx-exclusion-api` | `transaction-exclusion-api/**` |
-| `linea-besu-package` | `linea-besu\|tracer\|sequencer\|deps\|misc` | `linea-besu-package` | `tracer/**`, `tracer-constraints/**`, `linea-besu/plugins/linea-sequencer/**`, `linea-besu/besu/**`, `linea-besu/package/**`, `gradle/libs.versions.toml` |
-| `linea` (milestone) | `coordinator\|linea-besu\|tracer\|sequencer\|maru\|prover\|postman\|tx-exclusion-api\|deps\|misc` | `linea` | the union of every component path above |
+| `coordinator` | `coordinator\|deps\|misc` | `coordinator/**` | `coordinator` |
+| `maru` | `maru\|deps\|misc` | `maru/**` | `maru` |
+| `postman` | `postman\|deps\|misc` | `postman/**` | `postman` |
+| `prover` | `prover\|deps\|misc` | `prover/**` | `prover` |
+| `tx-exclusion-api` | `tx-exclusion-api\|deps\|misc` | `transaction-exclusion-api/**` | `transaction-exclusion-api` |
+| `linea-besu-package` | `linea-besu\|tracer\|sequencer\|deps\|misc` | `tracer/**`, `tracer-constraints/**`, `linea-besu/plugins/linea-sequencer/**`, `linea-besu/besu/**`, `linea-besu/package/**`, `gradle/libs.versions.toml` | `linea-besu/package` |
+| `linea` (milestone) | `coordinator\|linea-besu\|tracer\|sequencer\|maru\|prover\|postman\|tx-exclusion-api\|deps\|misc` | the union of every component path above | `.` |
 
 Notes:
 
-- `cliff.template.toml` is not runnable as-is — the `@@SCOPES@@` placeholder must be substituted first. An un-rendered template matches no commits and git-cliff reports "There is nothing to bump".
-- `--bumped-version` prints the full next tag (e.g. `releases/coordinator/v1.2.3`); drop it (as in step 3) to render the changelog instead. If nothing qualifies, git-cliff prints "There is nothing to bump" — meaning no release would be cut.
-- These are the same `scopes` and `include-path` values the workflows pass to the [`run-git-cliff-commands`](.github/actions/run-git-cliff-commands/action.yml) action, so the local result matches CI.
+- The dry-run targets are read-only: they never modify tracked files or the git remote. `prepend-dry-run` renders on a throwaway copy of `CHANGELOG.md` and prints the result to stdout; the real file is left untouched.
+- If a component has no qualifying commits, git-cliff reports "There is nothing to bump" and `changed=false` — meaning no release would be cut. This is the scope-and-path gating in action: a commit counts only when it is **both** in-scope **and** touches a component path.
+- The changelog/prepend previews render under the computed next-version header by default (`GENERATE_WITH_NEXT_TAG=true`); pass `GENERATE_WITH_NEXT_TAG=false` to preview under an `[unreleased]` header instead.
+- These are the same `scopes` and `include-path` values the workflows pass to the action, and the Makefile runs the same scripts, so the local result matches CI. Run `make -f "$MK" help` to list every target.
 
 ### Per-component release
 


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the composite action that drives semver bumps and CHANGELOG prepends in release workflows; behavior should be equivalent but any script/Makefile wiring bug could affect releases.
> 
> **Overview**
> **Refactors the `run-git-cliff-commands` composite action** so release/version/changelog logic lives in shared `scripts/*.sh` plus a `Makefile`, instead of large inline bash in `action.yml`. CI steps now invoke `make` targets (`paths`, `render`, `version`, `changelog`, `prepend`) with the same env vars workflows already pass.
> 
> **Adds local dry-run targets** (`version-dry-run`, `changelog-dry-run`, `prepend-dry-run`) so developers can preview next semver, changelog text, and prepended `CHANGELOG.md` without writing files or touching git remotes. `lib.sh` centralizes stdout vs `$GITHUB_OUTPUT` so one code path serves Actions and local `make`.
> 
> **README** replaces hand-rolled `sed`/`git cliff` examples with the Makefile workflow and expands the per-component table (`INCLUDE_PATH`, `FOLDER_NAME`). **Minor:** one workflow bot commit message gains a `linea-besu` conventional scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0236883120220b5b0dce0f866e373fe61cdc99a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->