### PR TITLE
refactor(prover-ray): export PCS batch/layout helpers and OpeningVeri…

### DIFF
--- a/prover-ray/wiop/compilers/pcs/pcs.go
+++ b/prover-ray/wiop/compilers/pcs/pcs.go
@@ -43,9 +43,9 @@ import (
 )
 
 const (
-	// friLogInverseRate is the log2 of the FRI blow-up factor (codeword size /
+	// FRILogInverseRate is the log2 of the FRI blow-up factor (codeword size /
 	// plaintext size).
-	friLogInverseRate = 1
+	FRILogInverseRate = 1
 )
 
 // friNumQueries is the number of FRI query openings. This is obtained from
@@ -79,41 +79,27 @@ var (
 // fixed maximum capacity.
 func staticFRI() (fri.Params, []*fri.RSEncoder) {
 	staticFRIOnce.Do(func() {
-		params, err := fri.NewParams(friLogInverseRate+maxCommittableSizeLog2, maxCommittableSizeLog2, uint(friNumQueries))
+		params, err := fri.NewParams(FRILogInverseRate+maxCommittableSizeLog2, maxCommittableSizeLog2, uint(friNumQueries))
 		if err != nil {
 			panic(fmt.Errorf("pcs: staticFRI: %w", err))
 		}
 		staticFRIParams = params
-		staticFRIEncoders = buildEncoders(1<<friLogInverseRate, maxCommittableSizeLog2)
+		staticFRIEncoders = buildEncoders(1<<FRILogInverseRate, maxCommittableSizeLog2)
 	})
 	return staticFRIParams, staticFRIEncoders
 }
 
-// FRILogInverseRate is the log2 of the FRI blow-up factor (codeword size /
-// plaintext size). Exported so out-of-package consumers — notably the
-// verifier-ray codegen — can reconstruct the per-proof FRI params from a
-// protocol's largest opened size (log_codeword = maxSize + FRILogInverseRate)
-// without duplicating the constant.
-const FRILogInverseRate = friLogInverseRate
-
 // FRINumQueries returns the number of FRI query openings currently configured.
-// It tracks [SetFRINumQueriesForTest], so the verifier-ray codegen emits the
-// same query count the prover committed to. Exported for that codegen; do not
-// use it to mutate query behaviour.
+// It tracks [SetFRINumQueriesForTest]; production callers must never use it to
+// mutate query behaviour.
 func FRINumQueries() int { return friNumQueries }
 
 // FRIMaxCommittableSizeLog2 is the log2 of the largest committed column size the
-// PCS supports — the fixed capacity of the static FRI envelope (2^22). The
-// verifier-ray codegen bakes this as the pcs.System envelope's log_plaintext_size
-// so ONE comptime System can restrict to any per-proof largest opened size via
-// fri.Params.restrictTo. Exported so the codegen never re-derives (and never
-// drifts from) the prover's actual envelope.
+// PCS supports — the fixed capacity of the static FRI envelope (2^22).
 func FRIMaxCommittableSizeLog2() uint8 { return maxCommittableSizeLog2 }
 
 // FRIStaticParams returns the process-wide FRI envelope parameters (sized to
-// FRIMaxCommittableSizeLog2). The verifier-ray codegen reads
-// LogCodewordSize/LogPlainTextSize/NumQueries off these to emit the pcs.System
-// envelope, so the emitted envelope is provably the one the prover commits with.
+// FRIMaxCommittableSizeLog2).
 func FRIStaticParams() fri.Params {
 	params, _ := staticFRI()
 	return params
@@ -142,7 +128,7 @@ func effectiveN(rt *wiop.Runtime, batches []BatchRef) int {
 			maxSizeIndex = idx
 		}
 	}
-	return 1 << (maxSizeIndex + friLogInverseRate)
+	return 1 << (maxSizeIndex + FRILogInverseRate)
 }
 
 // ColumnLocation records where a column sits inside its round's committed batch:
@@ -168,8 +154,7 @@ type compiled struct {
 }
 
 // BatchRef identifies one FRI batch: an interactive round, or the precomputed
-// round when IsPrecomp is set. Exported so verifier-side codegen can enumerate
-// the canonical batch ordering via [CommittedBatches] without re-deriving it.
+// round when IsPrecomp is set.
 type BatchRef struct {
 	Round     *wiop.Round
 	IsPrecomp bool
@@ -190,7 +175,7 @@ func Compile(sys *wiop.System) {
 	// runtime exposes the (static) precomputed assignments; its encoders are a
 	// prefix of the static schedule so the root is stable across proof runs.
 	if len(sys.PrecomputedRound.Columns) > 0 {
-		st := commitToRound(1<<friLogInverseRate, &sys.PrecomputedRound.Round, wiop.NewRuntime(sys))
+		st := commitToRound(1<<FRILogInverseRate, &sys.PrecomputedRound.Round, wiop.NewRuntime(sys))
 		c.precomputed = st
 		c.precomputedRoot = st.Tree.Root()
 		sys.PrecomputedCommitment = c.precomputedRoot
@@ -263,7 +248,7 @@ type commitRoundAction struct {
 }
 
 func (a *commitRoundAction) Run(rt *wiop.Runtime) {
-	st := commitToRound(1<<friLogInverseRate, a.round, rt)
+	st := commitToRound(1<<FRILogInverseRate, a.round, rt)
 	rt.Commitments[a.round.ID] = st.Tree.Root()
 	rt.SetState(committedStateKey(a.round.ID), st)
 }

--- a/prover-ray/wiop/compilers/pcs/pcs.go
+++ b/prover-ray/wiop/compilers/pcs/pcs.go
@@ -89,6 +89,36 @@ func staticFRI() (fri.Params, []*fri.RSEncoder) {
 	return staticFRIParams, staticFRIEncoders
 }
 
+// FRILogInverseRate is the log2 of the FRI blow-up factor (codeword size /
+// plaintext size). Exported so out-of-package consumers — notably the
+// verifier-ray codegen — can reconstruct the per-proof FRI params from a
+// protocol's largest opened size (log_codeword = maxSize + FRILogInverseRate)
+// without duplicating the constant.
+const FRILogInverseRate = friLogInverseRate
+
+// FRINumQueries returns the number of FRI query openings currently configured.
+// It tracks [SetFRINumQueriesForTest], so the verifier-ray codegen emits the
+// same query count the prover committed to. Exported for that codegen; do not
+// use it to mutate query behaviour.
+func FRINumQueries() int { return friNumQueries }
+
+// FRIMaxCommittableSizeLog2 is the log2 of the largest committed column size the
+// PCS supports — the fixed capacity of the static FRI envelope (2^22). The
+// verifier-ray codegen bakes this as the pcs.System envelope's log_plaintext_size
+// so ONE comptime System can restrict to any per-proof largest opened size via
+// fri.Params.restrictTo. Exported so the codegen never re-derives (and never
+// drifts from) the prover's actual envelope.
+func FRIMaxCommittableSizeLog2() uint8 { return maxCommittableSizeLog2 }
+
+// FRIStaticParams returns the process-wide FRI envelope parameters (sized to
+// FRIMaxCommittableSizeLog2). The verifier-ray codegen reads
+// LogCodewordSize/LogPlainTextSize/NumQueries off these to emit the pcs.System
+// envelope, so the emitted envelope is provably the one the prover commits with.
+func FRIStaticParams() fri.Params {
+	params, _ := staticFRI()
+	return params
+}
+
 // newStaticPCS wraps the shared static parameters in a fresh, per-proof [fri.PCS]
 // (which carries the mutable opening state). Wrapping is cheap — no domains are
 // rebuilt — and each proof restricts the fold schedule to its own witness size.
@@ -105,10 +135,10 @@ func newStaticPCS() *fri.PCS {
 // size of the largest committed column. Query positions are drawn from [0, N),
 // so this must match the size the PCS restricts its schedule to (both derive it
 // from the same committed columns).
-func effectiveN(rt *wiop.Runtime, batches []batchRef) int {
+func effectiveN(rt *wiop.Runtime, batches []BatchRef) int {
 	maxSizeIndex := 0
 	for _, b := range batches {
-		if idx := roundMaxSizeIndex(b.round, rt); idx > maxSizeIndex {
+		if idx := roundMaxSizeIndex(b.Round, rt); idx > maxSizeIndex {
 			maxSizeIndex = idx
 		}
 	}
@@ -137,18 +167,19 @@ type compiled struct {
 	precomputedRoot field.Octuplet
 }
 
-// batchRef identifies one FRI batch: an interactive round, or the precomputed
-// round when isPrecomp is set.
-type batchRef struct {
-	round     *wiop.Round
-	isPrecomp bool
+// BatchRef identifies one FRI batch: an interactive round, or the precomputed
+// round when IsPrecomp is set. Exported so verifier-side codegen can enumerate
+// the canonical batch ordering via [CommittedBatches] without re-deriving it.
+type BatchRef struct {
+	Round     *wiop.Round
+	IsPrecomp bool
 }
 
 // Compile wires the polynomial-commitment scheme onto sys. It must run last, after
 // every arithmetization pass has registered its columns and [wiop.LagrangeEval]
 // queries. It is a no-op when no columns are committed.
 func Compile(sys *wiop.System) {
-	batches := committedBatches(sys)
+	batches := CommittedBatches(sys)
 	if len(batches) == 0 {
 		return
 	}
@@ -169,12 +200,12 @@ func Compile(sys *wiop.System) {
 	// carrying a commitment (so AdvanceRound absorbs the root), and register the
 	// commit action that computes that root at prove time.
 	for _, b := range batches {
-		if b.isPrecomp {
+		if b.IsPrecomp {
 			continue
 		}
-		hideCommittedColumns(b.round)
-		b.round.HasCommitment = true
-		b.round.RegisterAction(&commitRoundAction{c: c, round: b.round})
+		hideCommittedColumns(b.Round)
+		b.Round.HasCommitment = true
+		b.Round.RegisterAction(&commitRoundAction{c: c, round: b.Round})
 	}
 
 	// A fresh final round hosts the opening: putting it after every committed
@@ -182,21 +213,21 @@ func Compile(sys *wiop.System) {
 	// before the opening squeezes alpha_DEEP.
 	openingRound := sys.NewRound()
 	openingRound.RegisterAction(&openingProverAction{c: c})
-	openingRound.RegisterVerifierAction(&openingVerifierAction{c: c})
+	openingRound.RegisterVerifierAction(&OpeningVerifierAction{c: c})
 }
 
-// committedBatches returns the canonical batch ordering: every interactive round
+// CommittedBatches returns the canonical batch ordering: every interactive round
 // that owns columns (in round order), then the precomputed round if it owns
 // columns. Deterministic from the System alone, so prover and verifier agree.
-func committedBatches(sys *wiop.System) []batchRef {
-	var refs []batchRef
+func CommittedBatches(sys *wiop.System) []BatchRef {
+	var refs []BatchRef
 	for _, r := range sys.Rounds {
 		if len(r.Columns) > 0 {
-			refs = append(refs, batchRef{round: r})
+			refs = append(refs, BatchRef{Round: r})
 		}
 	}
 	if len(sys.PrecomputedRound.Columns) > 0 {
-		refs = append(refs, batchRef{round: &sys.PrecomputedRound.Round, isPrecomp: true})
+		refs = append(refs, BatchRef{Round: &sys.PrecomputedRound.Round, IsPrecomp: true})
 	}
 	return refs
 }
@@ -246,10 +277,10 @@ func (a *openingProverAction) Run(rt *wiop.Runtime) {
 	rt.PCSOpeningProof = &proof
 }
 
-// openingVerifierAction replays the opening transcript and checks the proof.
-type openingVerifierAction struct{ c *compiled }
+// OpeningVerifierAction replays the opening transcript and checks the proof.
+type OpeningVerifierAction struct{ c *compiled }
 
-func (a *openingVerifierAction) Check(rt *wiop.Runtime) error {
+func (a *OpeningVerifierAction) Check(rt *wiop.Runtime) error {
 	return a.c.verify(rt, *rt.PCSOpeningProof)
 }
 
@@ -260,8 +291,8 @@ func (a *openingVerifierAction) Check(rt *wiop.Runtime) error {
 // open runs the full prover-side opening: register every batch on a fresh FRI
 // PCS, seed the DEEP quotient with alpha_DEEP, fold, and open the queries.
 func (c *compiled) open(rt *wiop.Runtime) fri.OpeningProof {
-	batches := committedBatches(rt.System)
-	batchShifts, batchClaims, _, evalPoint := recoverBatchClaims(rt, batches)
+	batches := CommittedBatches(rt.System)
+	batchShifts, batchClaims, _, evalPoint := RecoverBatchClaims(rt, batches)
 
 	pcs := newStaticPCS()
 	states := c.collectCommittedStates(rt, batches)
@@ -302,8 +333,8 @@ func (c *compiled) open(rt *wiop.Runtime) fri.OpeningProof {
 // verify replays the opening transcript exactly as the prover produced it and
 // checks the opening proof against the transported commitments.
 func (c *compiled) verify(rt *wiop.Runtime, proof fri.OpeningProof) error {
-	batches := committedBatches(rt.System)
-	batchShifts, batchClaims, shapes, evalPoint := recoverBatchClaims(rt, batches)
+	batches := CommittedBatches(rt.System)
+	batchShifts, batchClaims, shapes, evalPoint := RecoverBatchClaims(rt, batches)
 
 	pcs := newStaticPCS()
 
@@ -339,16 +370,16 @@ func (c *compiled) verify(rt *wiop.Runtime, proof fri.OpeningProof) error {
 // collectCommittedStates returns the committed states in batch order. Interactive
 // states were stashed on the runtime by the commit actions; the precomputed
 // state was committed once at compile time.
-func (c *compiled) collectCommittedStates(rt *wiop.Runtime, batches []batchRef) []*fri.CommitterState {
+func (c *compiled) collectCommittedStates(rt *wiop.Runtime, batches []BatchRef) []*fri.CommitterState {
 	states := make([]*fri.CommitterState, len(batches))
 	for i, b := range batches {
-		if b.isPrecomp {
+		if b.IsPrecomp {
 			states[i] = c.precomputed
 			continue
 		}
-		v, ok := rt.GetState(committedStateKey(b.round.ID))
+		v, ok := rt.GetState(committedStateKey(b.Round.ID))
 		if !ok {
-			panic(fmt.Sprintf("pcs: missing committed state for round %d", b.round.ID))
+			panic(fmt.Sprintf("pcs: missing committed state for round %d", b.Round.ID))
 		}
 		states[i] = v.(*fri.CommitterState)
 	}
@@ -357,16 +388,16 @@ func (c *compiled) collectCommittedStates(rt *wiop.Runtime, batches []batchRef) 
 
 // collectRoots returns the commitment roots in batch order: interactive roots
 // from the transported [Runtime.Commitments], the precomputed root from compile.
-func (c *compiled) collectRoots(rt *wiop.Runtime, batches []batchRef) []field.Octuplet {
+func (c *compiled) collectRoots(rt *wiop.Runtime, batches []BatchRef) []field.Octuplet {
 	roots := make([]field.Octuplet, len(batches))
 	for i, b := range batches {
-		if b.isPrecomp {
+		if b.IsPrecomp {
 			roots[i] = c.precomputedRoot
 			continue
 		}
-		root, ok := rt.Commitments[b.round.ID]
+		root, ok := rt.Commitments[b.Round.ID]
 		if !ok {
-			panic(fmt.Sprintf("pcs: missing commitment for round %d", b.round.ID))
+			panic(fmt.Sprintf("pcs: missing commitment for round %d", b.Round.ID))
 		}
 		roots[i] = root
 	}
@@ -409,7 +440,7 @@ func roundMaxSizeIndex(round *wiop.Round, rt *wiop.Runtime) int {
 // commitToRound sorts a round's columns into a [fri.MultiSizeTable] by padded
 // size (base then extension within each size, in column-declaration order) and
 // FRI-commits it with a freshly-built per-round encoder schedule (a prefix of
-// the global schedule). The column ordering matches [getLayout] exactly.
+// the global schedule). The column ordering matches [GetLayout] exactly.
 func commitToRound(inverseRate uint8, round *wiop.Round, rt *wiop.Runtime) *fri.CommitterState {
 
 	var (
@@ -449,11 +480,11 @@ func commitToRound(inverseRate uint8, round *wiop.Round, rt *wiop.Runtime) *fri.
 	return &committerState
 }
 
-// getLayout maps each of a round's columns to its [ColumnLocation] and returns
+// GetLayout maps each of a round's columns to its [ColumnLocation] and returns
 // the round's [fri.Shape] (per-size base/extension widths). The shape length is
 // maxSizeIndex+1, matching the committed table produced by [commitToRound], and
 // positions are assigned in column-declaration order so both agree.
-func getLayout(round *wiop.Round, rt *wiop.Runtime) (map[wiop.ObjectID]ColumnLocation, fri.Shape) {
+func GetLayout(round *wiop.Round, rt *wiop.Runtime) (map[wiop.ObjectID]ColumnLocation, fri.Shape) {
 
 	var (
 		cols   = round.Columns
@@ -503,13 +534,13 @@ type claimKey struct {
 	shift    int
 }
 
-// recoverBatchClaims walks every [wiop.LagrangeEval] and collects, per batch, the
+// RecoverBatchClaims walks every [wiop.LagrangeEval] and collects, per batch, the
 // shift schedule and claimed evaluations of each opened column at the (single,
 // shared) evaluation point zeta. Shifts are normalized into [0, size); repeated
 // (column, shift) openings are deduplicated and cross-checked for a consistent
 // claimed value. It returns the per-batch shifts, claims and shapes aligned with
 // batches, plus zeta.
-func recoverBatchClaims(rt *wiop.Runtime, batches []batchRef) (
+func RecoverBatchClaims(rt *wiop.Runtime, batches []BatchRef) (
 	[]fri.BatchShifts,
 	[]fri.BatchClaimedValues,
 	[]fri.Shape,
@@ -527,10 +558,10 @@ func recoverBatchClaims(rt *wiop.Runtime, batches []batchRef) (
 	)
 
 	for i, b := range batches {
-		layouts[i], shapes[i] = getLayout(b.round, rt)
+		layouts[i], shapes[i] = GetLayout(b.Round, rt)
 		shifts[i] = initializeBatchShift(shapes[i])
 		claims[i] = initializeBatchClaims(shapes[i])
-		batchOf[b.round] = i
+		batchOf[b.Round] = i
 	}
 
 	for _, eval := range sys.LagrangeEvals {


### PR DESCRIPTION

Exports FRILogInverseRate, FRINumQueries, FRIMaxCommittableSizeLog2, FRIStaticParams, BatchRef, CommittedBatches, GetLayout, RecoverBatchClaims, and OpeningVerifierAction from wiop/compilers/pcs. These are pure renames (no behavior change) so the verifier-ray codegen can consume the prover's own FRI/PCS parameters and batch layout directly, and can type-assert on OpeningVerifierAction instead of matching its type name via reflection.

