### PR TITLE
ci: bind composite action inputs via env before shell

### DIFF
--- a/.github/actions/check-image-tags-exist/action.yml
+++ b/.github/actions/check-image-tags-exist/action.yml
@@ -20,8 +20,11 @@ runs:
       id: last_commit_image_exists
       shell: bash
       continue-on-error: true
+      env:
+        IMAGE_NAME: ${{ inputs.image_name }}
+        LAST_COMMIT_TAG: ${{ inputs.last_commit_tag }}
       run: |
-        echo last_commit_tag_exists=$(docker pull ${{ inputs.image_name }}:${{ inputs.last_commit_tag }} > /dev/null ; echo $?) >> $GITHUB_OUTPUT
+        echo last_commit_tag_exists=$(docker pull "${IMAGE_NAME}:${LAST_COMMIT_TAG}" > /dev/null ; echo $?) >> $GITHUB_OUTPUT
     - name: Show outputs
       shell: bash
       run: |

--- a/.github/actions/docker-build-publish/action.yml
+++ b/.github/actions/docker-build-publish/action.yml
@@ -116,20 +116,22 @@ runs:
     - name: Configure cache
       id: cache-config
       shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image_name }}
       run: |
         if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
           echo "cache_from_test=" >> $GITHUB_OUTPUT
           echo "cache_from_push=" >> $GITHUB_OUTPUT
           echo "cache_to_push=" >> $GITHUB_OUTPUT
         else
-          echo "cache_from_test=type=registry,ref=${{ inputs.image_name }}:buildcache-amd64" >> $GITHUB_OUTPUT
+          echo "cache_from_test=type=registry,ref=${IMAGE_NAME}:buildcache-amd64" >> $GITHUB_OUTPUT
           echo "cache_from_push<<EOF" >> $GITHUB_OUTPUT
-          echo "type=registry,ref=${{ inputs.image_name }}:buildcache-amd64,platform=linux/amd64" >> $GITHUB_OUTPUT
-          echo "type=registry,ref=${{ inputs.image_name }}:buildcache-arm64,platform=linux/arm64" >> $GITHUB_OUTPUT
+          echo "type=registry,ref=${IMAGE_NAME}:buildcache-amd64,platform=linux/amd64" >> $GITHUB_OUTPUT
+          echo "type=registry,ref=${IMAGE_NAME}:buildcache-arm64,platform=linux/arm64" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
           echo "cache_to_push<<EOF" >> $GITHUB_OUTPUT
-          echo "type=registry,ref=${{ inputs.image_name }}:buildcache-amd64,mode=max,platform=linux/amd64" >> $GITHUB_OUTPUT
-          echo "type=registry,ref=${{ inputs.image_name }}:buildcache-arm64,mode=max,platform=linux/arm64" >> $GITHUB_OUTPUT
+          echo "type=registry,ref=${IMAGE_NAME}:buildcache-amd64,mode=max,platform=linux/amd64" >> $GITHUB_OUTPUT
+          echo "type=registry,ref=${IMAGE_NAME}:buildcache-arm64,mode=max,platform=linux/arm64" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
         fi
 
@@ -152,8 +154,11 @@ runs:
     - name: Save Docker image as artifact
       if: ${{ inputs.save_artifact == 'true' }}
       shell: bash
+      env:
+        PRIMARY_IMAGE: ${{ steps.set-tags.outputs.primary_image }}
+        ARTIFACT_NAME: ${{ inputs.artifact_name }}
       run: |
-        docker save ${{ steps.set-tags.outputs.primary_image }} | gzip > ${{ inputs.artifact_name }}-docker-image.tar.gz
+        docker save "$PRIMARY_IMAGE" | gzip > "${ARTIFACT_NAME}-docker-image.tar.gz"
 
     - name: Upload Docker image artifact
       if: ${{ inputs.save_artifact == 'true' }}

--- a/.github/actions/image-tag-and-push/action.yml
+++ b/.github/actions/image-tag-and-push/action.yml
@@ -62,9 +62,13 @@ runs:
     - name: Save Docker image as artifact for later use in e2e test
       if: ${{ github.ref == 'refs/heads/main' && inputs.last_commit_tag_exists == '0' }}
       shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image_name }}
+        COMMIT_TAG: ${{ inputs.commit_tag }}
+        IMAGE_NAME_SUFFIX: ${{ steps.split.outputs.image_name_suffix }}
       run: |
-        docker pull ${{ inputs.image_name }}:${{ inputs.commit_tag }}
-        docker save ${{ inputs.image_name }}:${{ inputs.commit_tag }} | gzip > ${{ steps.split.outputs.image_name_suffix }}-docker-image.tar.gz
+        docker pull "${IMAGE_NAME}:${COMMIT_TAG}"
+        docker save "${IMAGE_NAME}:${COMMIT_TAG}" | gzip > "${IMAGE_NAME_SUFFIX}-docker-image.tar.gz"
     - name: Upload Docker image artifact for later use in e2e test
       if: ${{ github.ref == 'refs/heads/main' && inputs.last_commit_tag_exists == '0' }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/actions/linea-besu-package/assemble/action.yml
+++ b/.github/actions/linea-besu-package/assemble/action.yml
@@ -26,10 +26,12 @@ runs:
     - name: Set local zip paths
       id: set_local_zip_paths
       shell: bash
+      env:
+        LOCAL_BESU_VERSION: ${{ inputs.local_besu_version }}
       run: |
         echo "local_tracer_dist_path=$GITHUB_WORKSPACE/tracer/plugins/build/install/linea-tracer" >> $GITHUB_OUTPUT
         echo "local_sequencer_dist_path=$GITHUB_WORKSPACE/linea-besu/plugins/linea-sequencer/sequencer/build/install/sequencer" >> $GITHUB_OUTPUT
-        echo "local_besu_zip_path=$GITHUB_WORKSPACE/tmp/besu-eth/build/distributions/besu-${{ inputs.local_besu_version }}.tar.gz" >> $GITHUB_OUTPUT
+        echo "local_besu_zip_path=$GITHUB_WORKSPACE/tmp/besu-eth/build/distributions/besu-${LOCAL_BESU_VERSION}.tar.gz" >> $GITHUB_OUTPUT
 
     - name: assemble the packages to linea-besu
       shell: bash

--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -142,6 +142,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:
+        IMAGE_TAG: ${{ inputs.image_tag }}
         LINEA_COORDINATOR_ARTIFACT_NAME: ${{ inputs.linea_coordinator_artifact_name }}
         LINEA_COORDINATOR_IMAGE_NAME: ${{ inputs.linea_coordinator_image_name }}
         LINEA_COORDINATOR_JAR: ${{ inputs.linea_coordinator_jar }}
@@ -165,7 +166,7 @@ runs:
           fi
 
           if [ -f "$artifact_path" ]; then
-            echo "${env_var}=${{ inputs.image_tag }}" >> "$GITHUB_ENV"
+            echo "${env_var}=${IMAGE_TAG}" >> "$GITHUB_ENV"
           elif [ -z "${!env_var:-}" ]; then
             # Fall back to "develop" only when the job-level env var is unset or empty.
             echo "${env_var}=develop" >> "$GITHUB_ENV"

--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -52,11 +52,15 @@ runs:
 
     - name: pnpm install
       working-directory: ${{ inputs.working-directory }}
-      run: pnpm i ${{ inputs.pnpm-install-options }}
+      env:
+        PNPM_INSTALL_OPTIONS: ${{ inputs.pnpm-install-options }}
+      run: pnpm i $PNPM_INSTALL_OPTIONS
       shell: bash
 
     - name: Run post-install commands
       if: inputs.commands != ''
       working-directory: ${{ inputs.working-directory }}
       shell: bash
-      run: ${{ inputs.commands }}
+      env:
+        POST_INSTALL_COMMANDS: ${{ inputs.commands }}
+      run: bash -c "$POST_INSTALL_COMMANDS"

--- a/.github/workflows/reusable-tracer-blockchain-tests.yml
+++ b/.github/workflows/reusable-tracer-blockchain-tests.yml
@@ -74,7 +74,9 @@ jobs:
         run: mv ${{ github.workspace }}/tmp/${{ github.head_ref || github.ref_name }}/failedBlockchainReferenceTests.json ${{ github.workspace }}/tmp/${{ github.head_ref || github.ref_name }}/failedBlockchainReferenceTests-input.json
 
       - name: Run reference execution spec blockchain tests
-        run: GOMAXPROCS=10 GOMEMLIMIT=20GiB ./gradlew :tracer:reference-tests:referenceExecutionSpecBlockchainTests -x spotlessCheck --tests "${{ inputs.test_filter || 'BlockchainReferenceTest_*' }}"
+        env:
+          TEST_FILTER: ${{ inputs.test_filter || 'BlockchainReferenceTest_*' }}
+        run: GOMAXPROCS=10 GOMEMLIMIT=20GiB ./gradlew :tracer:reference-tests:referenceExecutionSpecBlockchainTests -x spotlessCheck --tests "$TEST_FILTER"
         timeout-minutes: 360
         env:
           JUNIT_TESTS_PARALLELISM: 2


### PR DESCRIPTION
## Summary
- Bind `pnpm-install-options` / `commands` through `env:` in setup-nodejs before shell.
- Bind image name/tag inputs through `env:` before docker pull/save shell steps.
- Bind related docker-build-publish / besu assemble / e2e / tracer inputs through `env:` before shell.
- Same class as GitHub’s documented script-injection guidance for interpolating action/workflow inputs into `run:` scripts.

## Test plan
- [ ] setup-nodejs still installs with configured options and optional post-commands
- [ ] image tag/push and docker-build-publish still pull/save expected images
- [ ] tracer reusable workflow still filters tests when `test_filter` is set


Made with [Cursor](https://cursor.com)