### PR TITLE
fix(ci): linea besu jar not publish

### DIFF
--- a/.github/workflows/linea-besu-build-and-publish.yml
+++ b/.github/workflows/linea-besu-build-and-publish.yml
@@ -29,9 +29,11 @@ jobs:
           target_file_path: gradle/libs.versions.toml
 
       - name: Setup Java and Gradle
+        if: ${{ steps.check_besu_commit.outputs.version_changed == 'true' }}
         uses: ./.github/actions/setup-java-and-gradle
 
       - name: Build besu from source and publish to maven including Cloudsmith
+        if: ${{ steps.check_besu_commit.outputs.version_changed == 'true' }}
         run: ./gradlew :linea-besu:besu:build -PpublishToMaven=true
         env:
           JAVA_OPTS: -Xmx2g -Dorg.gradle.daemon=false

--- a/.github/workflows/linea-besu-build-and-publish.yml
+++ b/.github/workflows/linea-besu-build-and-publish.yml
@@ -29,11 +29,9 @@ jobs:
           target_file_path: gradle/libs.versions.toml
 
       - name: Setup Java and Gradle
-        if: ${{ steps.check_besu_commit.outputs.version_changed == 'true' }}
         uses: ./.github/actions/setup-java-and-gradle
 
       - name: Build besu from source and publish to maven including Cloudsmith
-        if: ${{ steps.check_besu_commit.outputs.version_changed == 'true' }}
         run: ./gradlew :linea-besu:besu:build -PpublishToMaven=true
         env:
           JAVA_OPTS: -Xmx2g -Dorg.gradle.daemon=false

--- a/linea-besu/besu/build.gradle
+++ b/linea-besu/besu/build.gradle
@@ -290,8 +290,8 @@ static void buildAndPublishBesuAction(
     logger.lifecycle('Skipping buildAndPublishBesu: no resolved Besu version (run a non-clean-only build first)')
     return
   }
-  def bomAvailableInMaven = isBesuAvailableInMavenLocal(logger, resolvedBesuVer, mavenLocalBase) &&
-      isBesuAvailableInMaven(logger, resolvedBesuVer)
+  def bomAvailableInMavenLocal = isBesuAvailableInMavenLocal(logger, resolvedBesuVer, mavenLocalBase)
+  def bomAvailableInMaven = isBesuAvailableInMaven(logger, resolvedBesuVer)
   def publishGradleTaskName = publishToMaven ? "publish" : "publishToMavenLocal"
   def shouldSkip = false
   if (publishToMaven) {
@@ -324,7 +324,7 @@ static void buildAndPublishBesuAction(
     return
   }
 
-  logger.lifecycle("Running buildAndPublishBesu as Besu ${resolvedBesuVer} was not found in remote/local maven")
+  logger.lifecycle("Running buildAndPublishBesu as Besu ${resolvedBesuVer} was not found in remote maven")
   runBuildDistAndPublishScript(logger, providers, rootDir, resolvedBesuVer, publishGradleTaskName, cloudsmithUser, cloudsmithApiKey)
 }
 

--- a/linea-besu/besu/build.gradle
+++ b/linea-besu/besu/build.gradle
@@ -228,12 +228,9 @@ static String execCapturing(providers, File workingDir, Map<String, Object> env,
     spec.setIgnoreExitValue(true)
   }
   def stdout = output.standardOutput.asText.get()
-  def stderr = output.standardError.asText.get()
   def exitValue = output.result.get().exitValue
-  // surface both streams even on success
-  System.out.println("--- ${commandLine.join(' ')} (exit ${exitValue}) stdout ---\n${stdout}")
-  System.out.println("--- ${commandLine.join(' ')} (exit ${exitValue}) stderr ---\n${stderr}")
   if (exitValue != 0) {
+    def stderr = output.standardError.asText.get()
     throw new GradleException(
     "Command '${commandLine.join(' ')}' failed with exit code ${exitValue}\n" +
     "--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}")
@@ -340,8 +337,6 @@ static void runBuildDistAndPublishScript(logger, providers, File rootDir, String
     env.CLOUDSMITH_USER = cloudsmithUser
     env.CLOUDSMITH_API_KEY = cloudsmithApiKey
   }
-  // DEBUG (temporary): confirm we got here and with which publish task
-  logger.lifecycle(">>> runBuildDistAndPublishScript: publishTask=${publishTask} besuVer=${resolvedBesuVer}")
   execCapturing(providers, rootDir, env, [
     'bash',
     "${rootPath}/linea-besu/besu/scripts/build-dist-and-publish.sh",

--- a/linea-besu/besu/build.gradle
+++ b/linea-besu/besu/build.gradle
@@ -228,9 +228,12 @@ static String execCapturing(providers, File workingDir, Map<String, Object> env,
     spec.setIgnoreExitValue(true)
   }
   def stdout = output.standardOutput.asText.get()
+  def stderr = output.standardError.asText.get()
   def exitValue = output.result.get().exitValue
+  // surface both streams even on success
+  System.out.println("--- ${commandLine.join(' ')} (exit ${exitValue}) stdout ---\n${stdout}")
+  System.out.println("--- ${commandLine.join(' ')} (exit ${exitValue}) stderr ---\n${stderr}")
   if (exitValue != 0) {
-    def stderr = output.standardError.asText.get()
     throw new GradleException(
     "Command '${commandLine.join(' ')}' failed with exit code ${exitValue}\n" +
     "--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}")
@@ -287,7 +290,7 @@ static void buildAndPublishBesuAction(
     logger.lifecycle('Skipping buildAndPublishBesu: no resolved Besu version (run a non-clean-only build first)')
     return
   }
-  def bomAvailableInMaven = isBesuAvailableInMavenLocal(logger, resolvedBesuVer, mavenLocalBase) ||
+  def bomAvailableInMaven = isBesuAvailableInMavenLocal(logger, resolvedBesuVer, mavenLocalBase) &&
       isBesuAvailableInMaven(logger, resolvedBesuVer)
   def publishGradleTaskName = publishToMaven ? "publish" : "publishToMavenLocal"
   def shouldSkip = false
@@ -317,12 +320,12 @@ static void buildAndPublishBesuAction(
   // build distTar alone instead of re-running the full checkout+build+publish pipeline.
   if (bomAvailableInMaven) {
     logger.lifecycle("Besu ${resolvedBesuVer} jars/BOM already published; building distTar only to materialize the missing distribution")
-    runBuildDistAndPublishScript(providers, rootDir, resolvedBesuVer, 'none', cloudsmithUser, cloudsmithApiKey)
+    runBuildDistAndPublishScript(logger, providers, rootDir, resolvedBesuVer, 'none', cloudsmithUser, cloudsmithApiKey)
     return
   }
 
   logger.lifecycle("Running buildAndPublishBesu as Besu ${resolvedBesuVer} was not found in remote/local maven")
-  runBuildDistAndPublishScript(providers, rootDir, resolvedBesuVer, publishGradleTaskName, cloudsmithUser, cloudsmithApiKey)
+  runBuildDistAndPublishScript(logger, providers, rootDir, resolvedBesuVer, publishGradleTaskName, cloudsmithUser, cloudsmithApiKey)
 }
 
 /**
@@ -330,13 +333,15 @@ static void buildAndPublishBesuAction(
  * ('publish', 'publishToMavenLocal', or 'none' to build distTar only). Cloudsmith
  * credentials are only wired in when an actual remote publish is requested.
  */
-static void runBuildDistAndPublishScript(providers, File rootDir, String resolvedBesuVer, String publishTask, String cloudsmithUser, String cloudsmithApiKey) {
+static void runBuildDistAndPublishScript(logger, providers, File rootDir, String resolvedBesuVer, String publishTask, String cloudsmithUser, String cloudsmithApiKey) {
   def rootPath = rootDir.absolutePath
   def env = [BESU_DIR: "${rootPath}/tmp/besu-eth", RESOLVED_BESU_VERSION: resolvedBesuVer]
   if (publishTask == 'publish') {
     env.CLOUDSMITH_USER = cloudsmithUser
     env.CLOUDSMITH_API_KEY = cloudsmithApiKey
   }
+  // DEBUG (temporary): confirm we got here and with which publish task
+  logger.lifecycle(">>> runBuildDistAndPublishScript: publishTask=${publishTask} besuVer=${resolvedBesuVer}")
   execCapturing(providers, rootDir, env, [
     'bash',
     "${rootPath}/linea-besu/besu/scripts/build-dist-and-publish.sh",

--- a/linea-besu/besu/build.gradle
+++ b/linea-besu/besu/build.gradle
@@ -287,7 +287,6 @@ static void buildAndPublishBesuAction(
     logger.lifecycle('Skipping buildAndPublishBesu: no resolved Besu version (run a non-clean-only build first)')
     return
   }
-  def bomAvailableInMavenLocal = isBesuAvailableInMavenLocal(logger, resolvedBesuVer, mavenLocalBase)
   def bomAvailableInMaven = isBesuAvailableInMaven(logger, resolvedBesuVer)
   def publishGradleTaskName = publishToMaven ? "publish" : "publishToMavenLocal"
   def shouldSkip = false
@@ -317,12 +316,12 @@ static void buildAndPublishBesuAction(
   // build distTar alone instead of re-running the full checkout+build+publish pipeline.
   if (bomAvailableInMaven) {
     logger.lifecycle("Besu ${resolvedBesuVer} jars/BOM already published; building distTar only to materialize the missing distribution")
-    runBuildDistAndPublishScript(logger, providers, rootDir, resolvedBesuVer, 'none', cloudsmithUser, cloudsmithApiKey)
+    runBuildDistAndPublishScript(providers, rootDir, resolvedBesuVer, 'none', cloudsmithUser, cloudsmithApiKey)
     return
   }
 
   logger.lifecycle("Running buildAndPublishBesu as Besu ${resolvedBesuVer} was not found in remote maven")
-  runBuildDistAndPublishScript(logger, providers, rootDir, resolvedBesuVer, publishGradleTaskName, cloudsmithUser, cloudsmithApiKey)
+  runBuildDistAndPublishScript(providers, rootDir, resolvedBesuVer, publishGradleTaskName, cloudsmithUser, cloudsmithApiKey)
 }
 
 /**
@@ -330,7 +329,7 @@ static void buildAndPublishBesuAction(
  * ('publish', 'publishToMavenLocal', or 'none' to build distTar only). Cloudsmith
  * credentials are only wired in when an actual remote publish is requested.
  */
-static void runBuildDistAndPublishScript(logger, providers, File rootDir, String resolvedBesuVer, String publishTask, String cloudsmithUser, String cloudsmithApiKey) {
+static void runBuildDistAndPublishScript(providers, File rootDir, String resolvedBesuVer, String publishTask, String cloudsmithUser, String cloudsmithApiKey) {
   def rootPath = rootDir.absolutePath
   def env = [BESU_DIR: "${rootPath}/tmp/besu-eth", RESOLVED_BESU_VERSION: resolvedBesuVer]
   if (publishTask == 'publish') {


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI/on-demand Besu materialization branching; wrong logic could still skip publishes or trigger extra full builds, but scope is limited to `linea-besu/besu/build.gradle`.
> 
> **Overview**
> **Fixes CI skipping remote Besu jar/BOM publish** when a matching BOM only exists in `~/.m2`, not in remote Maven.
> 
> In `buildAndPublishBesuAction`, `bomAvailableInMaven` no longer ORs in `isBesuAvailableInMavenLocal`—it only reflects **remote** BOM availability via `isBesuAvailableInMaven`. That flag decides whether the pipeline runs full `publish` / `publishToMavenLocal` or the **distTar-only** shortcut (`publishTask: 'none'`).
> 
> Previously, a stale or partial local BOM could make CI think artifacts were already published and skip the real publish step. Local-only fast paths for non-`publishToMaven` builds are unchanged (`isBesuAndDistributionAvailableInMavenLocal` is still used for `shouldSkip`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07ab42ac15f370698cd381e736bfca3ec070bfad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->