### PR TITLE
fix(linea-besu): align Besu Kotlin runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,12 @@ allprojects {
   }
 
   repositories {
+    maven {
+      url "https://artifacts.consensys.net/public/linea-besu/maven/"
+      content {
+        includeGroupAndSubgroups('org.hyperledger')
+      }
+    }
     mavenCentral()
     mavenLocal()
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,8 +41,8 @@ undercouchDownload = "5.6.0"
 # This is the single source of truth for the Besu version.
 # During task execution, linea-besu/besu/build.gradle resolves this commit,
 # writes linea-besu/besu/.besu-resolved, and read by dependent modules.
-# Besu version: 26.7.1
-besuCommit = "49026aaf059f832a93f964d8d27191de2f0580e9"
+# Besu version: 26.7.0
+besuCommit = "6580da84187533a3b0ced343dc516ebe2adba6ec"
 blobCompressor = "4.0.1"
 commonsIo = "2.21.0"
 blobShnarfCalculator = "3.0.1"

--- a/jvm-libs/linea/testing/besu/src/main/kotlin/linea/testing/besu/BesuFactory.kt
+++ b/jvm-libs/linea/testing/besu/src/main/kotlin/linea/testing/besu/BesuFactory.kt
@@ -76,7 +76,6 @@ object BesuFactory {
           )
         }.devMode(false)
         .discoveryEnabled(true)
-        .discoveryV5Enabled(false)
         .engineJsonRpcConfiguration(engineRpcConfig)
         .jsonRpcConfiguration(jsonRpcConfig)
         .synchronizerConfiguration(

--- a/linea-besu/besu/.besu-resolved
+++ b/linea-besu/besu/.besu-resolved
@@ -2,5 +2,5 @@
 # Written by Gradle (:linea-besu:resolveBesuVersion) and refreshed by CI
 # (.github/workflows/linea-besu-build-and-publish.yml) on besuCommit bumps.
 # Do NOT edit by hand and do NOT commit local changes — this file is gitignored.
-besuCommit=49026aaf059f832a93f964d8d27191de2f0580e9
-besuVersion=26.7.1-49026aa
+besuCommit=6580da84187533a3b0ced343dc516ebe2adba6ec
+besuVersion=26.7.0-6580da8

--- a/linea-besu/besu/build.gradle
+++ b/linea-besu/besu/build.gradle
@@ -41,6 +41,21 @@ dependencies {
   api("${besuArtifactGroup}:besu-plugin-api") {
     transitive = false
   }
+  api("${besuArtifactGroup}:besu-plugin-api-core") {
+    transitive = false
+  }
+  api("${besuArtifactGroup}:besu-plugin-api-metrics") {
+    transitive = false
+  }
+  api("${besuArtifactGroup}:besu-plugin-api-security") {
+    transitive = false
+  }
+  api("${besuArtifactGroup}:besu-plugin-api-permissioning") {
+    transitive = false
+  }
+  api("${besuArtifactGroup}:besu-plugin-api-storage") {
+    transitive = false
+  }
   api("${besuArtifactGroup}.internal:besu-ethereum-rlp") {
     transitive = false
   }

--- a/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/LineaPluginPoSTestBase.kt
+++ b/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/LineaPluginPoSTestBase.kt
@@ -22,13 +22,12 @@ import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.Awaitility.await
 import org.hyperledger.besu.crypto.SECP256K1
 import org.hyperledger.besu.datatypes.Address
-import org.hyperledger.besu.datatypes.BlobGas
 import org.hyperledger.besu.datatypes.Hash
 import org.hyperledger.besu.datatypes.RequestType
 import org.hyperledger.besu.datatypes.TransactionType
 import org.hyperledger.besu.datatypes.Wei
 import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcObjectMapperFactory
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EnginePayloadParameter
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.ExecutionPayloadV3
 import org.hyperledger.besu.ethereum.core.BlockHeader
 import org.hyperledger.besu.ethereum.core.BlockHeaderBuilder
 import org.hyperledger.besu.ethereum.core.Difficulty
@@ -543,7 +542,7 @@ abstract class LineaPluginPoSTestBase : LineaPluginTestBase() {
     mapper: ObjectMapper,
     blockParams: Map<String, String>,
   ): BlockHeader {
-    val blockParam = mapper.readValue(executionPayload.toString(), EnginePayloadParameter::class.java)
+    val blockParam = mapper.readValue(executionPayload.toString(), ExecutionPayloadV3::class.java)
 
     val transactionsRoot = Hash.fromHexString(blockParams[BlockParams.TRANSACTIONS_ROOT])
     val withdrawalsRoot = Hash.fromHexString(blockParams[BlockParams.WITHDRAWALS_ROOT])
@@ -570,13 +569,13 @@ abstract class LineaPluginPoSTestBase : LineaPluginTestBase() {
       .gasLimit(blockParam.gasLimit)
       .gasUsed(blockParam.gasUsed)
       .timestamp(blockParam.timestamp)
-      .extraData(Bytes.fromHexString(blockParam.extraData))
+      .extraData(blockParam.extraData)
       .baseFee(blockParam.baseFeePerGas)
       .prevRandao(blockParam.prevRandao)
       .nonce(0)
       .withdrawalsRoot(withdrawalsRoot)
       .blobGasUsed(blockParam.blobGasUsed)
-      .excessBlobGas(BlobGas.fromHexString(blockParam.excessBlobGas))
+      .excessBlobGas(blockParam.excessBlobGas)
       .parentBeaconBlockRoot(Bytes32.fromHexString(blockParams[BlockParams.PARENT_BEACON_BLOCK_ROOT]!!))
       .requestsHash(maybeRequests.map { BodyValidation.requestsHash(it) }.orElse(null))
       .blockHeaderFunctions(MainnetBlockHeaderFunctions())

--- a/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/TxInitializationSection.java
+++ b/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/TxInitializationSection.java
@@ -144,7 +144,7 @@ public final class TxInitializationSection extends TraceSection implements EndTr
             .dontCheckForDelegation(hub);
     latestAccountSnapshots.put(senderAddress, senderGasPaymentNew);
 
-    final Wei value = (Wei) tx.getBesuTransaction().getValue();
+    final Wei value = tx.getBesuTransaction().getValue();
 
     senderValueTransfer =
         deepCopyAndMaybeCheckForDelegation(hub, senderAddress, "sender [value transfer]", false);

--- a/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/TxSkipSection.java
+++ b/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/TxSkipSection.java
@@ -175,7 +175,7 @@ public final class TxSkipSection extends TraceSection implements EndTransactionD
     delegateNew = canonical(hub, world, delegateAddress, initialWarmth(hub, delegateAddress));
     coinbaseNew = canonical(hub, world, coinbaseAddress, initialWarmth(hub, coinbaseAddress));
 
-    final Wei value = (Wei) txMetadata.getBesuTransaction().getValue();
+    final Wei value = txMetadata.getBesuTransaction().getValue();
 
     if (txMetadata.senderAddressCollision()) {
       final BigInteger gasUsed = BigInteger.valueOf(txMetadata.getTotalGasUsed());

--- a/tracer/reference-tests/src/test/java/net/consensys/linea/CorsetBlockProcessor.java
+++ b/tracer/reference-tests/src/test/java/net/consensys/linea/CorsetBlockProcessor.java
@@ -104,11 +104,7 @@ public class CorsetBlockProcessor extends MainnetBlockProcessor {
       // Address when we support eip-8037 (likely never by this tracer)
       final long cumulativeStateGasUsed = 0;
       if (!hasAvailableBlockBudget(
-          blockHeader,
-          transaction,
-          currentGasUsed,
-          cumulativeStateGasUsed,
-          BlockGasAccountingStrategy.FRONTIER)) {
+          blockHeader, transaction, currentGasUsed, cumulativeStateGasUsed, protocolSpec)) {
         return new BlockProcessingResult(Optional.empty(), "provided gas insufficient");
       }
 

--- a/tracer/testing/src/main/java/net/consensys/linea/testing/EngineAPIService.java
+++ b/tracer/testing/src/main/java/net/consensys/linea/testing/EngineAPIService.java
@@ -122,7 +122,7 @@ public class EngineAPIService {
     final ObjectNode blobsBundle;
     final String newBlockHash;
     ArrayNode executionRequests = null;
-    String parentBeaconBlockRoot = "";
+    String parentBeaconBlockRoot = Hash.ZERO.getBytes().toHexString();
     ArrayNode expectedBlobVersionedHashes = mapper.createArrayNode();
     try (final Response getPayloadResponse = getPayloadRequest.execute()) {
       assertThat(getPayloadResponse.code()).isEqualTo(200);
@@ -155,8 +155,11 @@ public class EngineAPIService {
 
     try (final Response newPayloadResponse = newPayloadRequest.execute()) {
       assertThat(newPayloadResponse.code()).isEqualTo(200);
-      final String responseStatus =
-          mapper.readTree(newPayloadResponse.body().string()).get("result").get("status").asText();
+      final JsonNode response = mapper.readTree(newPayloadResponse.body().string());
+      assertThat(response.get("result"))
+          .withFailMessage("engine_newPayload failed: %s", response)
+          .isNotNull();
+      final String responseStatus = response.get("result").get("status").asText();
       assertThat(responseStatus).isEqualTo("VALID");
     }
 


### PR DESCRIPTION
- update Linea Besu to `6580da84187533a3b0ced343dc516ebe2adba6ec`, which provides Kotlin stdlib 2.4.0
- align Kotlin API/runtime resolution with Kotlin 2.4
- consume Besu modular plugin API artifacts and adapt acceptance/tracer code to the updated APIs
- remove the obsolete discovery-v5 builder setting