### PR TITLE
fix(linea-besu): add the missing web3j crypto jar in dist and fix ci …

### DIFF
--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -146,7 +146,6 @@ runs:
         LINEA_COORDINATOR_IMAGE_NAME: ${{ inputs.linea_coordinator_image_name }}
         LINEA_COORDINATOR_JAR: ${{ inputs.linea_coordinator_jar }}
         LINEA_COORDINATOR_TAG: ${{ inputs.coordinator_tag }}
-        LINEA_BESU_PACKAGE_TAG: ${{ inputs.linea_besu_package_tag }}
         LINEA_POSTMAN_TAG: ${{ inputs.postman_tag }}
         LINEA_PROVER_TAG: ${{ inputs.prover_tag }}
         LINEA_TRANSACTION_EXCLUSION_API_TAG: ${{ inputs.tx_exclusion_api_tag }}
@@ -179,11 +178,14 @@ runs:
       if: ${{ inputs.linea_besu_package_tag != '' }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+      env:
+        LINEA_BESU_PACKAGE_TAG: ${{ inputs.linea_besu_package_tag }}
       run: |
         set -euo pipefail
         artifact_path="$GITHUB_WORKSPACE/${{ inputs.working-directory }}/tmp/artifacts/linea-besu-package-images.tar.gz"
         if [ -f "$artifact_path" ]; then
           gunzip -c "$artifact_path" | docker load
+          echo "LINEA_BESU_PACKAGE_TAG=${LINEA_BESU_PACKAGE_TAG}" >> "$GITHUB_ENV"
         else
           echo "No artifact at ${artifact_path}; skipping docker load."
         fi

--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -146,6 +146,7 @@ runs:
         LINEA_COORDINATOR_IMAGE_NAME: ${{ inputs.linea_coordinator_image_name }}
         LINEA_COORDINATOR_JAR: ${{ inputs.linea_coordinator_jar }}
         LINEA_COORDINATOR_TAG: ${{ inputs.coordinator_tag }}
+        LINEA_BESU_PACKAGE_TAG: ${{ inputs.linea_besu_package_tag }}
         LINEA_POSTMAN_TAG: ${{ inputs.postman_tag }}
         LINEA_PROVER_TAG: ${{ inputs.prover_tag }}
         LINEA_TRANSACTION_EXCLUSION_API_TAG: ${{ inputs.tx_exclusion_api_tag }}

--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ Swap `SCOPES`, the `--tag-pattern` component, and the `--include-path` set per c
 
 | Component | `SCOPES` | `--tag-pattern` component | `--include-path`(s) |
 |---|---|---|---|
-| coordinator | `coordinator\|deps\|misc` | `coordinator` | `coordinator/**` |
-| maru | `maru\|deps\|misc` | `maru` | `maru/**` |
-| postman | `postman\|deps\|misc` | `postman` | `postman/**` |
-| prover | `prover\|deps\|misc` | `prover` | `prover/**` |
-| tx-exclusion-api | `tx-exclusion-api\|deps\|misc` | `tx-exclusion-api` | `transaction-exclusion-api/**` |
-| linea-besu-package | `linea-besu\|tracer\|sequencer\|deps\|misc` | `linea-besu-package` | `tracer/**`, `tracer-constraints/**`, `linea-besu/plugins/linea-sequencer/**`, `linea-besu/besu/**`, `linea-besu/package/**`, `gradle/libs.versions.toml` |
-| linea (milestone) | `coordinator\|linea-besu\|tracer\|sequencer\|maru\|prover\|postman\|tx-exclusion-api\|deps\|misc` | `linea` | the union of every component path above |
+| `coordinator` | `coordinator\|deps\|misc` | `coordinator` | `coordinator/**` |
+| `maru` | `maru\|deps\|misc` | `maru` | `maru/**` |
+| `postman` | `postman\|deps\|misc` | `postman` | `postman/**` |
+| `prover` | `prover\|deps\|misc` | `prover` | `prover/**` |
+| `tx-exclusion-api` | `tx-exclusion-api\|deps\|misc` | `tx-exclusion-api` | `transaction-exclusion-api/**` |
+| `linea-besu-package` | `linea-besu\|tracer\|sequencer\|deps\|misc` | `linea-besu-package` | `tracer/**`, `tracer-constraints/**`, `linea-besu/plugins/linea-sequencer/**`, `linea-besu/besu/**`, `linea-besu/package/**`, `gradle/libs.versions.toml` |
+| `linea` (milestone) | `coordinator\|linea-besu\|tracer\|sequencer\|maru\|prover\|postman\|tx-exclusion-api\|deps\|misc` | `linea` | the union of every component path above |
 
 Notes:
 

--- a/linea-besu/plugins/linea-sequencer/sequencer/build.gradle
+++ b/linea-besu/plugins/linea-sequencer/sequencer/build.gradle
@@ -39,6 +39,12 @@ dependencies {
   implementation "build.linea:blob-compressor:${libs.versions.blobCompressor.get()}"
   implementation "build.linea.internal:kotlin:${libs.versions.lineaKotlin.get()}"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:${libs.versions.kotlin.get()}"
+  // Used by LineaLivenessTxBuilder (org.web3j.crypto.*, abi.*, utils.Numeric). Declared
+  // explicitly so the jars are bundled into the plugin distribution; web3j otherwise only
+  // leaked onto the compile classpath transitively and was missing at runtime. 
+  // Version is intentionally omitted: the Besu BOM (on the plugin classpath) strictly pins
+  // web3j, so we align with the exact version Besu ships rather than fighting that constraint.
+  implementation "org.web3j:crypto"
 
   testImplementation 'org.assertj:assertj-core'
 


### PR DESCRIPTION
…to run e2e with locally built linea-besu-package

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Sequencer packaging and liveness transaction signing depend on the new web3j dependency alignment; incorrect bundling could affect sequencer nodes at runtime, though the change is narrowly scoped.
> 
> **Overview**
> Fixes **runtime failures** in the linea-besu sequencer plugin by declaring **`org.web3j:crypto`** as an explicit `implementation` dependency so it is included in the plugin distribution (it was only on the compile classpath transitively, which broke **`LineaLivenessTxBuilder`** at runtime). The version is left unpinned so it follows the Besu BOM.
> 
> Updates the **run-e2e-tests** action so that after loading a locally built **linea-besu-package** image from artifacts, **`LINEA_BESU_PACKAGE_TAG`** is written to **`GITHUB_ENV`**, letting Docker Compose pick the correct image tag during e2e instead of a default.
> 
> Minor **README** table tweak: backticks around component names in the git-cliff preview table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1d06c948e3a0a4d7a541f6037eaa617b14e182a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->