### PR TITLE
ci: only suppress coordinator-review findings from closed issues

### DIFF
--- a/.github/workflows/claude-coordinator-review.yml
+++ b/.github/workflows/claude-coordinator-review.yml
@@ -33,7 +33,10 @@ jobs:
             --repo "${{ github.repository }}" \
             --label "coordinator" \
             --label "claude-review" \
-            --state all \
+            # closed only: an open issue means the finding was never
+            # resolved, and suppressing on it would blind every future
+            # review to a live, unaddressed finding
+            --state closed \
             --limit 100 \
             --json body \
             --jq '.[].body' \
@@ -52,8 +55,9 @@ jobs:
           prompt: |
             Before starting your analysis, read the file `previous-findings.txt` in the
             repository root. It contains file:line references (e.g. `coordinator/src/.../Foo.kt:42`)
-            already reported in previous reviews. Skip any finding whose primary file:line location
-            appears in that file — do not re-report it even if the issue is still present.
+            from previous review issues that were CLOSED (i.e. resolved or explicitly declined).
+            Skip any finding whose primary file:line location appears in that file. Findings in
+            still-open issues are NOT in the list: re-report them while they remain unaddressed.
 
             You are reviewing the full Kotlin/JVM codebase in the `coordinator/` and
             `jvm-libs/` modules of the Lineth monorepo.


### PR DESCRIPTION
## Problem

The weekly coordinator security review builds its suppression list by grepping issue bodies with `--state all`:

```
gh issue list --label coordinator --label claude-review --state all ... > previous-findings.txt
```

The prompt then tells the agent to *"skip any finding whose primary file:line location appears in that file — do not re-report it even if the issue is still present."*

Because **open** issues are included, every finding the agent reports immediately suppresses itself: the issue is filed (open), its body contains the file:line, and every subsequent weekly review skips that location — *even if nobody ever fixes the underlying issue*. The review's coverage of live, unaddressed findings decays to zero over time.

## Fix

`--state closed`: suppression now keys on issues a human or process actually closed (resolved / won't-fix / false-positive). Findings in still-open issues are re-reported until someone acts on them — which is the point of a recurring review. The prompt text is updated to match.

## Notes

- No behavior change for closed findings.
- Line-number drift and free-text keying remain (a fuller design could key suppression on an explicit triage marker + commit SHA); this PR fixes the acute property with a minimal diff.

Made with Cursor

Made with [Cursor](https://cursor.com)