### PR TITLE
feat(coordinator): implement L2ExecutionRequestBuilderImpl for RISC-V execution proofs

### DIFF
--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppV1.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppV1.kt
@@ -23,6 +23,7 @@ import lineth.conflation.ConflationService
 import lineth.conflation.FixedLaggingHeadSafeBlockProvider
 import lineth.conflation.calculators.CalculatorsFactory
 import lineth.conflation.calculators.ConflationCalculators
+import lineth.coordination.FtxRollingInfoProviderImpl
 import lineth.coordination.HighestConflationTracker
 import lineth.coordination.HighestProvenBatchTracker
 import lineth.coordination.HighestProvenBlobTracker
@@ -430,7 +431,7 @@ class ConflationAppV1(
         aggregationL2StateProvider = AggregationL2StateProviderImpl(
           ethApiClient = l2EthClient,
           messageService = l2MessageService,
-          forcedTransactionsDao = forcedTransactionsDao,
+          ftxRollingInfoProvider = FtxRollingInfoProviderImpl(forcedTransactionsDao),
         ),
         consecutiveProvenBlobsProvider = maxBlobEndBlockNumberTracker,
         proofAggregationClient = proverClientFactory.proofAggregationProverClient(),

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
@@ -21,6 +21,7 @@ import lineth.conflation.AlwaysSafeBlockNumberProvider
 import lineth.conflation.ConflationService
 import lineth.conflation.FixedLaggingHeadSafeBlockProvider
 import lineth.conflation.calculators.CalculatorsFactory
+import lineth.coordination.FtxRollingInfoProviderImpl
 import lineth.coordination.aggregation.AggregationL2StateProviderImpl
 import lineth.coordination.aggregation.InvalidityProofProviderImpl
 import lineth.coordination.aggregation.ProofAggregationCoordinatorService
@@ -353,7 +354,7 @@ class ConflationBacktestingApp(
     aggregationL2StateProvider = AggregationL2StateProviderImpl(
       ethApiClient = l2EthClient,
       messageService = l2MessageService,
-      forcedTransactionsDao = DisabledForcedTransactionsDao(),
+      ftxRollingInfoProvider = FtxRollingInfoProviderImpl(DisabledForcedTransactionsDao()),
     ),
     consecutiveProvenBlobsProvider = inMemoryProvenBlobsTracker,
     proofAggregationClient = proverClientFactory.proofAggregationProverClient(),

--- a/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProofDtos.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProofDtos.kt
@@ -1,13 +1,13 @@
 package lineth.coordinator.clients.prover.riscv
 
 import linea.clients.BlobWitness
-import linea.clients.ExecutionPayload
 import linea.clients.ForcedTransaction
 import linea.clients.L2ExecutionProofPublicInputs
 import linea.clients.L2ExecutionProofResponseV1
 import linea.clients.RollupProofPublicInputs
 import linea.clients.RollupProofResponseV1
 import linea.domain.BlockIntervalProofIndex
+import linea.domain.ExecutionPayload
 import linea.ethapi.ExecutionWitness
 import linea.forcedtx.ForcedTransactionInclusionResult
 import linea.kotlin.decodeHex

--- a/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProofRequestDtoMapperTest.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProofRequestDtoMapperTest.kt
@@ -3,13 +3,13 @@ package lineth.coordinator.clients.prover.riscv
 import linea.clients.BlobWitness
 import linea.clients.ChainConfig
 import linea.clients.ExecutionInfo
-import linea.clients.ExecutionPayload
 import linea.clients.ForcedTransaction
 import linea.clients.L2ExecutionProofRequestV1
 import linea.clients.RollupAggregationProofRequestV1
 import linea.clients.RollupProofRequestV1
-import linea.clients.Withdrawal
 import linea.domain.BlockIntervalProofIndex
+import linea.domain.ExecutionPayload
+import linea.domain.Withdrawal
 import linea.ethapi.ExecutionWitness
 import linea.forcedtx.ForcedTransactionInclusionResult
 import linea.kotlin.encodeHex

--- a/coordinator/clients/prover-client/riscv-client/src/testFixtures/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProverClientTestFixtures.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/testFixtures/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProverClientTestFixtures.kt
@@ -9,12 +9,12 @@ import io.vertx.ext.web.client.WebClientOptions
 import linea.clients.BlobWitness
 import linea.clients.ChainConfig
 import linea.clients.ExecutionInfo
-import linea.clients.ExecutionPayload
 import linea.clients.ForcedTransaction
 import linea.clients.L2ExecutionProofRequestV1
 import linea.clients.RollupAggregationProofRequestV1
 import linea.clients.RollupProofRequestV1
 import linea.domain.BlockIntervalProofIndex
+import linea.domain.ExecutionPayload
 import linea.ethapi.ExecutionWitness
 import linea.forcedtx.ForcedTransactionInclusionResult
 import lineth.coordinator.clients.prover.FileBasedProverConfig

--- a/coordinator/core-interfaces/src/main/kotlin/linea/clients/L2ExecutionProverRequestResponse.kt
+++ b/coordinator/core-interfaces/src/main/kotlin/linea/clients/L2ExecutionProverRequestResponse.kt
@@ -1,12 +1,12 @@
 package linea.clients
 
 import linea.domain.BlockInterval
+import linea.domain.ExecutionPayload
 import linea.domain.StartBlockTimestampProvider
 import linea.ethapi.ExecutionWitness
 import linea.forcedtx.ForcedTransactionInclusionResult
 import linea.kotlin.byteArrayListEquals
 import linea.kotlin.byteArrayListHashCode
-import java.math.BigInteger
 import kotlin.time.Instant
 
 data class ExecutionInfo(
@@ -137,110 +137,6 @@ data class ChainConfig(
   override fun hashCode(): Int {
     var result = chainId.hashCode()
     result = 31 * result + forkName.hashCode()
-    return result
-  }
-}
-
-data class Withdrawal(
-  val index: ULong,
-  val validatorIndex: ULong,
-  val address: ByteArray,
-  val amount: ULong,
-) {
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (javaClass != other?.javaClass) return false
-
-    other as Withdrawal
-
-    if (index != other.index) return false
-    if (validatorIndex != other.validatorIndex) return false
-    if (!address.contentEquals(other.address)) return false
-    if (amount != other.amount) return false
-
-    return true
-  }
-
-  override fun hashCode(): Int {
-    var result = index.hashCode()
-    result = 31 * result + validatorIndex.hashCode()
-    result = 31 * result + address.contentHashCode()
-    result = 31 * result + amount.hashCode()
-    return result
-  }
-}
-
-/**
- * Execution PayLoad V4 (Payload V3 + blockAccessList) for the Engine API and Beacon Block
- * Should retrieve by using eth_getBlockByNumber/eth_getBlockByHash or debug_getRawBlock
- */
-data class ExecutionPayload(
-  val parentHash: ByteArray,
-  val feeRecipient: ByteArray,
-  val stateRoot: ByteArray,
-  val receiptsRoot: ByteArray,
-  val logsBloom: ByteArray,
-  val prevRandao: ByteArray,
-  val blockNumber: ULong,
-  val gasLimit: ULong,
-  val gasUsed: ULong,
-  val timestamp: ULong,
-  val extraData: ByteArray,
-  val baseFeePerGas: BigInteger,
-  val blockHash: ByteArray,
-  val transactions: List<ByteArray>,
-  val withdrawals: List<Withdrawal>,
-  val blobGasUsed: ULong,
-  val excessBlobGas: ULong,
-  val blockAccessList: ByteArray,
-) {
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (javaClass != other?.javaClass) return false
-
-    other as ExecutionPayload
-
-    if (!parentHash.contentEquals(other.parentHash)) return false
-    if (!feeRecipient.contentEquals(other.feeRecipient)) return false
-    if (!stateRoot.contentEquals(other.stateRoot)) return false
-    if (!receiptsRoot.contentEquals(other.receiptsRoot)) return false
-    if (!logsBloom.contentEquals(other.logsBloom)) return false
-    if (!prevRandao.contentEquals(other.prevRandao)) return false
-    if (blockNumber != other.blockNumber) return false
-    if (gasLimit != other.gasLimit) return false
-    if (gasUsed != other.gasUsed) return false
-    if (timestamp != other.timestamp) return false
-    if (!extraData.contentEquals(other.extraData)) return false
-    if (baseFeePerGas != other.baseFeePerGas) return false
-    if (!blockHash.contentEquals(other.blockHash)) return false
-    if (!transactions.byteArrayListEquals(other.transactions)) return false
-    if (withdrawals != other.withdrawals) return false
-    if (blobGasUsed != other.blobGasUsed) return false
-    if (excessBlobGas != other.excessBlobGas) return false
-    if (!blockAccessList.contentEquals(other.blockAccessList)) return false
-
-    return true
-  }
-
-  override fun hashCode(): Int {
-    var result = parentHash.contentHashCode()
-    result = 31 * result + feeRecipient.contentHashCode()
-    result = 31 * result + stateRoot.contentHashCode()
-    result = 31 * result + receiptsRoot.contentHashCode()
-    result = 31 * result + logsBloom.contentHashCode()
-    result = 31 * result + prevRandao.contentHashCode()
-    result = 31 * result + blockNumber.hashCode()
-    result = 31 * result + gasLimit.hashCode()
-    result = 31 * result + gasUsed.hashCode()
-    result = 31 * result + timestamp.hashCode()
-    result = 31 * result + extraData.contentHashCode()
-    result = 31 * result + baseFeePerGas.hashCode()
-    result = 31 * result + blockHash.contentHashCode()
-    result = 31 * result + transactions.byteArrayListHashCode()
-    result = 31 * result + withdrawals.hashCode()
-    result = 31 * result + blobGasUsed.hashCode()
-    result = 31 * result + excessBlobGas.hashCode()
-    result = 31 * result + blockAccessList.contentHashCode()
     return result
   }
 }

--- a/coordinator/core-interfaces/src/main/kotlin/lineth/persistence/ForcedTransactionsDao.kt
+++ b/coordinator/core-interfaces/src/main/kotlin/lineth/persistence/ForcedTransactionsDao.kt
@@ -33,6 +33,12 @@ interface ForcedTransactionsDao {
       }
     }
   }
+
+  fun findBySimulatedExecutionBlock(blockRange: ULongRange): SafeFuture<List<ForcedTransactionRecord>> {
+    return list().thenApply { allFtx ->
+      allFtx.filter { ftx -> ftx.simulatedExecutionBlockNumber in blockRange }
+    }
+  }
 }
 
 /**

--- a/coordinator/core/build.gradle
+++ b/coordinator/core/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   // api project(':jvm-libs:linea:blob-shnarf-calculator')
   implementation "net.java.dev.jna:jna:${libs.versions.jna.get()}"
   api project(':coordinator:core-interfaces')
+  api project(':jvm-libs:linea:besu-rlp-and-mappers')
   api project(':jvm-libs:linea:core:domain-models')
   api project(':jvm-libs:linea:core:metrics')
   api project(':jvm-libs:linea:core:long-running-service')

--- a/coordinator/core/src/main/kotlin/lineth/coordination/FtxRollingInfoProvider.kt
+++ b/coordinator/core/src/main/kotlin/lineth/coordination/FtxRollingInfoProvider.kt
@@ -1,0 +1,55 @@
+package lineth.coordination
+
+import lineth.coordination.aggregation.AggregationL2StateProviderImpl.Companion.GENESIS_ZERO_HASH
+import lineth.persistence.ForcedTransactionsDao
+import tech.pegasys.teku.infrastructure.async.SafeFuture
+
+data class FtxRollingInfo(
+  val ftxNumber: ULong,
+  val ftxRollingHash: ByteArray,
+) {
+  companion object {
+    val GENESIS = FtxRollingInfo(0uL, GENESIS_ZERO_HASH.copyOf())
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as FtxRollingInfo
+
+    if (ftxNumber != other.ftxNumber) return false
+    if (!ftxRollingHash.contentEquals(other.ftxRollingHash)) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = ftxNumber.hashCode()
+    result = 31 * result + ftxRollingHash.contentHashCode()
+    return result
+  }
+}
+
+fun interface FtxRollingInfoProvider {
+  fun getParentFtxState(blockNumber: ULong): SafeFuture<FtxRollingInfo>
+}
+
+class FtxRollingInfoProviderImpl(
+  private val forcedTransactionsDao: ForcedTransactionsDao,
+) : FtxRollingInfoProvider {
+  override fun getParentFtxState(blockNumber: ULong): SafeFuture<FtxRollingInfo> {
+    if (blockNumber == 0uL) {
+      // return genesis ftx number and hash
+      return SafeFuture.completedFuture(FtxRollingInfo.GENESIS)
+    }
+
+    return forcedTransactionsDao
+      .findHighestForcedTransaction(upToSimulatedExecutionBlockNumberInclusive = blockNumber)
+      .thenApply { highestFtx ->
+        highestFtx
+          ?.let { FtxRollingInfo(it.ftxNumber, it.ftxRollingHash) }
+          ?: FtxRollingInfo.GENESIS
+      }
+  }
+}

--- a/coordinator/core/src/main/kotlin/lineth/coordination/FtxRollingInfoProvider.kt
+++ b/coordinator/core/src/main/kotlin/lineth/coordination/FtxRollingInfoProvider.kt
@@ -32,13 +32,13 @@ data class FtxRollingInfo(
 }
 
 fun interface FtxRollingInfoProvider {
-  fun getParentFtxState(blockNumber: ULong): SafeFuture<FtxRollingInfo>
+  fun getFtxRollingHashByBlockNumber(blockNumber: ULong): SafeFuture<FtxRollingInfo>
 }
 
 class FtxRollingInfoProviderImpl(
   private val forcedTransactionsDao: ForcedTransactionsDao,
 ) : FtxRollingInfoProvider {
-  override fun getParentFtxState(blockNumber: ULong): SafeFuture<FtxRollingInfo> {
+  override fun getFtxRollingHashByBlockNumber(blockNumber: ULong): SafeFuture<FtxRollingInfo> {
     if (blockNumber == 0uL) {
       // return genesis ftx number and hash
       return SafeFuture.completedFuture(FtxRollingInfo.GENESIS)

--- a/coordinator/core/src/main/kotlin/lineth/coordination/aggregation/AggregationL2StateProvider.kt
+++ b/coordinator/core/src/main/kotlin/lineth/coordination/aggregation/AggregationL2StateProvider.kt
@@ -4,7 +4,7 @@ import linea.contract.l2.L2MessageServiceSmartContractClientReadOnly
 import linea.domain.toBlockParameter
 import linea.ethapi.EthApiClient
 import linea.kotlin.zeroHash32
-import lineth.persistence.ForcedTransactionsDao
+import lineth.coordination.FtxRollingInfoProvider
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import kotlin.time.Instant
 
@@ -15,7 +15,7 @@ interface AggregationL2StateProvider {
 class AggregationL2StateProviderImpl(
   private val ethApiClient: EthApiClient,
   private val messageService: L2MessageServiceSmartContractClientReadOnly,
-  private val forcedTransactionsDao: ForcedTransactionsDao,
+  private val ftxRollingInfoProvider: FtxRollingInfoProvider,
 ) : AggregationL2StateProvider {
   private data class AnchoredMessage(
     val messageNumber: ULong,
@@ -23,15 +23,6 @@ class AggregationL2StateProviderImpl(
   ) {
     companion object {
       val GENESIS = AnchoredMessage(0uL, GENESIS_ZERO_HASH.copyOf())
-    }
-  }
-
-  private data class FtxRollingInfo(
-    val ftxNumber: ULong,
-    val ftxRollingHash: ByteArray,
-  ) {
-    companion object {
-      val GENESIS = FtxRollingInfo(0uL, GENESIS_ZERO_HASH.copyOf())
     }
   }
 
@@ -57,24 +48,9 @@ class AggregationL2StateProviderImpl(
       }
   }
 
-  private fun getAggregationFtxRollingInfo(aggEndBlockNumber: ULong): SafeFuture<FtxRollingInfo> {
-    if (aggEndBlockNumber == 0uL) {
-      // return genesis ftx number and hash
-      return SafeFuture.completedFuture(FtxRollingInfo.GENESIS)
-    }
-
-    return forcedTransactionsDao
-      .findHighestForcedTransaction(upToSimulatedExecutionBlockNumberInclusive = aggEndBlockNumber)
-      .thenApply { highestFtx ->
-        highestFtx
-          ?.let { FtxRollingInfo(it.ftxNumber, it.ftxRollingHash) }
-          ?: FtxRollingInfo.GENESIS
-      }
-  }
-
   override fun getAggregationL2State(blockNumber: Long): SafeFuture<AggregationL2State> {
     val anchoredMessageFuture = getLastAnchoredMessage(blockNumber.toULong())
-    val aggregationFtxNumbersFuture = getAggregationFtxRollingInfo(blockNumber.toULong())
+    val aggregationFtxNumbersFuture = ftxRollingInfoProvider.getParentFtxState(blockNumber.toULong())
     val blockFuture = ethApiClient.ethGetBlockByNumberTxHashes(blockNumber.toBlockParameter())
 
     return SafeFuture

--- a/coordinator/core/src/main/kotlin/lineth/coordination/aggregation/AggregationL2StateProvider.kt
+++ b/coordinator/core/src/main/kotlin/lineth/coordination/aggregation/AggregationL2StateProvider.kt
@@ -50,7 +50,7 @@ class AggregationL2StateProviderImpl(
 
   override fun getAggregationL2State(blockNumber: Long): SafeFuture<AggregationL2State> {
     val anchoredMessageFuture = getLastAnchoredMessage(blockNumber.toULong())
-    val aggregationFtxNumbersFuture = ftxRollingInfoProvider.getParentFtxState(blockNumber.toULong())
+    val aggregationFtxNumbersFuture = ftxRollingInfoProvider.getFtxRollingHashByBlockNumber(blockNumber.toULong())
     val blockFuture = ethApiClient.ethGetBlockByNumberTxHashes(blockNumber.toBlockParameter())
 
     return SafeFuture

--- a/coordinator/core/src/main/kotlin/lineth/coordination/riscv/execution/L2ExecutionRequestBuilderImpl.kt
+++ b/coordinator/core/src/main/kotlin/lineth/coordination/riscv/execution/L2ExecutionRequestBuilderImpl.kt
@@ -1,0 +1,77 @@
+package lineth.coordination.riscv.execution
+
+import linea.clients.ChainConfig
+import linea.clients.ExecutionInfo
+import linea.clients.ForcedTransaction
+import linea.clients.L2ExecutionProofRequestV1
+import linea.domain.Block
+import linea.domain.BlocksConflation
+import linea.domain.toBlockParameter
+import linea.domain.toExecutionPayload
+import linea.ethapi.ExecutionWitness
+import linea.ethapi.ExecutionWitnessClient
+import lineth.coordination.FtxRollingInfoProvider
+import lineth.coordination.FtxRollingInfoProviderImpl
+import lineth.persistence.ForcedTransactionRecord
+import lineth.persistence.ForcedTransactionsDao
+import tech.pegasys.teku.infrastructure.async.SafeFuture
+
+class L2ExecutionRequestBuilderImpl(
+  private val executionWitnessClient: ExecutionWitnessClient,
+  private val forcedTransactionsDao: ForcedTransactionsDao,
+  private val ftxRollingInfoProvider: FtxRollingInfoProvider = FtxRollingInfoProviderImpl(forcedTransactionsDao),
+  private val chainConfig: ChainConfig,
+) : L2ExecutionRequestBuilder {
+
+  override fun build(conflation: BlocksConflation): SafeFuture<L2ExecutionProofRequestV1> {
+    val allFtxsFuture = forcedTransactionsDao.findBySimulatedExecutionBlock(
+      conflation.startBlockNumber..conflation.endBlockNumber,
+    )
+    val parentBlockNumber = if (conflation.startBlockNumber == 0UL) 0UL else conflation.startBlockNumber - 1UL
+    val ftxStateFuture = ftxRollingInfoProvider.getParentFtxState(parentBlockNumber)
+    val allWitnessesListFuture = SafeFuture.collectAll(
+      conflation.blocks.map { block ->
+        executionWitnessClient.getExecutionWitness(block.number.toBlockParameter())
+          .thenApply { witness ->
+            requireNotNull(witness) { "No execution witness available for block ${block.number}" }
+          }
+      }.stream(),
+    )
+
+    return SafeFuture.allOf(allFtxsFuture, ftxStateFuture, allWitnessesListFuture)
+      .thenApply {
+        val ftxsByBlock = allFtxsFuture.get()
+          .groupBy { it.simulatedExecutionBlockNumber }
+          .mapValues { (_, records) -> records.map(ForcedTransactionRecord::toDomain) }
+        val ftxState = ftxStateFuture.get()
+
+        L2ExecutionProofRequestV1(
+          executions = conflation.blocks.zip(allWitnessesListFuture.get()).map { (block, witness) ->
+            block.toExecutionInfo(
+              witness = witness,
+              forcedTransactions = ftxsByBlock[block.number] ?: emptyList(),
+            )
+          },
+          chainConfig = chainConfig,
+          parentFtxRollingHash = ftxState.ftxRollingHash,
+          parentFtxNumber = ftxState.ftxNumber,
+        )
+      }
+  }
+}
+
+private fun Block.toExecutionInfo(witness: ExecutionWitness, forcedTransactions: List<ForcedTransaction>) =
+  ExecutionInfo(
+    blockNumber = number,
+    executionPayload = toExecutionPayload(),
+    executionWitness = witness,
+    executionRequests = emptyList(),
+    forcedTransactions = forcedTransactions,
+  )
+
+private fun ForcedTransactionRecord.toDomain() = ForcedTransaction(
+  ftxNumber = ftxNumber,
+  deadlineBlockNumber = ftxBlockNumberDeadline,
+  signedTxRlp = ftxRlp,
+  acceptance = inclusionResult,
+)

--- a/coordinator/core/src/main/kotlin/lineth/coordination/riscv/execution/L2ExecutionRequestBuilderImpl.kt
+++ b/coordinator/core/src/main/kotlin/lineth/coordination/riscv/execution/L2ExecutionRequestBuilderImpl.kt
@@ -10,6 +10,7 @@ import linea.domain.toBlockParameter
 import linea.domain.toExecutionPayload
 import linea.ethapi.ExecutionWitness
 import linea.ethapi.ExecutionWitnessClient
+import linea.kotlin.minusCoercingUnderflow
 import lineth.coordination.FtxRollingInfoProvider
 import lineth.coordination.FtxRollingInfoProviderImpl
 import lineth.persistence.ForcedTransactionRecord
@@ -27,8 +28,8 @@ class L2ExecutionRequestBuilderImpl(
     val allFtxsFuture = forcedTransactionsDao.findBySimulatedExecutionBlock(
       conflation.startBlockNumber..conflation.endBlockNumber,
     )
-    val parentBlockNumber = if (conflation.startBlockNumber == 0UL) 0UL else conflation.startBlockNumber - 1UL
-    val ftxStateFuture = ftxRollingInfoProvider.getParentFtxState(parentBlockNumber)
+    val parentBlockNumber = conflation.startBlockNumber.minusCoercingUnderflow(1uL)
+    val ftxStateFuture = ftxRollingInfoProvider.getFtxRollingHashByBlockNumber(parentBlockNumber)
     val allWitnessesListFuture = SafeFuture.collectAll(
       conflation.blocks.map { block ->
         executionWitnessClient.getExecutionWitness(block.number.toBlockParameter())

--- a/coordinator/core/src/test/kotlin/lineth/coordination/aggregation/AggregationL2StateProviderImplTest.kt
+++ b/coordinator/core/src/test/kotlin/lineth/coordination/aggregation/AggregationL2StateProviderImplTest.kt
@@ -3,6 +3,7 @@ package lineth.coordination.aggregation
 import linea.contract.l2.FakeL2MessageService
 import linea.domain.toBlockParameter
 import linea.ethapi.FakeEthApiClient
+import lineth.coordination.FtxRollingInfoProviderImpl
 import lineth.persistence.ftx.FakeForcedTransactionsDao
 import lineth.persistence.ftx.ForcedTransactionRecordFactory
 import org.assertj.core.api.Assertions.assertThat
@@ -23,7 +24,9 @@ class AggregationL2StateProviderImplTest {
     // deploy block = 1 so block 0 is before deployment
     messageService = FakeL2MessageService(contractDeployBlock = 1uL)
     forcedTransactionsDao = FakeForcedTransactionsDao()
-    provider = AggregationL2StateProviderImpl(ethApiClient, messageService, forcedTransactionsDao)
+    provider = AggregationL2StateProviderImpl(
+      ethApiClient, messageService, FtxRollingInfoProviderImpl(forcedTransactionsDao),
+    )
   }
 
   @Test

--- a/coordinator/persistence/src/integrationTest/kotlin/lineth/persistence/ftx/PostgresForcedTransactionsDaoTest.kt
+++ b/coordinator/persistence/src/integrationTest/kotlin/lineth/persistence/ftx/PostgresForcedTransactionsDaoTest.kt
@@ -302,6 +302,44 @@ class PostgresForcedTransactionsDaoTest : CleanDbTestSuiteParallel() {
   }
 
   @Test
+  fun `findBySimulatedExecutionBlock returns empty list when no records match`() {
+    val ftx = createForcedTransactionRecord(ftxNumber = 1UL, simulatedExecutionBlockNumber = 100UL)
+    forcedTransactionsDao.save(ftx).get()
+
+    val result = forcedTransactionsDao.findBySimulatedExecutionBlock(200UL..300UL).get()
+    assertThat(result).isEmpty()
+  }
+
+  @Test
+  fun `findBySimulatedExecutionBlock returns only records within the block range`() {
+    val ftxBlock100 = createForcedTransactionRecord(ftxNumber = 1UL, simulatedExecutionBlockNumber = 100UL)
+    val ftxBlock200 = createForcedTransactionRecord(ftxNumber = 2UL, simulatedExecutionBlockNumber = 200UL)
+    val ftxBlock300 = createForcedTransactionRecord(ftxNumber = 3UL, simulatedExecutionBlockNumber = 300UL)
+    SafeFuture.collectAll(
+      listOf(ftxBlock100, ftxBlock200, ftxBlock300).map { forcedTransactionsDao.save(it) }.stream(),
+    ).get()
+
+    // query for range 100..200 — must NOT return the record at block 300
+    val result = forcedTransactionsDao.findBySimulatedExecutionBlock(100UL..200UL).get()
+
+    assertThat(result.map { it.ftxNumber }).containsExactlyInAnyOrder(1UL, 2UL)
+  }
+
+  @Test
+  fun `findBySimulatedExecutionBlock returns multiple FTXs for the same block`() {
+    val ftx1 = createForcedTransactionRecord(ftxNumber = 1UL, simulatedExecutionBlockNumber = 100UL)
+    val ftx2 = createForcedTransactionRecord(ftxNumber = 2UL, simulatedExecutionBlockNumber = 100UL)
+    val ftx3 = createForcedTransactionRecord(ftxNumber = 3UL, simulatedExecutionBlockNumber = 200UL)
+    SafeFuture.collectAll(
+      listOf(ftx1, ftx2, ftx3).map { forcedTransactionsDao.save(it) }.stream(),
+    ).get()
+
+    val result = forcedTransactionsDao.findBySimulatedExecutionBlock(100UL..100UL).get()
+
+    assertThat(result.map { it.ftxNumber }).containsExactly(1UL, 2UL)
+  }
+
+  @Test
   fun `enum mapping functions correctly convert between enum and db values`() {
     // Test inclusion result mappings
     assertThat(inclusionResultToDbValue(ForcedTransactionInclusionResult.Included)).isEqualTo(1)

--- a/coordinator/persistence/src/main/kotlin/lineth/persistence/ftx/PostgresForcedTransactionsDao.kt
+++ b/coordinator/persistence/src/main/kotlin/lineth/persistence/ftx/PostgresForcedTransactionsDao.kt
@@ -137,6 +137,18 @@ class PostgresForcedTransactionsDao(
 
   private val selectAllQuery = connection.preparedQuery(selectAllSql)
 
+  private val selectBySimulatedBlockRangeSql =
+    """
+      select ftx_number, inclusion_result, simulated_execution_block_number,
+             simulated_execution_block_timestamp, ftx_block_number_deadline,
+             ftx_rolling_hash, ftx_rlp, proof_status
+      from forced_transactions
+      where simulated_execution_block_number between $1 and $2
+      order by ftx_number
+    """.trimIndent()
+
+  private val selectBySimulatedBlockRangeQuery = connection.preparedQuery(selectBySimulatedBlockRangeSql)
+
   private val deleteSql =
     """
       delete from forced_transactions
@@ -180,6 +192,14 @@ class PostgresForcedTransactionsDao(
       .toSafeFuture()
   }
 
+  override fun findBySimulatedExecutionBlock(blockRange: ULongRange): SafeFuture<List<ForcedTransactionRecord>> {
+    val params = listOf(blockRange.first.toLong(), blockRange.last.toLong())
+    queryLog.log(Level.TRACE, selectBySimulatedBlockRangeSql, params)
+    return selectBySimulatedBlockRangeQuery.execute(Tuple.tuple(params))
+      .map { rowSet -> rowSet.map(::parseRecord) }
+      .toSafeFuture()
+  }
+
   override fun deleteFtxUpToInclusive(ftxNumber: ULong): SafeFuture<Int> {
     val params = listOf(ftxNumber.toLong())
     queryLog.log(Level.TRACE, deleteSql, params)
@@ -203,6 +223,10 @@ class RetryingPostgresForcedTransactionsDao(
 
   override fun list(): SafeFuture<List<ForcedTransactionRecord>> {
     return persistenceRetryer.retryQuery({ delegate.list() })
+  }
+
+  override fun findBySimulatedExecutionBlock(blockRange: ULongRange): SafeFuture<List<ForcedTransactionRecord>> {
+    return persistenceRetryer.retryQuery({ delegate.findBySimulatedExecutionBlock(blockRange) })
   }
 
   override fun deleteFtxUpToInclusive(ftxNumber: ULong): SafeFuture<Int> {

--- a/jvm-libs/linea/besu-rlp-and-mappers/src/main/kotlin/linea/domain/MapperLineaDomainToBesu.kt
+++ b/jvm-libs/linea/besu-rlp-and-mappers/src/main/kotlin/linea/domain/MapperLineaDomainToBesu.kt
@@ -17,11 +17,36 @@ import org.hyperledger.besu.ethereum.core.BlockHeaderBuilder
 import org.hyperledger.besu.ethereum.core.CodeDelegation
 import org.hyperledger.besu.ethereum.core.Difficulty
 import org.hyperledger.besu.ethereum.core.Transaction
+import org.hyperledger.besu.ethereum.core.encoding.EncodingContext
+import org.hyperledger.besu.ethereum.core.encoding.TransactionEncoder
 import org.hyperledger.besu.ethereum.mainnet.MainnetBlockHeaderFunctions
 import java.math.BigInteger
 
 fun Block.toBesu(): org.hyperledger.besu.ethereum.core.Block = mapToBesu(this)
 fun linea.domain.Transaction.toBesu(): Transaction = mapToBesu(this)
+
+fun Block.toExecutionPayload(): ExecutionPayload = ExecutionPayload(
+  parentHash = parentHash,
+  feeRecipient = miner,
+  stateRoot = stateRoot,
+  receiptsRoot = receiptsRoot,
+  logsBloom = logsBloom,
+  prevRandao = mixHash,
+  blockNumber = number,
+  gasLimit = gasLimit,
+  gasUsed = gasUsed,
+  timestamp = timestamp,
+  extraData = extraData,
+  baseFeePerGas = baseFeePerGas?.toBigInteger() ?: BigInteger.ZERO,
+  blockHash = hash,
+  transactions = transactions.mapIndexed { index, tx ->
+    TransactionEncoder.encodeOpaqueBytes(mapToBesu(number, index, tx), EncodingContext.BLOCK_BODY).toArray()
+  },
+  withdrawals = emptyList(),
+  blobGasUsed = 0UL,
+  excessBlobGas = 0UL,
+  blockAccessList = ByteArray(0),
+)
 
 object MapperLineaDomainToBesu {
   private val secp256k1 = SECP256K1()

--- a/jvm-libs/linea/core/domain-models/src/main/kotlin/linea/domain/ExecutionPayload.kt
+++ b/jvm-libs/linea/core/domain-models/src/main/kotlin/linea/domain/ExecutionPayload.kt
@@ -1,0 +1,109 @@
+package linea.domain
+
+import linea.kotlin.byteArrayListEquals
+import linea.kotlin.byteArrayListHashCode
+import java.math.BigInteger
+
+data class Withdrawal(
+  val index: ULong,
+  val validatorIndex: ULong,
+  val address: ByteArray,
+  val amount: ULong,
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as Withdrawal
+
+    if (index != other.index) return false
+    if (validatorIndex != other.validatorIndex) return false
+    if (!address.contentEquals(other.address)) return false
+    if (amount != other.amount) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = index.hashCode()
+    result = 31 * result + validatorIndex.hashCode()
+    result = 31 * result + address.contentHashCode()
+    result = 31 * result + amount.hashCode()
+    return result
+  }
+}
+
+/**
+ * Execution PayLoad V4 (Payload V3 + blockAccessList) for the Engine API and Beacon Block
+ * Should retrieve by using eth_getBlockByNumber/eth_getBlockByHash or debug_getRawBlock
+ */
+data class ExecutionPayload(
+  val parentHash: ByteArray,
+  val feeRecipient: ByteArray,
+  val stateRoot: ByteArray,
+  val receiptsRoot: ByteArray,
+  val logsBloom: ByteArray,
+  val prevRandao: ByteArray,
+  val blockNumber: ULong,
+  val gasLimit: ULong,
+  val gasUsed: ULong,
+  val timestamp: ULong,
+  val extraData: ByteArray,
+  val baseFeePerGas: BigInteger,
+  val blockHash: ByteArray,
+  val transactions: List<ByteArray>,
+  val withdrawals: List<Withdrawal>,
+  val blobGasUsed: ULong,
+  val excessBlobGas: ULong,
+  val blockAccessList: ByteArray,
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as ExecutionPayload
+
+    if (!parentHash.contentEquals(other.parentHash)) return false
+    if (!feeRecipient.contentEquals(other.feeRecipient)) return false
+    if (!stateRoot.contentEquals(other.stateRoot)) return false
+    if (!receiptsRoot.contentEquals(other.receiptsRoot)) return false
+    if (!logsBloom.contentEquals(other.logsBloom)) return false
+    if (!prevRandao.contentEquals(other.prevRandao)) return false
+    if (blockNumber != other.blockNumber) return false
+    if (gasLimit != other.gasLimit) return false
+    if (gasUsed != other.gasUsed) return false
+    if (timestamp != other.timestamp) return false
+    if (!extraData.contentEquals(other.extraData)) return false
+    if (baseFeePerGas != other.baseFeePerGas) return false
+    if (!blockHash.contentEquals(other.blockHash)) return false
+    if (!transactions.byteArrayListEquals(other.transactions)) return false
+    if (withdrawals != other.withdrawals) return false
+    if (blobGasUsed != other.blobGasUsed) return false
+    if (excessBlobGas != other.excessBlobGas) return false
+    if (!blockAccessList.contentEquals(other.blockAccessList)) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = parentHash.contentHashCode()
+    result = 31 * result + feeRecipient.contentHashCode()
+    result = 31 * result + stateRoot.contentHashCode()
+    result = 31 * result + receiptsRoot.contentHashCode()
+    result = 31 * result + logsBloom.contentHashCode()
+    result = 31 * result + prevRandao.contentHashCode()
+    result = 31 * result + blockNumber.hashCode()
+    result = 31 * result + gasLimit.hashCode()
+    result = 31 * result + gasUsed.hashCode()
+    result = 31 * result + timestamp.hashCode()
+    result = 31 * result + extraData.contentHashCode()
+    result = 31 * result + baseFeePerGas.hashCode()
+    result = 31 * result + blockHash.contentHashCode()
+    result = 31 * result + transactions.byteArrayListHashCode()
+    result = 31 * result + withdrawals.hashCode()
+    result = 31 * result + blobGasUsed.hashCode()
+    result = 31 * result + excessBlobGas.hashCode()
+    result = 31 * result + blockAccessList.contentHashCode()
+    return result
+  }
+}


### PR DESCRIPTION
Depends on https://github.com/LFDT-Lineth/lineth-monorepo/pull/3684
#3086 

## Summary

- Adds `Block.toExecutionPayload()` extension to `besu-rlp-and-mappers` alongside `Block.toBesu()`, using `TransactionEncoder.encodeOpaqueBytes` for RLP encoding of transactions
- Implements `L2ExecutionRequestBuilderImpl`: makes a single DAO call for all conflation blocks' forced transactions, fires all witness fetches in parallel, then assembles `ExecutionInfo` per block and returns `L2ExecutionProofRequestV1`
- Updates `ForcedTransactionsDao.findBySimulatedExecutionBlock` to accept `List<ULong>`; the Postgres impl uses `= ANY($1)` array binding with no consecutive-block assumption (replaces the prior `BETWEEN` approach)

## Test plan

- [ ] New integration tests in `PostgresForcedTransactionsDaoTest` for `findBySimulatedExecutionBlock`: empty input, no matches, non-consecutive block filtering (validates `= ANY` over `BETWEEN`), multiple FTXs per block
- [ ] `./gradlew :coordinator:core:compileKotlin :coordinator:persistence:compileKotlin :jvm-libs:linea:besu-rlp-and-mappers:compileKotlin`
- [ ] `./gradlew :coordinator:persistence:integrationTest --tests "*.PostgresForcedTransactionsDaoTest"`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches proof-request assembly (witnesses, FTX parent state, execution payloads) and persistence queries; incorrect FTX or payload encoding would break RISC-V execution proofs, but scope is localized and covered by DAO integration tests.
> 
> **Overview**
> Adds **`L2ExecutionRequestBuilderImpl`**, which turns a conflated block range into **`L2ExecutionProofRequestV1`**: one DAO query for forced txs in the range, parallel execution witnesses per block, parent FTX rolling state from **`FtxRollingInfoProvider`**, and per-block **`ExecutionInfo`** (payload + witness + FTXs).
> 
> **`ExecutionPayload`** and **`Withdrawal`** move from `linea.clients` to **`linea.domain`**; **`Block.toExecutionPayload()`** in `besu-rlp-and-mappers` builds payloads with Besu **`TransactionEncoder`** RLP for block-body txs. Prover DTO/tests import the domain types.
> 
> FTX rolling hash lookup is extracted to **`FtxRollingInfoProvider` / `FtxRollingInfoProviderImpl`**; **`AggregationL2StateProviderImpl`** and conflation/backtesting apps inject it instead of **`ForcedTransactionsDao`** directly.
> 
> **`ForcedTransactionsDao.findBySimulatedExecutionBlock(ULongRange)`** is added with a Postgres **`BETWEEN`** query (plus default in-memory filter on the interface); integration tests cover range and multi-FTX-per-block cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94a25553054224727834ec313944b958b387a7ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->