### PR TITLE
chore(maru): package renaming to lineth.*

### DIFF
--- a/maru/utils/build.gradle
+++ b/maru/utils/build.gradle
@@ -33,12 +33,12 @@ dependencies {
 
 tasks.register('runDifficultyCalculator', JavaExec) {
   classpath = sourceSets.main.runtimeClasspath
-  mainClass = 'linea.maru.DifficultyCalculator'
+  mainClass = 'lineth.maru.DifficultyCalculator'
   standardOutput = System.out
 }
 
 tasks.register('keytool', JavaExec) {
   classpath = sourceSets.main.runtimeClasspath
-  mainClass = 'linea.maru.KeyTool'
+  mainClass = 'lineth.maru.KeyTool'
   standardOutput = System.out
 }

--- a/maru/utils/src/main/kotlin/lineth/maru/DifficultyCalculator.kt
+++ b/maru/utils/src/main/kotlin/lineth/maru/DifficultyCalculator.kt
@@ -6,7 +6,7 @@
  *
  * SPDX-License-Identifier: MIT OR Apache-2.0
  */
-package linea.maru
+package lineth.maru
 
 /**
  * Utility tool to compute the expected difficulty at a given time for Clique blocks.

--- a/maru/utils/src/main/kotlin/lineth/maru/KeyTool.kt
+++ b/maru/utils/src/main/kotlin/lineth/maru/KeyTool.kt
@@ -6,7 +6,7 @@
  *
  * SPDX-License-Identifier: MIT OR Apache-2.0
  */
-package linea.maru
+package lineth.maru
 
 import linea.kotlin.decodeHex
 import maru.crypto.PrivateKeyGenerator


### PR DESCRIPTION
…, net.consensys.linea.*, net.consensys.*, build.linea.*, linea.*)

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical package and main-class renames for dev utilities; no logic or security-sensitive changes in the diff.
> 
> **Overview**
> Renames the **maru utils** CLI entrypoints from `linea.maru` to **`lineth.maru`**, matching the broader `lineth.*` package migration.
> 
> `DifficultyCalculator` and `KeyTool` now live under the `lineth.maru` package, and the Gradle `runDifficultyCalculator` and `keytool` tasks point their `mainClass` at the new names. Behavior of the tools is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 606dcb8ae38cd18fc8baa7859bcec7cea47142fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->