### PR TITLE
chore(e2e): fix e2e test plugin reload

### DIFF
--- a/e2e/src/config/clients/linea-rpc/sequencer-plugins.ts
+++ b/e2e/src/config/clients/linea-rpc/sequencer-plugins.ts
@@ -1,4 +1,4 @@
 export const SequencerPluginName = {
-  TransactionPoolValidator: "net.consensys.linea.sequencer.txpoolvalidation.LineaTransactionPoolValidatorPlugin",
-  TransactionSelector: "net.consensys.linea.sequencer.txselection.LineaTransactionSelectorPlugin",
+  TransactionPoolValidator: "lineth.sequencer.txpoolvalidation.LineaTransactionPoolValidatorPlugin",
+  TransactionSelector: "lineth.sequencer.txselection.LineaTransactionSelectorPlugin",
 } as const;


### PR DESCRIPTION
This PR implements issue(s) #3289 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only constant updates with no production runtime or security impact; aligns e2e with existing plugin package names.
> 
> **Overview**
> Updates **e2e** sequencer plugin identifiers in `sequencer-plugins.ts` so `pluginsReloadPluginConfig` targets the current Besu plugin classes after the **`net.consensys.linea.sequencer`** → **`lineth.sequencer`** package move.
> 
> `TransactionPoolValidator` and `TransactionSelector` now use `lineth.sequencer.txpoolvalidation.LineaTransactionPoolValidatorPlugin` and `lineth.sequencer.txselection.LineaTransactionSelectorPlugin`, fixing deny-list and related e2e flows that reload those plugins (issue #3289).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1a60166f66f8e6223f12db35aff2b395e060381. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->