### PR TITLE
feat(ci): add option to skip e2e test on release workflows

### DIFF
--- a/.github/workflows/coordinator-release.yml
+++ b/.github/workflows/coordinator-release.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: boolean
         default: false
+      skip_e2e_test:
+        description: 'Skip the run of e2e test'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: coordinator-release-${{ github.ref }}
@@ -43,4 +48,5 @@ jobs:
       release_tag_suffix: ${{ inputs.release_tag_suffix }}
       draft_release: ${{ !inputs.pre_release }}
       pre_release: ${{ inputs.pre_release }}
+      skip_e2e_test: ${{ inputs.skip_e2e_test }}
     secrets: inherit

--- a/.github/workflows/linea-besu-release.yml
+++ b/.github/workflows/linea-besu-release.yml
@@ -30,6 +30,11 @@ on:
         required: false
         type: boolean
         default: false
+      skip_e2e_test:
+        description: 'Skip the run of e2e test'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: linea-besu-release-${{ github.ref }}
@@ -104,7 +109,10 @@ jobs:
 
   run-e2e-tests:
     needs: [ build-and-upload-artifact ]
-    if: always() && !cancelled() && needs.build-and-upload-artifact.result == 'success'
+    if: >
+      always() && !cancelled() &&
+      needs.build-and-upload-artifact.result == 'success' &&
+      !inputs.skip_e2e_test
     concurrency:
       group: run-e2e-tests-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -117,7 +125,11 @@ jobs:
 
   push-tag-update-changelog-and-gh-release:
     needs: [run-test, run-e2e-tests]
-    if: always() && !cancelled() && needs.run-test.result == 'success' && needs.run-e2e-tests.result == 'success'
+    if: >
+      always() && !cancelled() &&
+      needs.run-test.result == 'success' &&
+      (needs.run-e2e-tests.result == 'success' ||
+       (needs.run-e2e-tests.result == 'skipped' && inputs.skip_e2e_test))
     uses: ./.github/workflows/reusable-linea-besu-package-gh-release.yml
     with:
       image_tag_suffix: ${{ inputs.image_tag_suffix }}

--- a/.github/workflows/maru-release.yml
+++ b/.github/workflows/maru-release.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: boolean
         default: false
+      skip_e2e_test:
+        description: 'Skip the run of e2e test'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: maru-release-${{ github.ref }}
@@ -43,4 +48,5 @@ jobs:
       release_tag_suffix: ${{ inputs.release_tag_suffix }}
       draft_release: ${{ !inputs.pre_release }}
       pre_release: ${{ inputs.pre_release }}
+      skip_e2e_test: ${{ inputs.skip_e2e_test }}
     secrets: inherit

--- a/.github/workflows/postman-release.yml
+++ b/.github/workflows/postman-release.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: boolean
         default: false
+      skip_e2e_test:
+        description: 'Skip the run of e2e test'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: postman-release-${{ github.ref }}
@@ -43,4 +48,5 @@ jobs:
       release_tag_suffix: ${{ inputs.release_tag_suffix }}
       draft_release: ${{ !inputs.pre_release }}
       pre_release: ${{ inputs.pre_release }}
+      skip_e2e_test: ${{ inputs.skip_e2e_test }}
     secrets: inherit

--- a/.github/workflows/prover-release.yml
+++ b/.github/workflows/prover-release.yml
@@ -25,6 +25,11 @@ on:
         required: false
         type: boolean
         default: false
+      skip_e2e_test:
+        description: 'Skip the run of e2e test'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: prover-release-${{ github.ref }}
@@ -44,4 +49,5 @@ jobs:
       release_tag_suffix: ${{ inputs.release_tag_suffix }}
       draft_release: ${{ !inputs.pre_release }}
       pre_release: ${{ inputs.pre_release }}
+      skip_e2e_test: ${{ inputs.skip_e2e_test }}
     secrets: inherit

--- a/.github/workflows/reusable-component-release.yml
+++ b/.github/workflows/reusable-component-release.yml
@@ -152,6 +152,7 @@ jobs:
     if: >
       always() && !cancelled() &&
       needs.compute-release-metadata.outputs.tag_changed == 'true' &&
+      !inputs.skip_e2e_test &&
       inputs.component-name == 'coordinator' &&
       (github.ref_name == 'main' || needs.run-test-coordinator.result == 'success')
     uses: ./.github/workflows/coordinator-build-and-publish.yml
@@ -166,6 +167,7 @@ jobs:
     if: >
       always() && !cancelled() &&
       needs.compute-release-metadata.outputs.tag_changed == 'true' &&
+      !inputs.skip_e2e_test &&
       inputs.component-name == 'postman' &&
       (github.ref_name == 'main' || needs.run-test-postman.result == 'success')
     uses: ./.github/workflows/postman-build-and-publish.yml
@@ -180,6 +182,7 @@ jobs:
     if: >
       always() && !cancelled() &&
       needs.compute-release-metadata.outputs.tag_changed == 'true' &&
+      !inputs.skip_e2e_test &&
       inputs.component-name == 'prover' &&
       (github.ref_name == 'main' || needs.run-test-prover.result == 'success')
     uses: ./.github/workflows/prover-build-and-publish.yml
@@ -194,6 +197,7 @@ jobs:
     if: >
       always() && !cancelled() &&
       needs.compute-release-metadata.outputs.tag_changed == 'true' &&
+      !inputs.skip_e2e_test &&
       inputs.component-name == 'maru' &&
       (github.ref_name == 'main' || needs.run-test-maru.result == 'success')
     uses: ./.github/workflows/maru-build-and-publish.yml
@@ -208,6 +212,7 @@ jobs:
     if: >
       always() && !cancelled() &&
       needs.compute-release-metadata.outputs.tag_changed == 'true' &&
+      !inputs.skip_e2e_test &&
       inputs.component-name == 'tx-exclusion-api' &&
       (github.ref_name == 'main' || needs.run-test-transaction-exclusion-api.result == 'success')
     uses: ./.github/workflows/transaction-exclusion-api-build-and-publish.yml

--- a/.github/workflows/reusable-component-release.yml
+++ b/.github/workflows/reusable-component-release.yml
@@ -45,6 +45,11 @@ on:
         required: false
         type: boolean
         default: false
+      skip_e2e_test:
+        description: 'Skip the run-e2e-tests job'
+        required: false
+        type: boolean
+        default: false
     outputs:
       tag_changed:
         description: "Indicate whether the release tag of the component has changed"
@@ -217,6 +222,7 @@ jobs:
     if: >
       always() && !cancelled() &&
       needs.compute-release-metadata.outputs.tag_changed == 'true' &&
+      !inputs.skip_e2e_test &&
       (needs.build-local-coordinator.result       == 'success' ||
        needs.build-local-postman.result           == 'success' ||
        needs.build-local-prover.result            == 'success' ||
@@ -231,8 +237,12 @@ jobs:
     secrets: inherit
 
   push-tag-update-changelog-and-gh-release:
-    needs: [run-e2e-tests]
-    if: always() && !cancelled() && needs.run-e2e-tests.result == 'success'
+    needs: [compute-release-metadata, run-e2e-tests]
+    if: >
+      always() && !cancelled() &&
+      needs.compute-release-metadata.outputs.tag_changed == 'true' &&
+      (needs.run-e2e-tests.result == 'success' ||
+       (needs.run-e2e-tests.result == 'skipped' && inputs.skip_e2e_test))
     uses: ./.github/workflows/reusable-component-gh-release.yml
     with:
       component-name: ${{ inputs.component-name }}

--- a/.github/workflows/tx-exclusion-api-release.yml
+++ b/.github/workflows/tx-exclusion-api-release.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: boolean
         default: false
+      skip_e2e_test:
+        description: 'Skip the run of e2e test'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: tx-exclusion-api-release-${{ github.ref }}
@@ -44,4 +49,5 @@ jobs:
       release_tag_suffix: ${{ inputs.release_tag_suffix }}
       draft_release: ${{ !inputs.pre_release }}
       pre_release: ${{ inputs.pre_release }}
+      skip_e2e_test: ${{ inputs.skip_e2e_test }}
     secrets: inherit

--- a/transaction-exclusion-api/CHANGELOG.md
+++ b/transaction-exclusion-api/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [unreleased]
+## [1.0.1-test] - 2026-08-11
 
 ### 🚜 Refactor
 

--- a/transaction-exclusion-api/CHANGELOG.md
+++ b/transaction-exclusion-api/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [1.0.1-test] - 2026-08-11
+## [unreleased]
 
 ### 🚜 Refactor
 


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in CI change that can bypass the e2e quality gate on releases. Default remains run-e2e, but misuse could ship untested artifacts.
> 
> **Overview**
> Adds a `skip_e2e_test` workflow_dispatch input (default `false`) to component and Linea Besu release workflows so operators can skip e2e during a release.
> 
> When set, `reusable-component-release.yml` skips local image builds and `run-e2e-tests`. The GitHub release job still runs if the tag changed and e2e was skipped *because* of this flag (not other skip reasons). Linea Besu uses the same gate: e2e is skipped, but `run-test` must still succeed before tagging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79fb327c948620a0ea7e3a6dbeedcce8ad69a58c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->