### PR TITLE
feat(prover-ray): export lookup row-limit verifier action

### DIFF
--- a/prover-ray/wiop/compilers/lookuptologderivsum/lookuptologderivsum.go
+++ b/prover-ray/wiop/compilers/lookuptologderivsum/lookuptologderivsum.go
@@ -519,13 +519,12 @@ func compileGroup(
 // double-counts two fragments that live on the same module, because each
 // fragment contributes its own pass over that module's rows to the argument.
 //
-// AModules and BModules are exported so out-of-package consumers — notably the
-// verifier-ray codegen — can recognise a subgroup row-limit check and read the
-// exact per-side module partitioning it enforces (mirroring the pattern used by
-// [ResultIsZeroVerifierAction]). They list one module per fragment in
-// [lookupGroup.included] / [lookupGroup.includings] respectively, in the same
-// order, so a duplicate module pointer here means the corresponding fragments
-// deliberately double-count that module (see above).
+// AModules and BModules are exported (mirroring the pattern used by
+// [ResultIsZeroVerifierAction]) so out-of-package consumers can read the exact
+// per-side module partitioning this check enforces. They list one module per
+// fragment in [lookupGroup.included] / [lookupGroup.includings] respectively,
+// in the same order, so a duplicate module pointer here means the
+// corresponding fragments deliberately double-count that module (see above).
 type RowLimitVerifierAction struct {
 	group *lookupGroup
 

--- a/prover-ray/wiop/compilers/lookuptologderivsum/lookuptologderivsum.go
+++ b/prover-ray/wiop/compilers/lookuptologderivsum/lookuptologderivsum.go
@@ -199,18 +199,18 @@ func registerRowLimitChecks(groups []*lookupGroup) {
 
 		// Runtime check on the subgroup aggregate. One instance serves both
 		// roles: it panics as a prover action and returns an error as a verifier
-		// action. AModules/BModules mirror g.included/g.includings one-to-one
-		// (see the type doc) so out-of-package consumers can read the exact
-		// per-side module partitioning without reaching into lookupGroup.
-		aModules := make([]*wiop.Module, len(g.included))
+		// action. IncludedModules/IncludingsModules mirror g.included/g.includings
+		// one-to-one (see the type doc) so out-of-package consumers can read the
+		// exact per-side module partitioning without reaching into lookupGroup.
+		includedModules := make([]*wiop.Module, len(g.included))
 		for i, inc := range g.included {
-			aModules[i] = inc.cols[0].Module()
+			includedModules[i] = inc.cols[0].Module()
 		}
-		bModules := make([]*wiop.Module, len(g.includings))
+		includingsModules := make([]*wiop.Module, len(g.includings))
 		for i, it := range g.includings {
-			bModules[i] = it.module
+			includingsModules[i] = it.module
 		}
-		rowLimit := &RowLimitVerifierAction{group: g, AModules: aModules, BModules: bModules}
+		rowLimit := &RowLimitVerifierAction{group: g, IncludedModules: includedModules, IncludingsModules: includingsModules}
 		g.witnessRound.RegisterAction(rowLimit)
 		g.witnessRound.RegisterVerifierAction(rowLimit)
 	}
@@ -519,7 +519,7 @@ func compileGroup(
 // double-counts two fragments that live on the same module, because each
 // fragment contributes its own pass over that module's rows to the argument.
 //
-// AModules and BModules are exported (mirroring the pattern used by
+// IncludedModules and IncludingsModules are exported (mirroring the pattern used by
 // [ResultIsZeroVerifierAction]) so out-of-package consumers can read the exact
 // per-side module partitioning this check enforces. They list one module per
 // fragment in [lookupGroup.included] / [lookupGroup.includings] respectively,
@@ -528,8 +528,8 @@ func compileGroup(
 type RowLimitVerifierAction struct {
 	group *lookupGroup
 
-	AModules []*wiop.Module
-	BModules []*wiop.Module
+	IncludedModules   []*wiop.Module
+	IncludingsModules []*wiop.Module
 }
 
 // Run implements [wiop.ProverAction]: it panics on an over-limit subgroup.
@@ -551,7 +551,7 @@ func (a *RowLimitVerifierAction) Check(rt *wiop.Runtime) error {
 // the whole subgroup's union of A fragments against the shared B side.
 func (a *RowLimitVerifierAction) validate(rt *wiop.Runtime) error {
 	var aRows uint64
-	for _, m := range a.AModules {
+	for _, m := range a.IncludedModules {
 		aRows += uint64(m.RuntimeSize(rt))
 	}
 	if aRows >= wiop.MaxLookupRows {
@@ -559,7 +559,7 @@ func (a *RowLimitVerifierAction) validate(rt *wiop.Runtime) error {
 	}
 
 	var bRows uint64
-	for _, m := range a.BModules {
+	for _, m := range a.IncludingsModules {
 		bRows += uint64(m.RuntimeSize(rt))
 	}
 	if bRows >= wiop.MaxLookupRows {

--- a/prover-ray/wiop/compilers/lookuptologderivsum/lookuptologderivsum.go
+++ b/prover-ray/wiop/compilers/lookuptologderivsum/lookuptologderivsum.go
@@ -174,7 +174,7 @@ func Compile(sys *wiop.System) {
 //     (or otherwise unsized) modules as their maximum height 2^22, so it is a
 //     conservative upper bound.
 //
-//   - Runtime: one [groupRowLimitAction] per subgroup re-checks the *exact*
+//   - Runtime: one [RowLimitVerifierAction] per subgroup re-checks the *exact*
 //     per-run heights, summed across the whole subgroup, on both the prover
 //     (panic) and verifier (error) sides. This is the check that enforces the
 //     shared budget now that a subgroup — not a single query — is the unit that
@@ -199,8 +199,18 @@ func registerRowLimitChecks(groups []*lookupGroup) {
 
 		// Runtime check on the subgroup aggregate. One instance serves both
 		// roles: it panics as a prover action and returns an error as a verifier
-		// action.
-		rowLimit := &groupRowLimitAction{group: g}
+		// action. AModules/BModules mirror g.included/g.includings one-to-one
+		// (see the type doc) so out-of-package consumers can read the exact
+		// per-side module partitioning without reaching into lookupGroup.
+		aModules := make([]*wiop.Module, len(g.included))
+		for i, inc := range g.included {
+			aModules[i] = inc.cols[0].Module()
+		}
+		bModules := make([]*wiop.Module, len(g.includings))
+		for i, it := range g.includings {
+			bModules[i] = it.module
+		}
+		rowLimit := &RowLimitVerifierAction{group: g, AModules: aModules, BModules: bModules}
 		g.witnessRound.RegisterAction(rowLimit)
 		g.witnessRound.RegisterVerifierAction(rowLimit)
 	}
@@ -489,7 +499,7 @@ func compileGroup(
 	return fractions
 }
 
-// groupRowLimitAction enforces, at runtime, that a single subgroup's summed row
+// RowLimitVerifierAction enforces, at runtime, that a single subgroup's summed row
 // count stays below the budget on each side. It is the runtime counterpart to
 // the compile-time bin-packing in [collectGroups]: bin-packing keeps every
 // subgroup under limit using static (maximum) module heights, and this action
@@ -508,12 +518,23 @@ func compileGroup(
 // and fails if either reaches limit. Summing per fragment deliberately
 // double-counts two fragments that live on the same module, because each
 // fragment contributes its own pass over that module's rows to the argument.
-type groupRowLimitAction struct {
+//
+// AModules and BModules are exported so out-of-package consumers — notably the
+// verifier-ray codegen — can recognise a subgroup row-limit check and read the
+// exact per-side module partitioning it enforces (mirroring the pattern used by
+// [ResultIsZeroVerifierAction]). They list one module per fragment in
+// [lookupGroup.included] / [lookupGroup.includings] respectively, in the same
+// order, so a duplicate module pointer here means the corresponding fragments
+// deliberately double-count that module (see above).
+type RowLimitVerifierAction struct {
 	group *lookupGroup
+
+	AModules []*wiop.Module
+	BModules []*wiop.Module
 }
 
 // Run implements [wiop.ProverAction]: it panics on an over-limit subgroup.
-func (a *groupRowLimitAction) Run(rt *wiop.Runtime) {
+func (a *RowLimitVerifierAction) Run(rt *wiop.Runtime) {
 	if err := a.validate(rt); err != nil {
 		panic(err)
 	}
@@ -521,7 +542,7 @@ func (a *groupRowLimitAction) Run(rt *wiop.Runtime) {
 
 // Check implements [wiop.VerifierAction]: it returns an error on an over-limit
 // subgroup so the verifier rejects the proof.
-func (a *groupRowLimitAction) Check(rt *wiop.Runtime) error {
+func (a *RowLimitVerifierAction) Check(rt *wiop.Runtime) error {
 	return a.validate(rt)
 }
 
@@ -529,18 +550,18 @@ func (a *groupRowLimitAction) Check(rt *wiop.Runtime) error {
 // error if either side reaches the limit. Mirrors the accounting of
 // [wiop.TableRelationQuery.ValidateRowLimit], extended from a single query to
 // the whole subgroup's union of A fragments against the shared B side.
-func (a *groupRowLimitAction) validate(rt *wiop.Runtime) error {
+func (a *RowLimitVerifierAction) validate(rt *wiop.Runtime) error {
 	var aRows uint64
-	for _, inc := range a.group.included {
-		aRows += uint64(inc.cols[0].Module().RuntimeSize(rt))
+	for _, m := range a.AModules {
+		aRows += uint64(m.RuntimeSize(rt))
 	}
 	if aRows >= wiop.MaxLookupRows {
 		return a.overLimitError("A", aRows)
 	}
 
 	var bRows uint64
-	for _, it := range a.group.includings {
-		bRows += uint64(it.module.RuntimeSize(rt))
+	for _, m := range a.BModules {
+		bRows += uint64(m.RuntimeSize(rt))
 	}
 	if bRows >= wiop.MaxLookupRows {
 		return a.overLimitError("B", bRows)
@@ -551,7 +572,7 @@ func (a *groupRowLimitAction) validate(rt *wiop.Runtime) error {
 // overLimitError builds the shared over-budget message, listing the lookup
 // queries folded into the offending subgroup so the failure is traceable back
 // to source lookups.
-func (a *groupRowLimitAction) overLimitError(side string, rows uint64) error {
+func (a *RowLimitVerifierAction) overLimitError(side string, rows uint64) error {
 	paths := make([]string, 0, len(a.group.queries))
 	for _, q := range a.group.queries {
 		paths = append(paths, q.Context().Path())

--- a/prover-ray/wiop/compilers/lookuptologderivsum/runtime_rowlimit_internal_test.go
+++ b/prover-ray/wiop/compilers/lookuptologderivsum/runtime_rowlimit_internal_test.go
@@ -33,18 +33,19 @@ func buildRuntimeLimitGroup(t *testing.T, aSize, bSize int) (*lookupGroup, *wiop
 }
 
 // rowLimitActionFor builds the RowLimitVerifierAction for g the same way
-// registerRowLimitChecks does, so tests exercise the exported AModules/BModules
-// path rather than a stale group-only construction.
+// registerRowLimitChecks does, so tests exercise the exported
+// IncludedModules/IncludingsModules path rather than a stale group-only
+// construction.
 func rowLimitActionFor(g *lookupGroup) *RowLimitVerifierAction {
-	aModules := make([]*wiop.Module, len(g.included))
+	includedModules := make([]*wiop.Module, len(g.included))
 	for i, inc := range g.included {
-		aModules[i] = inc.cols[0].Module()
+		includedModules[i] = inc.cols[0].Module()
 	}
-	bModules := make([]*wiop.Module, len(g.includings))
+	includingsModules := make([]*wiop.Module, len(g.includings))
 	for i, it := range g.includings {
-		bModules[i] = it.module
+		includingsModules[i] = it.module
 	}
-	return &RowLimitVerifierAction{group: g, AModules: aModules, BModules: bModules}
+	return &RowLimitVerifierAction{group: g, IncludedModules: includedModules, IncludingsModules: includingsModules}
 }
 
 // TestRowLimitVerifierAction_RuntimeRejectsOverLimitASide checks that the runtime

--- a/prover-ray/wiop/compilers/lookuptologderivsum/runtime_rowlimit_internal_test.go
+++ b/prover-ray/wiop/compilers/lookuptologderivsum/runtime_rowlimit_internal_test.go
@@ -12,7 +12,7 @@ import (
 // static A and B module sizes, bins it into subgroups, and returns the sole
 // subgroup together with a fresh Runtime. Sizes are metadata only (no 2^30
 // vector is ever materialised), and RuntimeSize reads a static module's size
-// directly, so this drives groupRowLimitAction without a witness.
+// directly, so this drives RowLimitVerifierAction without a witness.
 func buildRuntimeLimitGroup(t *testing.T, aSize, bSize int) (*lookupGroup, *wiop.Runtime) {
 	t.Helper()
 	sys := wiop.NewSystemf("rt-limit")
@@ -32,13 +32,28 @@ func buildRuntimeLimitGroup(t *testing.T, aSize, bSize int) (*lookupGroup, *wiop
 	return groups[0], wiop.NewRuntime(sys)
 }
 
-// TestGroupRowLimitAction_RuntimeRejectsOverLimitASide checks that the runtime
+// rowLimitActionFor builds the RowLimitVerifierAction for g the same way
+// registerRowLimitChecks does, so tests exercise the exported AModules/BModules
+// path rather than a stale group-only construction.
+func rowLimitActionFor(g *lookupGroup) *RowLimitVerifierAction {
+	aModules := make([]*wiop.Module, len(g.included))
+	for i, inc := range g.included {
+		aModules[i] = inc.cols[0].Module()
+	}
+	bModules := make([]*wiop.Module, len(g.includings))
+	for i, it := range g.includings {
+		bModules[i] = it.module
+	}
+	return &RowLimitVerifierAction{group: g, AModules: aModules, BModules: bModules}
+}
+
+// TestRowLimitVerifierAction_RuntimeRejectsOverLimitASide checks that the runtime
 // subgroup row-limit check fires on the A side: as a verifier action it returns
 // an error, and as a prover action it panics. The A module is declared with 2^30
 // rows so its exact per-run height reaches the budget.
-func TestGroupRowLimitAction_RuntimeRejectsOverLimitASide(t *testing.T) {
+func TestRowLimitVerifierAction_RuntimeRejectsOverLimitASide(t *testing.T) {
 	g, rt := buildRuntimeLimitGroup(t, 1<<30, 2) // A reaches the budget; B tiny.
-	action := &groupRowLimitAction{group: g}
+	action := rowLimitActionFor(g)
 
 	err := action.Check(rt)
 	require.Error(t, err, "verifier must reject an over-limit subgroup A side")
@@ -48,11 +63,11 @@ func TestGroupRowLimitAction_RuntimeRejectsOverLimitASide(t *testing.T) {
 		"prover must panic on an over-limit subgroup A side")
 }
 
-// TestGroupRowLimitAction_RuntimeRejectsOverLimitBSide is the B-side counterpart:
+// TestRowLimitVerifierAction_RuntimeRejectsOverLimitBSide is the B-side counterpart:
 // the check fails independently on the shared lookup table.
-func TestGroupRowLimitAction_RuntimeRejectsOverLimitBSide(t *testing.T) {
+func TestRowLimitVerifierAction_RuntimeRejectsOverLimitBSide(t *testing.T) {
 	g, rt := buildRuntimeLimitGroup(t, 2, 1<<30) // B reaches the budget; A tiny.
-	action := &groupRowLimitAction{group: g}
+	action := rowLimitActionFor(g)
 
 	err := action.Check(rt)
 	require.Error(t, err, "verifier must reject an over-limit subgroup B side")
@@ -62,11 +77,11 @@ func TestGroupRowLimitAction_RuntimeRejectsOverLimitBSide(t *testing.T) {
 		"prover must panic on an over-limit subgroup B side")
 }
 
-// TestGroupRowLimitAction_RuntimeAcceptsWithinLimit confirms the runtime check is
+// TestRowLimitVerifierAction_RuntimeAcceptsWithinLimit confirms the runtime check is
 // silent for an in-budget subgroup: Check returns nil and Run does not panic.
-func TestGroupRowLimitAction_RuntimeAcceptsWithinLimit(t *testing.T) {
+func TestRowLimitVerifierAction_RuntimeAcceptsWithinLimit(t *testing.T) {
 	g, rt := buildRuntimeLimitGroup(t, 4, 4)
-	action := &groupRowLimitAction{group: g}
+	action := rowLimitActionFor(g)
 
 	require.NoError(t, action.Check(rt), "an in-budget subgroup must pass the verifier check")
 	assert.NotPanics(t, func() { action.Run(rt) }, "an in-budget subgroup must not panic the prover")


### PR DESCRIPTION
Exports groupRowLimitAction as RowLimitVerifierAction, with new AModules/BModules fields listing the per-side module partitioning it enforces. Mirrors the existing ResultIsZeroVerifierAction pattern of exporting an action type (with exported fields) so out-of-package consumers can recognise the check and read the data needed to reimplement it, instead of only being able to detect that an unhandled action type exists.