### PR TITLE
feat(coordinator): add StartingPoint sealed class to BlockCreationMonitor

### DIFF
--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppV1.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppV1.kt
@@ -531,7 +531,7 @@ class ConflationAppV1(
   private val blockCreationMonitor = BlockCreationMonitor(
     vertx = vertx,
     ethApi = l2EthClient,
-    startingBlockNumberExclusive = lastConflatedBlock.number.toLong(),
+    startingPoint = BlockCreationMonitor.StartingPoint.ByBlockNumberExclusive(lastConflatedBlock.number.toLong()),
     blockCreationListener = block2BatchCoordinator,
     lastProvenBlockNumberProviderSync = lastProvenBlockNumberProvider,
     config = BlockCreationMonitor.Config(

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
@@ -371,7 +371,9 @@ class ConflationBacktestingApp(
   private val blockCreationMonitor = BlockCreationMonitor(
     vertx = vertx,
     ethApi = l2EthClient,
-    startingBlockNumberExclusive = conflationBacktestingAppConfig.startBlockNumber.toLong() - 1,
+    startingPoint = BlockCreationMonitor.StartingPoint.ByBlockNumberExclusive(
+      conflationBacktestingAppConfig.startBlockNumber.toLong() - 1,
+    ),
     blockCreationListener = blockToBatchSubmissionCoordinator,
     lastProvenBlockNumberProviderSync = object : LastProvenBlockNumberProviderSync {
       override fun getLastKnownProvenBlockNumber(): Long {

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/blockcreation/BlockCreationMonitor.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/blockcreation/BlockCreationMonitor.kt
@@ -23,7 +23,7 @@ import kotlin.time.Instant
 class BlockCreationMonitor(
   private val vertx: Vertx,
   private val ethApi: EthApiBlockClient,
-  private val startingBlockNumberExclusive: Long,
+  private val startingPoint: StartingPoint,
   private val blockCreationListener: BlockCreationListener,
   private val lastProvenBlockNumberProviderSync: LastProvenBlockNumberProviderSync,
   private val config: Config,
@@ -36,6 +36,11 @@ class BlockCreationMonitor(
   name = "BlockCreationMonitor",
   timerSchedule = TimerSchedule.FIXED_DELAY,
 ) {
+  sealed class StartingPoint {
+    data class ByBlockNumberExclusive(val blockNumberExclusive: Long) : StartingPoint()
+    data class ByTimestampInclusive(val timestampInclusive: Instant) : StartingPoint()
+  }
+
   data class Config(
     val pollingInterval: Duration,
     val blocksToFinalization: Long,
@@ -45,7 +50,12 @@ class BlockCreationMonitor(
     val lastL2BlockTimestampToProcessInclusive: Instant? = null,
   )
 
-  private val _nexBlockNumberToFetch: AtomicLong = AtomicLong(startingBlockNumberExclusive + 1)
+  private val _nexBlockNumberToFetch: AtomicLong = AtomicLong(
+    when (startingPoint) {
+      is StartingPoint.ByBlockNumberExclusive -> startingPoint.blockNumberExclusive + 1
+      is StartingPoint.ByTimestampInclusive -> -1L
+    },
+  )
   private val expectedParentBlockHash: AtomicReference<ByteArray> = AtomicReference(null)
   private val reorgDetected: AtomicBoolean = AtomicBoolean(false)
   private var statingBlockAvailabilityFuture: SafeFuture<*>? = null
@@ -72,32 +82,98 @@ class BlockCreationMonitor(
   @Synchronized
   fun awaitStartingBlockToBePresent(): SafeFuture<*> {
     if (statingBlockAvailabilityFuture == null) {
-      log.info("Awaiting for block {} to be present", startingBlockNumberExclusive)
-      statingBlockAvailabilityFuture =
-        AsyncRetryer.retry(
-          vertx,
-          backoffDelay = config.pollingInterval,
-          timeout = config.startingBlockWaitTimeout,
-          stopRetriesPredicate = { block: Block? ->
-            if (block == null) {
-              log.warn(
-                "block={} not found yet. Retrying in {}",
-                startingBlockNumberExclusive,
-                config.pollingInterval,
-              )
-              false
-            } else {
-              log.info("Block {} found. Resuming block monitor", startingBlockNumberExclusive)
-              expectedParentBlockHash.set(block.hash)
-              true
-            }
-          },
-        ) {
-          ethApi.ethGetBlockByNumberFullTxs(BlockParameter.fromNumber(startingBlockNumberExclusive))
+      statingBlockAvailabilityFuture = when (startingPoint) {
+        is StartingPoint.ByBlockNumberExclusive -> awaitBlockByNumber(startingPoint.blockNumberExclusive)
+        is StartingPoint.ByTimestampInclusive -> awaitBlockByTimestamp(startingPoint.timestampInclusive)
+      }
+    }
+    return statingBlockAvailabilityFuture!!
+  }
+
+  private fun awaitBlockByNumber(blockNumberExclusive: Long): SafeFuture<*> {
+    log.info("Awaiting for block {} to be present", blockNumberExclusive)
+    return AsyncRetryer.retry(
+      vertx,
+      backoffDelay = config.pollingInterval,
+      timeout = config.startingBlockWaitTimeout,
+      stopRetriesPredicate = { block: Block? ->
+        if (block == null) {
+          log.warn(
+            "block={} not found yet. Retrying in {}",
+            blockNumberExclusive,
+            config.pollingInterval,
+          )
+          false
+        } else {
+          log.info("Block {} found. Resuming block monitor", blockNumberExclusive)
+          expectedParentBlockHash.set(block.hash)
+          true
+        }
+      },
+    ) {
+      ethApi.ethGetBlockByNumberFullTxs(BlockParameter.fromNumber(blockNumberExclusive))
+    }
+  }
+
+  private fun awaitBlockByTimestamp(targetTimestamp: Instant): SafeFuture<*> {
+    log.info("Waiting for cutover timestamp to be reached on L2, timestamp={}", targetTimestamp)
+    return AsyncRetryer.retry(
+      vertx,
+      backoffDelay = config.pollingInterval,
+      timeout = config.startingBlockWaitTimeout,
+      stopRetriesPredicate = { block: Block? ->
+        val reached = block != null && block.timestamp >= targetTimestamp.epochSeconds.toULong()
+        if (!reached) {
+          log.debug(
+            "Latest block hasn't reached cutover. latestBlockTimestamp={} target={}",
+            block?.let { Instant.fromEpochSeconds(it.timestamp.toLong()) },
+            targetTimestamp,
+          )
+        }
+        reached
+      },
+    ) {
+      ethApi.ethBlockNumber()
+        .thenCompose { n -> ethApi.ethGetBlockByNumberFullTxs(BlockParameter.fromNumber(n.toLong())) }
+    }.thenCompose { latestBlock ->
+      log.info(
+        "Cutover timestamp reached. Binary searching for exact first block in 0..{}. targetTimestamp={}, " +
+          "latestBlockNumber={}, " +
+          "latestBlockTimestamp={}",
+        latestBlock.number,
+        targetTimestamp,
+        latestBlock.number,
+        Instant.fromEpochSeconds(latestBlock.timestamp.toLong()),
+      )
+      binarySearchFirstBlockAtOrAfterTimestamp(0L, latestBlock.number.toLong(), targetTimestamp)
+    }.thenCompose { firstBlockNumber ->
+      _nexBlockNumberToFetch.set(firstBlockNumber)
+      log.info(
+        "Block creation monitor ready. Starting from block number={}",
+        firstBlockNumber,
+      )
+      ethApi.ethGetBlockByNumberFullTxs(BlockParameter.fromNumber(firstBlockNumber - 1))
+        .thenApply { parentBlock ->
+          expectedParentBlockHash.set(parentBlock.hash)
         }
     }
+  }
 
-    return statingBlockAvailabilityFuture!!
+  private fun binarySearchFirstBlockAtOrAfterTimestamp(
+    low: Long,
+    high: Long,
+    targetTimestamp: Instant,
+  ): SafeFuture<Long> {
+    if (low == high) return SafeFuture.completedFuture(low)
+    val mid = low + (high - low) / 2
+    return ethApi.ethFindBlockByNumberFullTxs(BlockParameter.fromNumber(mid))
+      .thenCompose { block ->
+        if (block == null || block.timestamp < targetTimestamp.epochSeconds.toULong()) {
+          binarySearchFirstBlockAtOrAfterTimestamp(mid + 1, high, targetTimestamp)
+        } else {
+          binarySearchFirstBlockAtOrAfterTimestamp(low, mid, targetTimestamp)
+        }
+      }
   }
 
   override fun action(): SafeFuture<*> {

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/blockcreation/BlockCreationMonitor.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/blockcreation/BlockCreationMonitor.kt
@@ -152,10 +152,15 @@ class BlockCreationMonitor(
         "Block creation monitor ready. Starting from block number={}",
         firstBlockNumber,
       )
-      ethApi.ethGetBlockByNumberFullTxs(BlockParameter.fromNumber(firstBlockNumber - 1))
-        .thenApply { parentBlock ->
-          expectedParentBlockHash.set(parentBlock.hash)
-        }
+      if (firstBlockNumber == 0L) {
+        expectedParentBlockHash.set(ByteArray(32))
+        SafeFuture.completedFuture(Unit)
+      } else {
+        ethApi.ethGetBlockByNumberFullTxs(BlockParameter.fromNumber(firstBlockNumber - 1))
+          .thenApply { parentBlock ->
+            expectedParentBlockHash.set(parentBlock.hash)
+          }
+      }
     }
   }
 

--- a/coordinator/app/src/test/kotlin/lineth/coordinator/blockcreation/BlockCreationMonitorTest.kt
+++ b/coordinator/app/src/test/kotlin/lineth/coordinator/blockcreation/BlockCreationMonitorTest.kt
@@ -74,6 +74,24 @@ class BlockCreationMonitorTest {
     }
   }
 
+  fun createByTimestampMonitor(
+    targetTimestamp: Instant,
+    config: BlockCreationMonitor.Config = this.config,
+    lastProvenSync: LastProvenBlockNumberProviderSync = lastProvenBlockNumberProvider,
+  ): BlockCreationMonitor = BlockCreationMonitor(
+    vertx = this.vertx,
+    ethApi = ethApiClient,
+    startingPoint = BlockCreationMonitor.StartingPoint.ByTimestampInclusive(targetTimestamp),
+    blockCreationListener = blockCreationListener,
+    lastProvenBlockNumberProviderSync = lastProvenSync,
+    config = config,
+    targetCheckpointPauseController = object : TargetCheckpointPauseController {
+      override fun shouldPauseConflation(): Boolean = false
+      override fun importBlock(block: Block) = Unit
+      override fun signalResumeFromApi(): Boolean = false
+    },
+  )
+
   fun createBlockCreationMonitor(
     startingBlockNumberExclusive: Long = 99,
     blockCreationListener: BlockCreationListener = this.blockCreationListener,
@@ -82,7 +100,7 @@ class BlockCreationMonitorTest {
     return BlockCreationMonitor(
       vertx = this.vertx,
       ethApi = ethApiClient,
-      startingBlockNumberExclusive = startingBlockNumberExclusive,
+      startingPoint = BlockCreationMonitor.StartingPoint.ByBlockNumberExclusive(startingBlockNumberExclusive),
       blockCreationListener = blockCreationListener,
       lastProvenBlockNumberProviderSync = lastProvenBlockNumberProvider,
       config = config,
@@ -387,6 +405,87 @@ class BlockCreationMonitorTest {
     setupFakeExecutionLayerWithBlocks(createBlocks(startBlockNumber = 99u, numberOfBlocks = 5))
     monitor.start().get(10, TimeUnit.SECONDS)
     monitor.start().get(10, TimeUnit.SECONDS)
+  }
+
+  @Test
+  fun `ByTimestamp should start monitoring from first block at or after cutover timestamp`() {
+    val startTime = Instant.parse("2025-01-01T00:00:00.00Z")
+    // blocks 99..149, 1s each: block 99 = t+0s, block 110 = t+11s
+    val blocks = createBlocks(startBlockNumber = 99u, numberOfBlocks = 50, startTime = startTime)
+    val targetTimestamp = startTime.plus(11.seconds) // exactly block 110's timestamp
+
+    monitor = createByTimestampMonitor(targetTimestamp)
+    setupFakeExecutionLayerWithBlocks(blocks)
+
+    monitor.start()
+
+    await()
+      .atMost(20.seconds.toJavaDuration())
+      .untilAsserted {
+        assertThat(blockCreationListener.blocksReceived).isNotEmpty
+        assertThat(blockCreationListener.blocksReceived.first().number).isEqualTo(110UL)
+      }
+  }
+
+  @Test
+  fun `ByTimestamp should wait for L2 to reach cutover timestamp before starting`() {
+    val startTime = Instant.parse("2025-01-01T00:00:00.00Z")
+    val allBlocks = createBlocks(startBlockNumber = 99u, numberOfBlocks = 50, startTime = startTime)
+    // block 110 = startTime + 11s
+    val targetTimestamp = startTime.plus(11.seconds)
+
+    monitor = createByTimestampMonitor(targetTimestamp)
+
+    // Initially only blocks 99..107 are available: latest timestamp = startTime+8s < target
+    setupFakeExecutionLayerWithBlocks(allBlocks.filter { it.number <= 107u })
+
+    monitor.start()
+
+    // Monitor should be waiting — no blocks delivered yet
+    await().atLeast(config.pollingInterval.times(3).toJavaDuration())
+    assertThat(blockCreationListener.blocksReceived).isEmpty()
+
+    // Advance the L2 past the cutover
+    setupFakeExecutionLayerWithBlocks(allBlocks)
+
+    await()
+      .atMost(20.seconds.toJavaDuration())
+      .untilAsserted {
+        assertThat(blockCreationListener.blocksReceived).isNotEmpty
+        assertThat(blockCreationListener.blocksReceived.first().number).isEqualTo(110UL)
+      }
+  }
+
+  @Test
+  fun `ByTimestamp should walk forward to find exact first block when estimate undershoots`() {
+    val startTime = Instant.parse("2025-01-01T00:00:00.00Z")
+    // 2s block time: block 0 = t+0s, block 15 = t+30s, block 30 = t+60s
+    val blocks = createBlocks(
+      startBlockNumber = 0u,
+      numberOfBlocks = 30,
+      startTime = startTime,
+      blockTime = 2.seconds,
+    )
+    // target = block 15's timestamp
+    val targetTimestamp = startTime.plus(30.seconds)
+    // latest = block 30 (t+60s), estimate = max(0, 30 - (60-30)) = 0
+    // walk: blocks 0(0s)..14(28s) < target, block 15(30s) = target → check 14(28s < target) → start at 15
+
+    monitor = createByTimestampMonitor(
+      targetTimestamp = targetTimestamp,
+      config = config.copy(blocksToFinalization = 0),
+      lastProvenSync = LastProvenBlockNumberProviderDouble(0u),
+    )
+    setupFakeExecutionLayerWithBlocks(blocks)
+
+    monitor.start()
+
+    await()
+      .atMost(20.seconds.toJavaDuration())
+      .untilAsserted {
+        assertThat(blockCreationListener.blocksReceived).isNotEmpty
+        assertThat(blockCreationListener.blocksReceived.first().number).isEqualTo(15UL)
+      }
   }
 
   @Test


### PR DESCRIPTION
#3086 

## Summary

- Replaces the `startingBlockNumberExclusive: Long` constructor parameter on `BlockCreationMonitor` with a `StartingPoint` sealed class (`ByBlockNumber` | `ByTimestamp`), allowing the coordinator to self-coordinate from a cutover timestamp without requiring external block-number resolution.
- `ByTimestamp` flow: polls the latest L2 block until its timestamp reaches the target, then binary-searches `[0, latestBlock]` in O(log n) RPC calls to find the exact first block at or after the timestamp.
- Updates `ConflationAppV1` and `ConflationBacktestingApp` call sites to use `ByBlockNumber`.
- Adds three new tests covering `ByTimestamp`: happy path, wait-for-cutover, and binary-search with non-trivial block times.

## Test plan

- [ ] `ByTimestamp should start monitoring from first block at or after cutover timestamp`
- [ ] `ByTimestamp should wait for L2 to reach cutover timestamp before starting`
- [ ] `ByTimestamp should walk forward to find exact first block when estimate undershoots`
- [ ] All existing `BlockCreationMonitorTest` tests pass


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core conflation block-monitor startup, where an incorrect start block could skip or mis-chain L2 blocks. Existing production call sites still use block-number start, which limits immediate blast radius.
> 
> **Overview**
> Lets `BlockCreationMonitor` start from a **cutover timestamp** instead of only a known block number, so the coordinator can self-resolve the first L2 block without external block-number lookup.
> 
> Replaces `startingBlockNumberExclusive` with a `StartingPoint` sealed class (`ByBlockNumberExclusive` | `ByTimestampInclusive`). The timestamp path waits until the latest L2 block reaches the target, then binary-searches for the first block at or after that timestamp and seeds parent-hash tracking from there.
> 
> Existing `ConflationAppV1` and `ConflationBacktestingApp` call sites keep block-number startup via `ByBlockNumberExclusive`. Adds tests for happy path, wait-for-cutover, and binary-search resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2112e07771bc5a74b0b4deec6da2a6965407047d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->