### PR TITLE
chore(coordinator): scaffold ConflationAppV2 for RISC-V cutover

### DIFF
--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/CoordinatorApp.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/CoordinatorApp.kt
@@ -17,6 +17,7 @@ import linea.web3j.createWeb3jHttpClient
 import linea.web3j.ethapi.createEthApiClient
 import lineth.coordinator.api.Api
 import lineth.coordinator.app.conflation.ConflationAppV1
+import lineth.coordinator.app.conflation.ConflationAppV2
 import lineth.coordinator.app.conflationbacktesting.ConflationBacktestingService
 import lineth.coordinator.config.v2.CoordinatorConfig
 import lineth.coordinator.config.v2.DatabaseConfig
@@ -216,6 +217,19 @@ class CoordinatorApp(
     httpJsonRpcClientFactory = httpJsonRpcClientFactory,
   )
 
+  private val conflationAppV2: ConflationAppV2? =
+    if (configs.conflation.riscvStartingBlockTimestampInclusive != null) {
+      ConflationAppV2(
+        vertx = vertx,
+        ethApi = createEthApiClient(rpcUrl = configs.conflation.l2Endpoint.toString()),
+        lastFinalizedBlock = lastFinalizedBlock,
+        batchesRepository = batchesRepository,
+        configs = configs,
+      )
+    } else {
+      null
+    }
+
   private val l1FinalizationMonitorApp = L1FinalizationMonitorApp(
     configs = configs,
     vertx = vertx,
@@ -312,6 +326,7 @@ class CoordinatorApp(
     SafeFuture.completedFuture(Unit)
       .thenCompose { l1FinalizationMonitorApp.start() }
       .thenCompose { conflationApp.start() }
+      .thenCompose { conflationAppV2?.start() ?: SafeFuture.completedFuture(Unit) }
       .thenCompose { l1RelayingAppV1.start() }
       .thenCompose { messageAnchoringApp.start() }
       .thenCompose { l2PricingApp.start() }
@@ -329,6 +344,7 @@ class CoordinatorApp(
     return try {
       l1FinalizationMonitorApp.stop()
         .thenCompose { conflationApp.stop() }
+        .thenCompose { conflationAppV2?.stop() ?: SafeFuture.completedFuture(Unit) }
         .thenCompose {
           SafeFuture.allOf(
             SafeFuture.allOf(*extensionServices.map { it.stop().toSafeFuture() }.toTypedArray()),

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/CoordinatorApp.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/CoordinatorApp.kt
@@ -221,7 +221,6 @@ class CoordinatorApp(
     if (configs.conflation.riscvStartingBlockTimestampInclusive != null) {
       ConflationAppV2(
         vertx = vertx,
-        ethApi = createEthApiClient(rpcUrl = configs.conflation.l2Endpoint.toString()),
         lastFinalizedBlock = lastFinalizedBlock,
         batchesRepository = batchesRepository,
         configs = configs,

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppV1.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppV1.kt
@@ -543,7 +543,12 @@ class ConflationAppV1(
       // block_number = forceStopConflationAtBlockInclusive + 1 to trigger conflation at
       // forceStopConflationAtBlockInclusive
       lastL2BlockNumberToProcessInclusive = configs.conflation.forceStopConflationAtBlockInclusive?.inc(),
-      lastL2BlockTimestampToProcessInclusive = configs.conflation.forceStopConflationAtBlockTimestampInclusive,
+      // Stop before the RISC-V cutover (riscvStartingBlockTimestampInclusive is V2's first block,
+      // so V1's last block has timestamp = cutover - 1s). Also respect any existing force-stop config.
+      lastL2BlockTimestampToProcessInclusive = listOfNotNull(
+        configs.conflation.riscvStartingBlockTimestampInclusive?.minus(1.seconds),
+        configs.conflation.forceStopConflationAtBlockTimestampInclusive,
+      ).minOrNull(),
     ),
     targetCheckpointPauseController = targetCheckpointPauseController,
   )

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppV1.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppV1.kt
@@ -248,6 +248,13 @@ class ConflationAppV1(
   private val log = LogManager.getLogger("conflation.app")
 
   init {
+    configs.conflation.riscvStartingBlockTimestampInclusive?.let { cutover ->
+      require(cutover in configs.conflation.proofAggregation.timestampBasedHardForks) {
+        "riscvStartingBlockTimestampInclusive=$cutover must be present in " +
+          "conflation.proofAggregation.timestampBasedHardForks so that V1 seals its last " +
+          "conflation batch when the cutover block arrives"
+      }
+    }
     log.info(
       "Resuming conflation from block={} inclusive blockTime={}",
       lastConflatedBlock.number + 1UL,
@@ -543,10 +550,11 @@ class ConflationAppV1(
       // block_number = forceStopConflationAtBlockInclusive + 1 to trigger conflation at
       // forceStopConflationAtBlockInclusive
       lastL2BlockNumberToProcessInclusive = configs.conflation.forceStopConflationAtBlockInclusive?.inc(),
-      // Stop before the RISC-V cutover (riscvStartingBlockTimestampInclusive is V2's first block,
-      // so V1's last block has timestamp = cutover - 1s). Also respect any existing force-stop config.
+      // riscvStartingBlockTimestampInclusive is the cutover block (V2's first block). V1 needs to
+      // see it so the HARD_FORK calculator (wired via timestampBasedHardForks) seals V1's last
+      // conflation batch at the block before cutover. Also respect any existing force-stop config.
       lastL2BlockTimestampToProcessInclusive = listOfNotNull(
-        configs.conflation.riscvStartingBlockTimestampInclusive?.minus(1.seconds),
+        configs.conflation.riscvStartingBlockTimestampInclusive,
         configs.conflation.forceStopConflationAtBlockTimestampInclusive,
       ).minOrNull(),
     ),

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppV2.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppV2.kt
@@ -4,7 +4,8 @@ import io.vertx.core.Vertx
 import linea.LongRunningService
 import linea.domain.Block
 import linea.domain.BlockParameter
-import linea.ethapi.EthApiBlockClient
+import linea.ethapi.EthApiClient
+import linea.web3j.ethapi.createEthApiClient
 import lineth.coordination.blockcreation.BlockCreationListener
 import lineth.coordinator.blockcreation.BatchesRepoBasedLastProvenBlockNumberProvider
 import lineth.coordinator.blockcreation.BlockCreationMonitor
@@ -26,7 +27,6 @@ import kotlin.time.Instant
  */
 class ConflationAppV2(
   private val vertx: Vertx,
-  private val ethApi: EthApiBlockClient,
   private val lastFinalizedBlock: ULong,
   private val batchesRepository: BatchesRepository,
   private val configs: CoordinatorConfig,
@@ -60,6 +60,13 @@ class ConflationAppV2(
       override fun signalResumeFromApi() = false
     }
 
+  private val l2EthClient: EthApiClient = createEthApiClient(
+    rpcUrl = configs.conflation.l2Endpoint.toString(),
+    log = LogManager.getLogger("clients.l2.eth.conflation"),
+    requestRetryConfig = configs.conflation.l2RequestRetries,
+    vertx = vertx,
+  )
+
   /**
    * Returns the block number of the last block processed by the RISC-V proof pipeline,
    * or null if no RISC-V blocks have been processed yet (cold start).
@@ -72,7 +79,7 @@ class ConflationAppV2(
     val cutover = configs.conflation.riscvStartingBlockTimestampInclusive!!
     return getLastRiscVConflatedBlock().thenCompose { riscvLastBlock ->
       val candidateBlock = maxOf(lastFinalizedBlock, riscvLastBlock ?: lastFinalizedBlock)
-      ethApi
+      l2EthClient
         .ethGetBlockByNumberFullTxs(BlockParameter.fromNumber(candidateBlock.toLong()))
         .thenApply { block ->
           val blockTimestamp = Instant.fromEpochSeconds(block.timestamp.toLong())
@@ -104,7 +111,7 @@ class ConflationAppV2(
         val monitor =
           BlockCreationMonitor(
             vertx = vertx,
-            ethApi = ethApi,
+            ethApi = l2EthClient,
             startingPoint = startingPoint,
             blockCreationListener = blockCreationListener,
             lastProvenBlockNumberProviderSync = lastProvenBlockNumberProvider,

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppV2.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppV2.kt
@@ -1,0 +1,131 @@
+package lineth.coordinator.app.conflation
+
+import io.vertx.core.Vertx
+import linea.LongRunningService
+import linea.domain.Block
+import linea.domain.BlockParameter
+import linea.ethapi.EthApiBlockClient
+import lineth.coordination.blockcreation.BlockCreationListener
+import lineth.coordinator.blockcreation.BatchesRepoBasedLastProvenBlockNumberProvider
+import lineth.coordinator.blockcreation.BlockCreationMonitor
+import lineth.coordinator.blockcreation.TargetCheckpointPauseController
+import lineth.coordinator.config.v2.CoordinatorConfig
+import lineth.persistence.BatchesRepository
+import org.apache.logging.log4j.LogManager
+import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.util.concurrent.CompletableFuture
+import kotlin.time.Instant
+
+/**
+ * Monitors L2 blocks starting from the RISC-V cutover
+ * (riscvStartingBlockTimestampInclusive in ConflationConfig) and feeds them into the
+ * RISC-V execution proof pipeline.
+ *
+ * ConflationAppV1 stops at the block immediately before the cutover; this app picks up
+ * from the next block onward.
+ */
+class ConflationAppV2(
+  private val vertx: Vertx,
+  private val ethApi: EthApiBlockClient,
+  private val lastFinalizedBlock: ULong,
+  private val batchesRepository: BatchesRepository,
+  private val configs: CoordinatorConfig,
+) : LongRunningService {
+
+  private val log = LogManager.getLogger(ConflationAppV2::class.java)
+  private var blockCreationMonitor: BlockCreationMonitor? = null
+
+  init {
+    requireNotNull(configs.conflation.riscvStartingBlockTimestampInclusive) {
+      "riscvStartingBlockTimestampInclusive must be set to use ConflationAppV2"
+    }
+  }
+
+  private val blockCreationListener = BlockCreationListener { blockCreated ->
+    log.info("ConflationAppV2: received block number={}", blockCreated.block.number)
+    SafeFuture.completedFuture(Unit)
+  }
+
+  private val lastProvenBlockNumberProvider =
+    BatchesRepoBasedLastProvenBlockNumberProvider(
+      startingBlockNumberExclusive = lastFinalizedBlock.toLong(),
+      latestL1FinalizedBlock = lastFinalizedBlock.toLong(),
+      batchesRepository = batchesRepository,
+    )
+
+  private val targetCheckpointPauseController =
+    object : TargetCheckpointPauseController {
+      override fun shouldPauseConflation() = false
+      override fun importBlock(block: Block) = Unit
+      override fun signalResumeFromApi() = false
+    }
+
+  /**
+   * Returns the block number of the last block processed by the RISC-V proof pipeline,
+   * or null if no RISC-V blocks have been processed yet (cold start).
+   *
+   * Stubbed to null until the RISC-V proof repository is implemented.
+   */
+  private fun getLastRiscVConflatedBlock(): SafeFuture<ULong?> = SafeFuture.completedFuture(null)
+
+  private fun resolveStartingPoint(): SafeFuture<BlockCreationMonitor.StartingPoint> {
+    val cutover = configs.conflation.riscvStartingBlockTimestampInclusive!!
+    return getLastRiscVConflatedBlock().thenCompose { riscvLastBlock ->
+      val candidateBlock = maxOf(lastFinalizedBlock, riscvLastBlock ?: lastFinalizedBlock)
+      ethApi
+        .ethGetBlockByNumberFullTxs(BlockParameter.fromNumber(candidateBlock.toLong()))
+        .thenApply { block ->
+          val blockTimestamp = Instant.fromEpochSeconds(block.timestamp.toLong())
+          if (blockTimestamp < cutover) {
+            log.info(
+              "Cold start: no RISC-V progress found. " +
+                "Will wait for cutover timestamp {}. candidateBlock={} blockTimestamp={}",
+              cutover,
+              candidateBlock,
+              blockTimestamp,
+            )
+            BlockCreationMonitor.StartingPoint.ByTimestampInclusive(cutover)
+          } else {
+            log.info(
+              "Resuming RISC-V conflation from block {}. blockTimestamp={} cutover={}",
+              candidateBlock,
+              blockTimestamp,
+              cutover,
+            )
+            BlockCreationMonitor.StartingPoint.ByBlockNumberExclusive(candidateBlock.toLong())
+          }
+        }
+    }
+  }
+
+  override fun start(): CompletableFuture<Unit> {
+    return resolveStartingPoint()
+      .thenCompose { startingPoint ->
+        val monitor =
+          BlockCreationMonitor(
+            vertx = vertx,
+            ethApi = ethApi,
+            startingPoint = startingPoint,
+            blockCreationListener = blockCreationListener,
+            lastProvenBlockNumberProviderSync = lastProvenBlockNumberProvider,
+            config =
+            BlockCreationMonitor.Config(
+              pollingInterval = configs.conflation.blocksPollingInterval,
+              blocksToFinalization = 0L,
+              blocksFetchLimit = configs.conflation.l2FetchBlocksLimit.toLong(),
+            ),
+            targetCheckpointPauseController = targetCheckpointPauseController,
+          )
+        blockCreationMonitor = monitor
+        monitor
+          .start()
+          .thenPeek { log.info("ConflationAppV2 started with startingPoint={}", startingPoint) }
+      }
+  }
+
+  override fun stop(): CompletableFuture<Unit> {
+    return blockCreationMonitor
+      ?.let { SafeFuture.allOf(it.stop()).thenApply { log.info("ConflationAppV2 stopped") } }
+      ?: SafeFuture.completedFuture(Unit)
+  }
+}


### PR DESCRIPTION
#3086 

## Summary

- Adds `ConflationAppV2`, the RISC-V conflation app that monitors L2 blocks from the cutover timestamp onward.
-  `ConflationAppV1` is updated to stop at `min(riscvStartingBlockTimestampInclusive - 1s, forceStopConflationAtBlockTimestampInclusive)` so V1 and V2 hand off cleanly.
- `ConflationAppV2` is wired into `CoordinatorApp` and only instantiated when `riscvStartingBlockTimestampInclusive` is configured.

## Design

**Starting point resolution** (`resolveStartingPoint`): on `start()`, V2 fetches `max(lastFinalizedBlock, lastRiscVConflatedBlock)` and checks its timestamp against the cutover:
- Timestamp < cutover → `ByTimestampInclusive(cutover)` — cold start, polls until L2 reaches cutover then binary-searches for the exact first block
- Timestamp ≥ cutover → `ByBlockNumberExclusive(candidateBlock)` — restart, resumes from last known block

**Stubs (to be replaced)**:
- `getLastRiscVConflatedBlock()` returns `null` — wired to RISC-V execution proof repository once implemented
- `blockCreationListener` logs the block number — wired to `ExecutionProofGeneratingCoordinator` once the pipeline is ready

**Internal dependencies** (not constructor params):
- `lastProvenBlockNumberProvider` — `BatchesRepoBasedLastProvenBlockNumberProvider`, same as V1
- `targetCheckpointPauseController` — no-op (V2 has no checkpoint pausing)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes conflation lifecycle and V1 stop boundaries at a hard-fork cutover; misconfiguration could affect where V1 stops, though V2 does not yet process proofs.
> 
> **Overview**
> Introduces **`ConflationAppV2`**, a scaffold that watches L2 blocks from the RISC-V cutover onward and will feed the RISC-V execution proof pipeline. It is created only when **`riscvStartingBlockTimestampInclusive`** is set and is started/stopped alongside V1 in **`CoordinatorApp`**.
> 
> **`ConflationAppV1`** is adjusted for a clean handoff: it requires the cutover timestamp to appear in **`timestampBasedHardForks`**, and its block monitor’s **`lastL2BlockTimestampToProcessInclusive`** becomes the minimum of the cutover timestamp and any existing force-stop timestamp so V1 can seal its last batch at the cutover block.
> 
> V2 resolves a **`BlockCreationMonitor`** starting point on startup (wait for cutover vs resume by block number). Proof progress and real conflation are **stubbed**—the listener only logs blocks and **`getLastRiscVConflatedBlock()`** always returns null until later work lands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d14b486f132a073b4449177e2fcb7cc6daa9874. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->