### PR TITLE
feat(coordinator): check proof response before submitting request in ExecutionProofGeneratingCoordinator

### DIFF
--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/lineth/coordinator/clients/prover/ABProverClientRouter.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/lineth/coordinator/clients/prover/ABProverClientRouter.kt
@@ -69,6 +69,9 @@ class ABProverClientRouter<ProofRequest : Any, ProofResponse, TProofIndex : Proo
     return getProver(proofRequest).requestProof(proofRequest)
   }
 
+  override fun getProofIndex(proofRequest: ProofRequest): TProofIndex =
+    getProver(proofRequest).getProofIndex(proofRequest)
+
   override fun createProofRequest(proofRequest: ProofRequest): SafeFuture<TProofIndex> {
     return getProver(proofRequest).createProofRequest(proofRequest)
   }

--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/lineth/coordinator/clients/prover/GenericFileBasedProverClient.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/lineth/coordinator/clients/prover/GenericFileBasedProverClient.kt
@@ -78,6 +78,8 @@ open class GenericFileBasedProverClient<Request, Response, RequestDto, ResponseD
       }
   }
 
+  override fun getProofIndex(proofRequest: Request): TProofIndex = proofIndexProvider(proofRequest)
+
   override fun createProofRequest(proofRequest: Request): SafeFuture<TProofIndex> {
     val proofIndex = proofIndexProvider(proofRequest)
     log.debug(

--- a/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/GenericRiscVProverClient.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/GenericRiscVProverClient.kt
@@ -50,6 +50,8 @@ open class GenericRiscVProverClient<Request, Response, RequestDto, ResponseDto, 
       .thenApply { responseDto -> responseDto?.let { parseResponse(it) } }
   }
 
+  override fun getProofIndex(proofRequest: Request): TProofIndex = proofIndexProvider(proofRequest)
+
   override fun createProofRequest(proofRequest: Request): SafeFuture<TProofIndex> {
     val proofIndex = proofIndexProvider(proofRequest)
     log.debug(

--- a/coordinator/core-interfaces/src/main/kotlin/linea/clients/ProverClient.kt
+++ b/coordinator/core-interfaces/src/main/kotlin/linea/clients/ProverClient.kt
@@ -20,6 +20,7 @@ interface ProverProofResponseChecker<ProofResponse, TProofIndex : ProofIndex> {
 }
 
 interface ProverProofRequestCreator<ProofRequest : Any, TProofIndex : ProofIndex> {
+  fun getProofIndex(proofRequest: ProofRequest): TProofIndex
   fun createProofRequest(proofRequest: ProofRequest): SafeFuture<TProofIndex>
 }
 

--- a/coordinator/core/src/main/kotlin/lineth/coordination/riscv/execution/ExecutionProofGeneratingCoordinator.kt
+++ b/coordinator/core/src/main/kotlin/lineth/coordination/riscv/execution/ExecutionProofGeneratingCoordinator.kt
@@ -90,25 +90,41 @@ class ExecutionProofGeneratingCoordinator(
 
   override fun handleConflatedBatch(conflation: BlocksConflation): SafeFuture<*> {
     val blockIntervalString = conflation.conflationResult.intervalString()
+    log.info(
+      "new batch: batch={} trigger={}",
+      blockIntervalString,
+      conflation.conflationResult.conflationTrigger,
+    )
     return runCatching {
-      log.info(
-        "new batch: batch={} trigger={}",
-        blockIntervalString,
-        conflation.conflationResult.conflationTrigger,
-      )
       AsyncRetryer.retry(
         vertx = vertx,
         backoffDelay = config.conflationAndProofGenerationRetryBackoffDelay,
         exceptionConsumer = {
           log.warn(
-            "l2-execution proof creation flow failed batch={} will retry in backOff={} errorMessage={}",
+            "l2-execution request building failed batch={} will retry in backOff={} errorMessage={}",
             blockIntervalString,
             config.conflationAndProofGenerationRetryBackoffDelay,
             it.message,
           )
         },
       ) {
-        conflationToProofCreation(conflation)
+        l2ExecutionRequestBuilder.build(conflation)
+      }.thenCompose { proofRequest ->
+        val proofIndex = l2ExecutionProverClient.getProofIndex(proofRequest)
+        AsyncRetryer.retry(
+          vertx = vertx,
+          backoffDelay = config.conflationAndProofGenerationRetryBackoffDelay,
+          exceptionConsumer = {
+            log.warn(
+              "l2-execution proof creation flow failed batch={} will retry in backOff={} errorMessage={}",
+              blockIntervalString,
+              config.conflationAndProofGenerationRetryBackoffDelay,
+              it.message,
+            )
+          },
+        ) {
+          checkAndSubmitProof(proofIndex, proofRequest, blockIntervalString)
+        }
       }
     }.getOrElse { error -> SafeFuture.failedFuture<Unit>(error) }
       .whenException { th ->
@@ -121,47 +137,30 @@ class ExecutionProofGeneratingCoordinator(
       }
   }
 
-  private fun conflationToProofCreation(conflation: BlocksConflation): SafeFuture<*> {
-    val blockIntervalString = conflation.conflationResult.intervalString()
-    return l2ExecutionRequestBuilder.build(conflation)
-      .whenException { th ->
-        log.debug(
-          "l2-execution request building failed: batch={} errorMessage={}",
-          blockIntervalString,
-          th.message,
-          th,
-        )
-      }
-      .thenCompose { proofRequest ->
-        l2ExecutionProverClient.createProofRequest(proofRequest)
-          .thenCompose { proofIndex ->
-            l2ExecutionProverClient.findProofResponse(proofIndex)
-              .thenCompose<Unit> { existingResponse ->
-                if (existingResponse != null) {
-                  log.info(
-                    "batch={} already proven, skipping l2-execution proof response polling",
-                    blockIntervalString,
-                  )
-                  l2ExecutionProofHandler.acceptNewL2ExecutionProof(existingResponse).thenApply { }
-                } else {
-                  log.info(
-                    "l2-execution proof request generated: proofIndex={} batch={}",
-                    proofIndex,
-                    blockIntervalString,
-                  )
-                  proofRequestsInProgress.addLast(proofIndex)
-                  SafeFuture.completedFuture(Unit)
-                }
-              }
-          }
-          .whenException { th ->
-            log.debug(
-              "l2-execution proof failure: batch={} errorMessage={}",
-              blockIntervalString,
-              th.message,
-              th,
-            )
-          }
+  private fun checkAndSubmitProof(
+    proofIndex: BlockIntervalProofIndex,
+    proofRequest: L2ExecutionProofRequestV1,
+    blockIntervalString: String,
+  ): SafeFuture<Unit> {
+    return l2ExecutionProverClient.findProofResponse(proofIndex)
+      .thenCompose { existingResponse ->
+        if (existingResponse != null) {
+          log.info(
+            "batch={} already proven, skipping l2-execution proof response polling",
+            blockIntervalString,
+          )
+          l2ExecutionProofHandler.acceptNewL2ExecutionProof(existingResponse).thenApply { }
+        } else {
+          l2ExecutionProverClient.createProofRequest(proofRequest)
+            .thenApply {
+              log.info(
+                "l2-execution proof request generated: proofIndex={} batch={}",
+                proofIndex,
+                blockIntervalString,
+              )
+              proofRequestsInProgress.addLast(proofIndex)
+            }
+        }
       }
   }
 }

--- a/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/FakeInvalidityProverClient.kt
+++ b/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/FakeInvalidityProverClient.kt
@@ -15,6 +15,10 @@ class FakeInvalidityProverClient() : InvalidityProverClientV1 {
     TODO("Not yet implemented")
   }
 
+  override fun getProofIndex(proofRequest: InvalidityProofRequest): InvalidityProofIndex {
+    TODO("Not yet implemented")
+  }
+
   override fun createProofRequest(proofRequest: InvalidityProofRequest): SafeFuture<InvalidityProofIndex> {
     TODO("Not yet implemented")
   }


### PR DESCRIPTION
#3086 
Follow up to https://github.com/LFDT-Lineth/lineth-monorepo/pull/3684#discussion_r3736521451

## Summary

- Add `getProofIndex()` to `ProverProofRequestCreator` interface so the proof index can be derived from a proof request without submitting it
- Fix `ExecutionProofGeneratingCoordinator` to check for an existing proof response **before** creating the proof request (previously the request was submitted first just to get the index)
- Split the single `AsyncRetryer` into two: one retrying only `l2ExecutionRequestBuilder.build()` (expensive — no reason to rebuild on submission failure) and a second retrying the check-and-submit flow

## Test plan

- [ ] Existing unit tests for `GenericRiscVProverClient`, `GenericFileBasedProverClient`, and `ABProverClientRouter` pass
- [ ] `FakeInvalidityProverClient` compiles with the new interface method stubbed
- [ ] No regressions in `coordinator:core`, `coordinator:clients:prover-client:*`, or `coordinator:ethereum:forced-transactions`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the L2 execution proof submission flow and retry boundaries in a core coordinator path, which could affect whether proofs are skipped or resubmitted incorrectly.
> 
> **Overview**
> Avoids submitting redundant L2 execution proof requests by deriving the proof index and checking for an existing response **before** calling `createProofRequest`.
> 
> Adds `getProofIndex()` to `ProverProofRequestCreator` (implemented by file-based, RISC-V, and router clients) so the index can be obtained without submission. In `ExecutionProofGeneratingCoordinator`, splits retries into request building vs check-and-submit, and only submits when no response already exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaf60ef0e446aa2541351e53c04a9f9494c48d6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->