### PR TITLE
chore(linea-besu): logging reduce noise

### DIFF
--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/bl/TransactionProfitabilityCalculator.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/bl/TransactionProfitabilityCalculator.java
@@ -69,10 +69,11 @@ public class TransactionProfitabilityCalculator {
 
     final var profitAtWei = Wei.ofNumber(BigDecimal.valueOf(profitAt).toBigInteger());
 
-    log.atDebug()
+    log.atTrace()
         .setMessage(
-            "Estimated profitable priorityFeePerGas: {}; minMargin={}, fixedCostWei={}, "
-                + "variableCostWei={}, gas={}, txSize={}, compressedTxSize={}")
+            "Estimated profitable: tx={} priorityFeePerGas={}, minMargin={}, fixedCostWei={}, "
+                + "variableCostWei={}, gas={}, txSize={}, compressedTxSize={} ")
+        .addArgument(transaction::getHash)
         .addArgument(profitAtWei::toHumanReadableString)
         .addArgument(minMargin)
         .addArgument(profitabilityConf.fixedCostWei())
@@ -135,24 +136,11 @@ public class TransactionProfitabilityCalculator {
       final Wei minGasPriceWei) {
 
     final Wei profitableGasPrice = baseFee.add(profitablePriorityFee);
-
-    if (payingGasPrice.lessThan(profitableGasPrice)) {
-      log(
-          log.atDebug(),
-          context,
-          transaction,
-          minMargin,
-          payingGasPrice,
-          baseFee,
-          profitablePriorityFee,
-          profitableGasPrice,
-          gas,
-          minGasPriceWei);
-      return false;
-    }
+    final boolean isProfitable = payingGasPrice.greaterOrEqualThan(profitableGasPrice);
+    final LoggingEventBuilder loggingAtLevel = isProfitable ? log.atTrace() : log.atDebug();
 
     log(
-        log.atTrace(),
+        loggingAtLevel,
         context,
         transaction,
         minMargin,
@@ -162,7 +150,8 @@ public class TransactionProfitabilityCalculator {
         profitableGasPrice,
         gas,
         minGasPriceWei);
-    return true;
+
+    return isProfitable;
   }
 
   /**
@@ -188,7 +177,7 @@ public class TransactionProfitabilityCalculator {
       final Wei minGasPriceWei) {
 
     leb.setMessage(
-            "Context {}. Transaction {} has a margin of {}, minMargin={}, payingGasPrice={},"
+            "Context {}: tx={} has margin={}, minMargin={}, payingGasPrice={},"
                 + " profitableGasPrice={}, baseFee={}, profitablePriorityFee={}, fixedCostWei={}, variableCostWei={}, "
                 + " gasUsed={}")
         .addArgument(context)

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/sequencer/txselection/selectors/CompressionAwareTransactionSelector.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/sequencer/txselection/selectors/CompressionAwareTransactionSelector.java
@@ -259,7 +259,7 @@ public class CompressionAwareTransactionSelector
       if (!appendResult.getBlockAppended()) {
         log.atTrace()
             .setMessage(
-                "event=tx_selection path=slow decision=reject reason=block_compressed_size_overflow tx_hash={} fast_path_limit={}")
+                "event=tx_selection path=slow decision=reject reason=block_compressed_size_overflow tx={} fast_path_limit={}")
             .addArgument(transaction::getHash)
             .addArgument(fastExecutionPathLimit)
             .log();

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/sequencer/txselection/selectors/CompressionAwareTransactionSelector.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/sequencer/txselection/selectors/CompressionAwareTransactionSelector.java
@@ -179,7 +179,7 @@ public class CompressionAwareTransactionSelector
     if (newConservativeCumulative <= fastExecutionPathLimit) {
       log.atTrace()
           .setMessage(
-              "event=tx_selection path=fast decision=select tx_hash={} tx_compressed_size={} cumulative_conservative={} fast_path_limit={}")
+              "event=tx_selection path=fast decision=select tx={} tx_compressed_size={} cumulative_conservative={} fast_path_limit={}")
           .addArgument(transaction::getHash)
           .addArgument(txCompressedSize)
           .addArgument(newConservativeCumulative)
@@ -198,7 +198,7 @@ public class CompressionAwareTransactionSelector
 
     log.atTrace()
         .setMessage(
-            "event=tx_selection path=slow decision=pending tx_hash={} fast_path_limit={} tentative_tx_count={} tentative_block_rlp_size={}")
+            "event=tx_selection path=slow decision=pending tx={} fast_path_limit={} tentative_tx_count={} tentative_block_rlp_size={}")
         .addArgument(transaction::getHash)
         .addArgument(fastExecutionPathLimit)
         .addArgument(tentativeTxs::size)
@@ -235,7 +235,7 @@ public class CompressionAwareTransactionSelector
         final long waitNs = System.nanoTime() - waitStartNs;
         if (waitNs > 0) {
           log.atDebug()
-              .setMessage("event=tx_selection path=slow compression_wait_us={} tx_hash={}")
+              .setMessage("event=tx_selection path=slow compression_wait_us={} tx={}")
               .addArgument(waitNs / 1_000)
               .addArgument(transaction::getHash)
               .log();
@@ -243,14 +243,13 @@ public class CompressionAwareTransactionSelector
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
         log.atWarn()
-            .setMessage(
-                "event=tx_selection path=slow interrupted waiting for compression tx_hash={}")
+            .setMessage("event=tx_selection path=slow interrupted waiting for compression tx={}")
             .addArgument(transaction::getHash)
             .log();
         return BLOCK_COMPRESSED_SIZE_OVERFLOW;
       } catch (final ExecutionException e) {
         log.atWarn()
-            .setMessage("event=tx_selection path=slow compression failed tx_hash={}")
+            .setMessage("event=tx_selection path=slow compression failed tx={}")
             .addArgument(transaction::getHash)
             .setCause(e.getCause())
             .log();
@@ -270,7 +269,7 @@ public class CompressionAwareTransactionSelector
       newCumulativeSize = appendResult.getCompressedSizeAfter();
       log.atTrace()
           .setMessage(
-              "event=tx_selection path=slow decision=select tx_hash={} compressed_size_after={} fast_path_limit={}")
+              "event=tx_selection path=slow decision=select tx={} compressed_size_after={} fast_path_limit={}")
           .addArgument(transaction::getHash)
           .addArgument(newCumulativeSize)
           .addArgument(fastExecutionPathLimit)

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/sequencer/txselection/selectors/ProfitableTransactionSelector.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/sequencer/txselection/selectors/ProfitableTransactionSelector.java
@@ -223,15 +223,15 @@ public class ProfitableTransactionSelector implements PluginTransactionSelector 
 
     log.atTrace()
         .setMessage(
-            "{}: block[{}] tx {} , baseFee {}, effectiveGasPrice {}, ratio (effectivePayingPriorityFee {} / calculatedProfitablePriorityFee {}) {}")
+            "{}: block={}, tx={}, baseFee={}, effectiveGasPrice={}, ratio={} (effectivePayingPriorityFee={}/calculatedProfitablePriorityFee={})")
         .addArgument(label.name())
         .addArgument(evaluationContext.getPendingBlockHeader().getNumber())
         .addArgument(tx.getHash())
         .addArgument(baseFee::toHumanReadableString)
         .addArgument(evaluationContext.getTransactionGasPrice()::toHumanReadableString)
+        .addArgument(ratio)
         .addArgument(effectivePriorityFee::toHumanReadableString)
         .addArgument(profitablePriorityFeePerGas::toHumanReadableString)
-        .addArgument(ratio)
         .log();
   }
 

--- a/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
+++ b/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
@@ -140,7 +140,7 @@ public class ZkTracer implements LineCountingTracer {
     this.debugMode =
         debugLevel.none() ? Optional.empty() : Optional.of(new DebugMode(debugLevel, this.hub));
 
-    log.debug("Created ZkTracer for fork {}", chain.fork);
+    log.trace("Created ZkTracer for fork {}", chain.fork);
   }
 
   public void writeToFile(final Path filename, long startBlock, long endBlock) {

--- a/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
+++ b/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
@@ -120,7 +120,7 @@ public class ZkTracer implements LineCountingTracer {
   public ZkTracer(ChainConfig chain, PublicInputs publicInputs) {
     if (publicInputs.missingSomeInfos()) {
       log.info(
-          "[ZkTracer] Missing part of the public inputs, assuming line counting only, testing, or tracing very specific conflation. Tracing might fail. \nhistorical blockhashes size = {}\nblob base fees size = {}",
+          "Missing part of the public inputs, assuming line counting only, testing, or tracing very specific conflation. Tracing might fail. \nhistorical blockhashes size = {}\nblob base fees size = {}",
           publicInputs.historicalBlockhashes() == null
               ? 0
               : publicInputs.historicalBlockhashes().size(),
@@ -140,7 +140,7 @@ public class ZkTracer implements LineCountingTracer {
     this.debugMode =
         debugLevel.none() ? Optional.empty() : Optional.of(new DebugMode(debugLevel, this.hub));
 
-    log.info("[ZkTracer] Created ZkTracer for fork {}", chain.fork);
+    log.debug("Created ZkTracer for fork {}", chain.fork);
   }
 
   public void writeToFile(final Path filename, long startBlock, long endBlock) {
@@ -378,8 +378,7 @@ public class ZkTracer implements LineCountingTracer {
   /** When called, erase all tracing related to the bundle of all transactions since the last. */
   @Override
   public void popTransactionBundle() {
-    log.info(
-        "[ZkTracer] Transaction bundle has been popped, assuming block building. Tracing might fail.");
+    log.info("Transaction bundle has been popped, assuming block building. Tracing might fail.");
     hub.popTransactionBundle();
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to log levels and message text; transaction selection and tracing behavior are unchanged aside from what appears in logs at default levels.
> 
> **Overview**
> Lowers log volume during block building and tracing by adjusting levels and tightening message formats, without changing selection or tracing logic.
> 
> In **`TransactionProfitabilityCalculator`**, the profitable-priority-fee estimate moves from **debug** to **trace** and includes the transaction hash. Profitability checks now emit a **single** log per evaluation: **trace** when the tx is profitable, **debug** when it is not (replacing the previous split where unprofitable paths logged at debug and profitable at trace separately).
> 
> **`CompressionAwareTransactionSelector`** and **`ProfitableTransactionSelector`** only rename log fields (`tx_hash` → `tx`) and reorder/format profitability ratio fields for readability.
> 
> **`ZkTracer`** drops the `[ZkTracer]` prefix on several messages and downgrades routine “created for fork” logging from **info** to **trace**, while keeping **info** for missing public inputs and bundle pop warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 683e2fa1f6c9a91f84cbcbbc6c5b2a0927590eb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->