### PR TITLE
fix(verifier-ray): bench-compress

### DIFF
--- a/verifier-ray/bench/bench_compress/bench/bench-compress.csv
+++ b/verifier-ray/bench/bench_compress/bench/bench-compress.csv
@@ -1,2 +1,2 @@
 operation,cycles_per_call
-poseidon2 compress,8657.60
+poseidon2 compress,8674.20

--- a/verifier-ray/bench/bench_compress/build.zig
+++ b/verifier-ray/bench/bench_compress/build.zig
@@ -7,19 +7,46 @@ pub fn build(b: *std.Build) void {
     const target = common.standardGuestTarget(b);
     const optimize: std.builtin.OptimizeMode = .ReleaseSmall;
 
+    // This benchmark only ever builds for the R5 guest target, so `is_r5_zkvm`
+    // is unconditionally true here rather than an option as it is in
+    // ../../build.zig. Accelerators follow the same `-Ddisable-accelerators`
+    // convention as the main build so the two can be compared directly:
+    // measuring the software Poseidon2 path is the point of this benchmark, but
+    // the accelerated path is a one-flag change.
+    const disable_accelerators = b.option(
+        bool,
+        "disable-accelerators",
+        "Disable Lineth zkVM accelerator wrappers (measure the software path)",
+    ) orelse true;
+
+    const accel_dep = b.dependency("lineth_accelerators", .{ .target = target, .optimize = optimize });
+    const accel_mod = accel_dep.module("lineth_accelerators");
+
     const verifier_mod = b.addModule("verifier_ray", .{
         .root_source_file = b.path("../../src/lib.zig"),
         .target = target,
         .optimize = optimize,
         .strip = true,
     });
+    // src/crypto/poseidon2.zig imports `lineth_accelerators` only when
+    // r5_config.disable_accelerators is false, so the import must be supplied on
+    // exactly the same condition or the module fails to resolve.
+    if (!disable_accelerators) {
+        verifier_mod.addImport("lineth_accelerators", accel_mod);
+    }
+
+    // r5_config is required by src/crypto/poseidon2.zig since #3455 (Poseidon2
+    // acceleration). Without it the guest does not compile at all; this file had
+    // not been updated to match, so the benchmark had been broken since then.
+    const r5_options = b.addOptions();
+    r5_options.addOption(bool, "is_r5_zkvm", true);
+    r5_options.addOption(bool, "disable_accelerators", disable_accelerators);
+    verifier_mod.addOptions("r5_config", r5_options);
+
     const profiling_opts = b.addOptions();
     profiling_opts.addOption(bool, "is_enabled", false);
     profiling_opts.addOption(bool, "is_r5_marks", true);
     verifier_mod.addOptions("profiling_config", profiling_opts);
-
-    const accel_dep = b.dependency("lineth_accelerators", .{ .target = target, .optimize = optimize });
-    const accel_mod = accel_dep.module("lineth_accelerators");
 
     const main_mod = b.createModule(.{
         .root_source_file = b.path("main.zig"),

--- a/verifier-ray/bench/bench_compress/run.go
+++ b/verifier-ray/bench/bench_compress/run.go
@@ -55,6 +55,8 @@ type traceStats struct {
 
 func main() {
 	outFlag := flag.String("out", defaultOutput, "CSV output path")
+	accelFlag := flag.Bool("accel", false,
+		"measure the accelerated Poseidon2 path (custom RISC-V opcode) instead of the software one")
 	flag.Parse()
 	args := flag.Args()
 	zkcBin := "zkc"
@@ -62,8 +64,15 @@ func main() {
 		zkcBin = args[0]
 	}
 
+	// The build flag has to be forwarded here: this runner rebuilds the guest
+	// itself, so a manually flagged `zig build` would be silently overwritten.
+	buildArgs := []string{"build", "--release=small"}
+	if *accelFlag {
+		buildArgs = append(buildArgs, "-Ddisable-accelerators=false")
+	}
+
 	fmt.Fprintln(os.Stderr, "building R5 ELF...")
-	if err := run("zig", "build", "--release=small"); err != nil {
+	if err := run("zig", buildArgs...); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
@@ -92,13 +101,18 @@ func main() {
 	}
 
 	fmt.Fprintln(os.Stderr, "running zkc...")
+	// -vvv is required: zkc gates printf output behind verbosity level PRINTF.
+	// Both the arithmetization's per-instruction "clock cycle:" trace and the
+	// guest's VERIFIER-MARK writes go through printf, so without it this runner
+	// sees an empty stream and reports "no cycles recorded".
+	//
 	// --fast: execute for cycle counts only. The default (tracing) mode lowers
 	// the word machine to a field machine for AIR constraints, which currently
 	// panics under KOALABEAR_16 — the 32-bit `instruction` register exceeds the
 	// 16-bit field register width and register splitting (--split) is incomplete
 	// for multi-limb arithmetic. The benchmark only needs cycle counts, so the
 	// trace/AIR path is unnecessary.
-	zkcCmd := exec.Command(zkcBin, "exec", "--fast", r5JSON, zkcMain)
+	zkcCmd := exec.Command(zkcBin, "exec", "--fast", "-vvv", r5JSON, zkcMain)
 	stdout, err := zkcCmd.StdoutPipe()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
`bench_compress` has not compiled since #3455 added an `r5_config` import to `poseidon2.zig`, and its runner reported "no cycles recorded" because zkc gates `printf` output — which carries both the `clock cycle:` trace and the guest's `VERIFIER-MARK` writes — behind `-vvv`.

Fixes both, and forwards `-Ddisable-accelerators` through `run.go -accel`, which makes the accelerated Poseidon2 path measurable for the first time: **141.40 cycles/call against 8674.20 for software**.