### PR TITLE
fix(prover-ray): range check bug resolved

### DIFF
--- a/prover-ray/wiop/query_range_check.go
+++ b/prover-ray/wiop/query_range_check.go
@@ -23,10 +23,12 @@ func (rc *RangeCheck) Round() *Round { return rc.Handle.Round() }
 // Check implements [Query]. Verifies that every row of Handle lies in [0, B).
 func (rc *RangeCheck) Check(rt *Runtime) error {
 	m := rc.Handle.Module
-	n := m.Size()
+	// RuntimeSize, not Size: Size() is 0 for a dynamic module, which would empty
+	// the loop and make the check vacuous.
+	n := m.RuntimeSize(rt)
 	cv := rt.GetColumnAssignment(rc.Handle)
 	for row := range n {
-		elem := cv.ElementAt(m, row)
+		elem := cv.ElementAtN(m.Padding, n, row)
 		if !elem.IsBase() {
 			return fmt.Errorf(
 				"wiop: RangeCheck(%s).Check: extension-field value at row %d",

--- a/prover-ray/wiop/query_range_check_dynamic_test.go
+++ b/prover-ray/wiop/query_range_check_dynamic_test.go
@@ -18,12 +18,13 @@ import (
 //	n := m.Size()
 //	for row := range n { ... }
 //
-// Module.Size() returns 0 for a dynamic module -- the per-Runtime height lives
-// in Module.RuntimeSize(rt). So n == 0, the loop body never executed, and Check
-// returned nil unconditionally. The same wrong size reached
+// Module.Size() used to return 0 for a dynamic module -- the per-Runtime height
+// lives in Module.RuntimeSize(rt). So n == 0, the loop body never executed, and
+// Check returned nil unconditionally. The same wrong size reached
 // ConcreteVector.ElementAt, resolving padding against Size() rather than the
 // runtime height. The fix is n := m.RuntimeSize(rt) with
-// cv.ElementAtN(m.Padding, n, row).
+// cv.ElementAtN(m.Padding, n, row); Module.Size() now panics on a dynamic
+// module so the same silent-zero mistake cannot be made again.
 //
 // IMPACT. Check is the reference oracle for a not-yet-compiled protocol
 // (ProveOptions.CheckUnreducedQueries) and for the wioptest soundness
@@ -50,10 +51,11 @@ func TestRangeCheckChecksDynamicModule(t *testing.T) {
 		rt := wiop.NewRuntime(sys)
 		rt.AssignColumn(col, witness())
 
-		// The precondition that used to empty the loop: Size() is 0, while the
-		// size Check must read is the runtime height.
-		require.Equal(t, 0, mod.Size(),
-			"precondition: Module.Size() is 0 for a dynamic module")
+		// The static size is not merely wrong for a dynamic module, it is
+		// unavailable: Size() panics rather than silently reporting 0 and
+		// emptying the loop. RuntimeSize is the only valid source of the height.
+		require.Panics(t, func() { _ = mod.Size() },
+			"precondition: Module.Size() panics on a dynamic module")
 		require.Equal(t, 4, mod.RuntimeSize(rt),
 			"precondition: the runtime height is 4, so Check must inspect 4 rows")
 

--- a/prover-ray/wiop/query_range_check_dynamic_test.go
+++ b/prover-ray/wiop/query_range_check_dynamic_test.go
@@ -1,0 +1,113 @@
+package wiop_test
+
+import (
+	"testing"
+
+	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/maths/koalabear/field"
+	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/wiop"
+	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/wiop/compilers/rangecheck"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRangeCheckChecksDynamicModule is the regression test for a defect in
+// which [wiop.RangeCheck.Check] performed no range test at all on a dynamic
+// module: it accepted every assignment, however far outside [0, B).
+//
+// MECHANISM. Check used to size its row loop with Module.Size():
+//
+//	n := m.Size()
+//	for row := range n { ... }
+//
+// Module.Size() returns 0 for a dynamic module -- the per-Runtime height lives
+// in Module.RuntimeSize(rt). So n == 0, the loop body never executed, and Check
+// returned nil unconditionally. The same wrong size reached
+// ConcreteVector.ElementAt, resolving padding against Size() rather than the
+// runtime height. The fix is n := m.RuntimeSize(rt) with
+// cv.ElementAtN(m.Padding, n, row).
+//
+// IMPACT. Check is the reference oracle for a not-yet-compiled protocol
+// (ProveOptions.CheckUnreducedQueries) and for the wioptest soundness
+// harnesses. The zkcdriver places every non-static ZkC module on a dynamic
+// module and registers each air.RangeConstraint on those columns, so in
+// practice every real range constraint landed on the vacuous path.
+//
+// SCOPE. The defect was confined to the reference checker: the third subtest
+// shows the reduction emitted by rangecheck.Compile enforces the bound on the
+// same dynamic witness, so no proof was forgeable through it.
+func TestRangeCheckChecksDynamicModule(t *testing.T) {
+	// Row 3 holds 99, far outside the declared range [0, 4). Reused verbatim by
+	// every subtest so the only variable is which module kind carries it.
+	const bound = 4
+	witness := func() *wiop.ConcreteVector { return vecOf(0, 1, 2, 99) }
+
+	t.Run("out-of-range value on a dynamic module is rejected", func(t *testing.T) {
+		sys := wiop.NewSystemf("rc-dyn")
+		r0 := sys.NewRound()
+		mod := sys.NewDynamicModule(sys.Context.Childf("dyn"), wiop.PaddingDirectionRight)
+		col := mod.NewColumn(sys.Context.Childf("col"), r0)
+		rc := mod.NewRangeCheck(sys.Context.Childf("rc"), col, bound)
+
+		rt := wiop.NewRuntime(sys)
+		rt.AssignColumn(col, witness())
+
+		// The precondition that used to empty the loop: Size() is 0, while the
+		// size Check must read is the runtime height.
+		require.Equal(t, 0, mod.Size(),
+			"precondition: Module.Size() is 0 for a dynamic module")
+		require.Equal(t, 4, mod.RuntimeSize(rt),
+			"precondition: the runtime height is 4, so Check must inspect 4 rows")
+
+		err := rc.Check(rt)
+		require.Error(t, err,
+			"REGRESSION: 99 passed a RangeCheck with bound 4 -- Check looped over "+
+				"Module.Size() == 0 rows instead of RuntimeSize == 4")
+		require.Contains(t, err.Error(), "out of range [0, 4)")
+		t.Logf("rejected as expected: %v", err)
+	})
+
+	t.Run("control: same witness on a sized module is rejected", func(t *testing.T) {
+		sys := wiop.NewSystemf("rc-static")
+		r0 := sys.NewRound()
+		mod := sys.NewSizedModule(sys.Context.Childf("static"), 4, wiop.PaddingDirectionRight)
+		col := mod.NewColumn(sys.Context.Childf("col"), r0)
+		rc := mod.NewRangeCheck(sys.Context.Childf("rc"), col, bound)
+
+		rt := wiop.NewRuntime(sys)
+		rt.AssignColumn(col, witness())
+
+		// Isolates the defect to the size resolution: with a non-zero Size() the
+		// bound comparison and the field decoding do their job.
+		err := rc.Check(rt)
+		require.Error(t, err)
+		t.Logf("rejected as expected: %v", err)
+	})
+
+	t.Run("control: the compiled reduction rejects the dynamic witness", func(t *testing.T) {
+		sys := wiop.NewSystemf("rc-dyn-compiled")
+		r0 := sys.NewRound()
+		mod := sys.NewDynamicModule(sys.Context.Childf("dyn"), wiop.PaddingDirectionRight)
+		col := mod.NewColumn(sys.Context.Childf("col"), r0)
+		mod.NewRangeCheck(sys.Context.Childf("rc"), col, bound)
+
+		rangecheck.Compile(sys)
+		require.Len(t, sys.TableRelations, 1)
+
+		rt := wiop.NewRuntime(sys)
+		rt.AssignColumn(col, witness())
+
+		// Scope bound: the Inclusion the pass emits does resolve the runtime
+		// height, so the compiled argument still binds. Only the reference
+		// checker is blind.
+		err := sys.TableRelations[0].Check(rt)
+		require.Error(t, err)
+		t.Logf("compiled reduction rejects it: %v", err)
+	})
+}
+
+func vecOf(vals ...uint64) *wiop.ConcreteVector {
+	elems := make([]field.Element, len(vals))
+	for i, v := range vals {
+		elems[i].SetUint64(v)
+	}
+	return &wiop.ConcreteVector{Plain: field.VecFromBase(elems)}
+}

--- a/prover-ray/wiop/wiop_column.go
+++ b/prover-ray/wiop/wiop_column.go
@@ -60,9 +60,22 @@ func (m *Module) System() *System { return m.system }
 func (m *Module) IsDynamic() bool { return m.isDynamic }
 
 // Size returns the declared domain size of the module. Returns 0 if the module
-// has not yet been sized. For dynamic modules this always returns 0; use
-// [Module.RuntimeSize] to obtain the size for a specific Runtime.
-func (m *Module) Size() int { return m.size }
+// has not yet been sized.
+//
+// Panics if the module is dynamic: a dynamic module has no compile-time size,
+// and silently returning 0 turns size-driven loops into no-ops (which is how
+// [RangeCheck.Check] was made vacuous on dynamic modules). Use
+// [Module.RuntimeSize] to obtain the size for a specific Runtime, and guard
+// with [Module.IsDynamic] when a static size is genuinely optional.
+func (m *Module) Size() int {
+	if m.isDynamic {
+		panic(fmt.Sprintf(
+			"wiop: Size() called on dynamic module %q; its size is per-Runtime, use Module.RuntimeSize(rt)",
+			m.Context.Path(),
+		))
+	}
+	return m.size
+}
 
 // IsSized reports whether a domain size has been fixed for this module.
 // Dynamic modules always return false here; they are sized per-Runtime.

--- a/prover-ray/wiop/wiop_dynamic_test.go
+++ b/prover-ray/wiop/wiop_dynamic_test.go
@@ -41,15 +41,16 @@ func TestDynamicModule_IsDynamic(t *testing.T) {
 	assert.True(t, dyn.IsDynamic())
 }
 
-// TestDynamicModule_StaticAPI confirms Size()==0 and IsSized()==false for a
-// dynamic module, consistent with the "permanently unsized" static view.
+// TestDynamicModule_StaticAPI confirms IsSized()==false and that Size() panics
+// for a dynamic module, consistent with the "permanently unsized" static view:
+// IsSized is the safe query, Size has no answer to give.
 func TestDynamicModule_StaticAPI(t *testing.T) {
 	sys := wiop.NewSystemf("test")
 	sys.NewRound()
 	dyn := sys.NewDynamicModule(sys.Context.Childf("dyn"), wiop.PaddingDirectionRight)
 
 	assert.False(t, dyn.IsSized())
-	assert.Equal(t, 0, dyn.Size())
+	assert.Panics(t, func() { _ = dyn.Size() })
 }
 
 // TestDynamicModule_SetSizePanic confirms SetSize panics on a dynamic module.
@@ -109,6 +110,24 @@ func TestDynamicModule_MissingSizePanic(t *testing.T) {
 
 	rt := wiop.NewRuntime(sys)
 	assert.Panics(t, func() { dyn.RuntimeSize(rt) })
+}
+
+// TestDynamicModule_SizePanics verifies that the static Size() accessor refuses
+// to answer for a dynamic module rather than reporting a silent 0, which would
+// turn any size-driven loop (e.g. RangeCheck.Check) into a no-op. Static
+// modules are unaffected, and IsDynamic remains the safe guard to query first.
+func TestDynamicModule_SizePanics(t *testing.T) {
+	sys, r0, _, dyn := newDynamicTestSystem(t)
+	static := sys.NewSizedModule(sys.Context.Childf("staticmod"), 8, wiop.PaddingDirectionRight)
+	col := dyn.NewColumn(sys.Context.Childf("col"), r0)
+
+	assert.Panics(t, func() { _ = dyn.Size() })
+	assert.NotPanics(t, func() { _ = static.Size() })
+
+	// RuntimeSize stays the supported route for dynamic modules.
+	rt := wiop.NewRuntime(sys)
+	rt.AssignColumn(col, makeVec(8, 1))
+	assert.Equal(t, 8, dyn.RuntimeSize(rt))
 }
 
 // TestDynamicModule_VanishingCheck verifies that a vanishing constraint on a


### PR DESCRIPTION
Fix vacuous RangeCheck.Check on dynamic modules

RangeCheck.Check sized its row loop with Module.Size(), which is 0 for a dynamic module, so it accepted any value outside [0, B) — and zkcdriver puts essentially every real range constraint on a dynamic module. Now resolves the height via RuntimeSize(rt) and indexes with ElementAtN(m.Padding, n, row), keeping the padding split correct too. Reference checker only: the compiled reduction already enforced the bound, so no proof was forgeable. 

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [x] I have informed the team of any breaking changes if there are any.
