### PR TITLE
fix(prover-ray): permutation/lookup bug involving shifts cancellation from vanishing calls

### DIFF
--- a/prover-ray/wiop/compilers/grandproduct/grandproduct.go
+++ b/prover-ray/wiop/compilers/grandproduct/grandproduct.go
@@ -139,17 +139,30 @@ func buildZ(
 		round,
 	)
 
-	// Recurrence Z[i]·zDen − Z[i−1]·zNum. The −1 shift on Z places row 0 in
-	// NewVanishing's cancelled positions, so the recurrence is vacuous on row 0
-	// (pinned separately by the local constraint below) and on a one-row
-	// dynamic module. For a statically one-row module it is skipped outright.
+	// Recurrence Z[i]·zDen − Z[i−1]·zNum, cancelled on row 0 only: row 0 is
+	// pinned separately by the local constraint below, and cancelling it also
+	// makes the recurrence vacuous on a one-row dynamic module. For a statically
+	// one-row module it is skipped outright.
+	//
+	// The cancellation set is declared manually rather than inferred by
+	// NewVanishing. Inference derives cancelled rows from every shift in the
+	// expression tree, and zNum/zDen embed the caller's factor expressions
+	// verbatim -- a factor read as col.View().Shift(+k) would cancel the last k
+	// rows too. Row n−1 is exactly the row opened as ZFinal below and fed to
+	// FinalProductCheck; cancelling it would sever Z[n−1] from Z[n−2] and let a
+	// prover choose the endpoint freely, so CheckResultIsOne would accept an
+	// arbitrary non-permuted multiset. Shifts on factor columns are cyclic
+	// (tableElemAt wraps mod n), so the recurrence is genuinely well-defined on
+	// every row but the first and needs no further exemption. Compare
+	// localvanishing.liftToGlobal, which avoids the same inference for its own
+	// reasons.
 	if m.IsDynamic() || m.Size() > 1 {
 		zView := zCol.View()
 		recurrence := wiop.Sub(
 			wiop.Mul(zView, zDen),
 			wiop.Mul(zView.Shift(-1), zNum),
 		)
-		m.NewVanishing(ctx.Childf("z-recurrence-m%d-k%d", mi, k), recurrence)
+		m.NewVanishingManual(ctx.Childf("z-recurrence-m%d-k%d", mi, k), recurrence, 0)
 	}
 
 	// Initial condition at row 0: Z[0]·zDen − zNum = 0, i.e. Z[0] = zNum/zDen.

--- a/prover-ray/wiop/compilers/grandproduct/z_recurrence_cancellation_test.go
+++ b/prover-ray/wiop/compilers/grandproduct/z_recurrence_cancellation_test.go
@@ -1,0 +1,68 @@
+package grandproduct_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/wiop"
+	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/wiop/compilers/grandproduct"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// zRecurrenceCancellations returns, for every Vanishing whose context name
+// contains "z-recurrence", the constraint name and its CancelledPositions.
+func zRecurrenceCancellations(sys *wiop.System) map[string][]int {
+	out := make(map[string][]int)
+	for _, m := range sys.Modules {
+		for _, v := range m.Vanishings {
+			name := v.Context().String()
+			if strings.Contains(name, "z-recurrence") {
+				out[name] = v.CancelledPositions
+			}
+		}
+	}
+	return out
+}
+
+// TestBuildZ_ShiftedFactorMustNotCancelEndpointRow pins the invariant that the
+// running-product recurrence cancels row 0 and nothing else, regardless of what
+// shifts appear inside the caller's factor expressions.
+//
+// The recurrence is Z·zDen − Z<<−1·zNum, and zNum/zDen embed the permutation's
+// factor expressions verbatim. Registering it with Module.NewVanishing derives
+// the cancelled rows from *every* shift in the tree, so a factor column read as
+// colA.View().Shift(+1) cancels the last row on top of row 0.
+//
+// The last row is exactly the row opened as ZFinal and fed to
+// FinalProductCheck. Cancelling it severs Z[n−1] from Z[n−2]: a malicious
+// prover picks the endpoint freely so the product reads as one, and
+// CheckResultIsOne accepts an arbitrary non-permuted multiset. Only row 0 may
+// ever be cancelled here -- factor-column shifts are cyclic (tableElemAt wraps
+// mod n), so the recurrence is well-defined on every row but the first.
+func TestBuildZ_ShiftedFactorMustNotCancelEndpointRow(t *testing.T) {
+	sys := wiop.NewSystemf("gp-shifted-factor")
+	r0 := sys.NewRound()
+	modA := sys.NewSizedModule(sys.Context.Childf("modA"), 4, wiop.PaddingDirectionNone)
+	modB := sys.NewSizedModule(sys.Context.Childf("modB"), 4, wiop.PaddingDirectionNone)
+	colA := modA.NewColumn(sys.Context.Childf("A"), r0)
+	colB := modB.NewColumn(sys.Context.Childf("B"), r0)
+	sys.NewPermutation(
+		sys.Context.Childf("perm"),
+		[]wiop.Table{wiop.NewTable(colA.View().Shift(1))}, // A side read with a +1 shift
+		[]wiop.Table{wiop.NewTable(colB.View())},
+	)
+
+	grandproduct.Compile(sys)
+
+	cancellations := zRecurrenceCancellations(sys)
+	require.NotEmpty(t, cancellations,
+		"compile must register at least one z-recurrence Vanishing")
+
+	for name, positions := range cancellations {
+		assert.Equal(t, []int{0}, positions,
+			"%s: z-recurrence must cancel row 0 only; cancelling a negative "+
+				"position un-constrains the ZFinal endpoint row and breaks "+
+				"soundness of the permutation argument", name)
+	}
+}

--- a/prover-ray/wiop/compilers/logderivativesum/logderivativesum.go
+++ b/prover-ray/wiop/compilers/logderivativesum/logderivativesum.go
@@ -160,9 +160,21 @@ func buildZ(
 		ctx.Childf("z-b%d-k%d", bIdx, kIdx),
 		round)
 
-	// The recurrence zNum − (Z − Z<<−1)·zDen carries a −1 shift on Z, so
-	// NewVanishing automatically cancels row 0; the row-0 boundary is pinned
-	// separately by the local constraint below.
+	// The recurrence zNum − (Z − Z<<−1)·zDen is cancelled on row 0 only; the
+	// row-0 boundary is pinned separately by the local constraint below.
+	//
+	// The cancellation set is declared manually rather than inferred by
+	// NewVanishing. Inference derives cancelled rows from every shift in the
+	// expression tree, and zNum/zDen embed the caller's fraction expressions
+	// verbatim -- a numerator read as col.View().Shift(+k) would cancel the last
+	// k rows too. This is production-reachable: zkcdriver applies
+	// ColumnAccess.RelativeShift to lookup source/target views, so any corset
+	// lookup over a shifted register lands here. Row n−1 is exactly the row
+	// opened as the Z endpoint and summed into the LogDerivativeSum Result;
+	// cancelling it would sever Z[n−1] from Z[n−2] and let a prover choose the
+	// endpoint freely, passing the final-sum check for an arbitrary witness.
+	// Shifts on fraction columns are cyclic (tableElemAt wraps mod n), so the
+	// recurrence is genuinely well-defined on every row but the first.
 	//
 	// For a *statically* one-row module the recurrence is vacuous and we
 	// skip it as an optimisation. For a dynamic module we cannot know the
@@ -174,15 +186,16 @@ func buildZ(
 		recurrence := wiop.Sub(
 			zNum,
 			wiop.Mul(
-				// Shift(-1) is load-bearing for the dynamic n=1 corner case: it puts row 0 in NewVanishing's
-				// CancelledPositions, so when RuntimeSize == 1 the only row is cancelled and Check is vacuous.
+				// Cancelling row 0 is load-bearing for the dynamic n=1 corner case: when
+				// RuntimeSize == 1 the only row is cancelled and Check is vacuous.
 				wiop.Sub(zView, zView.Shift(-1)),
 				zDen,
 			),
 		)
-		m.NewVanishing(
+		m.NewVanishingManual(
 			ctx.Childf("z-recurrence-b%d-k%d", bIdx, kIdx),
 			recurrence,
+			0,
 		)
 	}
 

--- a/prover-ray/wiop/compilers/logderivativesum/z_recurrence_cancellation_test.go
+++ b/prover-ray/wiop/compilers/logderivativesum/z_recurrence_cancellation_test.go
@@ -1,0 +1,74 @@
+package logderivativesum_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/maths/koalabear/field"
+	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/wiop"
+	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/wiop/compilers/logderivativesum"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// zRecurrenceCancellations returns, for every Vanishing whose context name
+// contains "z-recurrence", the constraint name and its CancelledPositions.
+func zRecurrenceCancellations(sys *wiop.System) map[string][]int {
+	out := make(map[string][]int)
+	for _, m := range sys.Modules {
+		for _, v := range m.Vanishings {
+			name := v.Context().String()
+			if strings.Contains(name, "z-recurrence") {
+				out[name] = v.CancelledPositions
+			}
+		}
+	}
+	return out
+}
+
+// TestBuildZ_ShiftedFractionMustNotCancelEndpointRow pins the invariant that
+// the running-sum recurrence cancels row 0 and nothing else, regardless of what
+// shifts appear inside the caller's fraction expressions.
+//
+// The recurrence is zNum − (Z − Z<<−1)·zDen, and zNum/zDen embed the fraction
+// numerators/denominators verbatim. Registering it with Module.NewVanishing
+// derives the cancelled rows from *every* shift in the tree, so a numerator
+// read as col.View().Shift(+1) cancels the last row on top of row 0.
+//
+// The last row is exactly the row opened as the Z endpoint and summed into the
+// LogDerivativeSum Result. Cancelling it severs Z[n−1] from Z[n−2], letting a
+// malicious prover choose the endpoint freely and pass the final-sum check for
+// an arbitrary witness. This path is production-reachable: zkcdriver applies
+// ColumnAccess.RelativeShift to lookup source/target views, so any corset
+// lookup over a shifted register lands here.
+//
+// Only row 0 may ever be cancelled -- shifts on fraction columns are cyclic
+// (tableElemAt wraps mod n), so the recurrence is well-defined on every row
+// but the first.
+func TestBuildZ_ShiftedFractionMustNotCancelEndpointRow(t *testing.T) {
+	sys := wiop.NewSystemf("lds-shifted-fraction")
+	r0 := sys.NewRound()
+	sys.NewRound()
+	mod := sys.NewSizedModule(sys.Context.Childf("mod"), 4, wiop.PaddingDirectionNone)
+	num := mod.NewColumn(sys.Context.Childf("num"), r0)
+	one := wiop.NewConstantVector(mod, field.NewFromString("1"))
+	sys.NewLogDerivativeSum(
+		sys.Context.Childf("ld"),
+		// Numerator read with a +1 shift, mirroring what zkcdriver produces for
+		// a lookup over a shifted register.
+		[]wiop.Fraction{{Numerator: num.View().Shift(1), Denominator: one}},
+	)
+
+	logderivativesum.Compile(sys)
+
+	cancellations := zRecurrenceCancellations(sys)
+	require.NotEmpty(t, cancellations,
+		"compile must register at least one z-recurrence Vanishing")
+
+	for name, positions := range cancellations {
+		assert.Equal(t, []int{0}, positions,
+			"%s: z-recurrence must cancel row 0 only; cancelling a negative "+
+				"position un-constrains the Z endpoint row and breaks soundness "+
+				"of the log-derivative argument", name)
+	}
+}

--- a/prover-ray/wiop/query_vanishing.go
+++ b/prover-ray/wiop/query_vanishing.go
@@ -106,6 +106,24 @@ func (v *Vanishing) CheckGnark(_ frontend.API, _ GnarkRuntime) {
 //
 // The resulting position list is sorted and deduplicated before storage.
 //
+// WARNING: inference walks the *whole* expression tree and cannot distinguish a
+// shift that denotes a real domain-boundary exemption from one that is merely
+// incidental. It is safe only when the caller authored every shift in expr and
+// intends each to exempt rows. Do not use it on a compiler-synthesised
+// expression that splices in subexpressions supplied by a caller: a shift
+// buried in a spliced-in operand silently widens the cancellation set, and
+// every cancelled row is a row on which the constraint does not hold. If such a
+// row is also read by an opening or a downstream check, the value there is
+// unconstrained and the argument loses soundness -- this is exactly how
+// grandproduct and logderivativesum un-constrained their Z endpoints when a
+// factor column carried a +k shift. Use [Module.NewVanishingManual] with an
+// explicit set whenever the intended exemptions are known up front; see
+// buildZ in either compiler, or localvanishing.liftToGlobal, for the pattern.
+//
+// Note also that shifts on a cyclic domain wrap (tableElemAt reads mod n), so a
+// shifted read is well-defined on every row and does not by itself require any
+// exemption.
+//
 // Panics if ctx or expr is nil.
 func (m *Module) NewVanishing(ctx *ContextFrame, expr Expression) *Vanishing {
 	if ctx == nil {
@@ -125,6 +143,11 @@ func (m *Module) NewVanishing(ctx *ContextFrame, expr Expression) *Vanishing {
 //
 // Positive positions index from the start; negative positions index from the
 // end. The list is sorted and deduplicated before storage.
+//
+// Prefer this over [Module.NewVanishing] whenever the intended exemptions are
+// known at construction time -- in particular when expr embeds subexpressions
+// supplied by a caller, where shift-based inference would over-cancel. See the
+// warning on [Module.NewVanishing].
 //
 // Panics if ctx or expr is nil.
 func (m *Module) NewVanishingManual(ctx *ContextFrame, expr Expression, positions ...int) *Vanishing {


### PR DESCRIPTION
`buildZ` in grandproduct and logderivativesum registered the running-product/sum recurrence with `NewVanishing`, which infers cancelled rows from *every* shift in the tree — including shifts inside the caller's factor/fraction expressions — so a `+k`-shifted column cancelled the last k rows on top of row 0, leaving the opened `ZFinal` row unconstrained and letting a prover forge the endpoint (reachable in production via `zkcdriver`'s `RelativeShift` on lookup views).

Both now use `NewVanishingManual(..., 0)` to cancel row 0 only — preserving the dynamic `n=1` vacuity — plus a warning on `NewVanishing` about inference over spliced-in subexpressions, and a regression test per compiler pinning `CancelledPositions == {0}`.

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.
