### PR TITLE
feat(coordinator): add RiscvProverClientFactory with execution proof support

### DIFF
--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/lineth/coordinator/clients/prover/ABProverClientRouter.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/lineth/coordinator/clients/prover/ABProverClientRouter.kt
@@ -5,6 +5,7 @@ import linea.clients.InvalidityProofRequest
 import linea.clients.ProverClient
 import linea.domain.AggregationProofIndex
 import linea.domain.BlobCompressionProofRequest
+import linea.domain.BlockInterval
 import linea.domain.CompressionProofIndex
 import linea.domain.ExecutionProofIndex
 import linea.domain.InvalidityProofIndex
@@ -27,6 +28,7 @@ class StartBlockNumberBasedSwitchPredicate(
       is CompressionProofIndex -> proofRequestOrIndex.startBlockNumber
       is AggregationProofIndex -> proofRequestOrIndex.startBlockNumber
       is InvalidityProofIndex -> proofRequestOrIndex.simulatedExecutionBlockNumber
+      is BlockInterval -> proofRequestOrIndex.startBlockNumber
       else ->
         throw IllegalArgumentException("Unsupported proof request or index type: ${proofRequestOrIndex::class}")
     }
@@ -52,6 +54,40 @@ class ABProverClientRouter<ProofRequest : Any, ProofResponse, TProofIndex : Proo
   private val proverB: ProverClient<ProofRequest, ProofResponse, TProofIndex>,
   private val switchToProverBPredicate: (Any) -> Boolean,
 ) : ProverClient<ProofRequest, ProofResponse, TProofIndex> {
+
+  companion object {
+    fun <TProverConfig, ProofRequest : Any, ProofResponse, TProofIndex : ProofIndex> create(
+      proverAConfig: TProverConfig,
+      proverBConfig: TProverConfig?,
+      switchBlockNumberInclusive: ULong?,
+      switchBlockTimestamp: Instant?,
+      clientBuilder: (TProverConfig) -> ProverClient<ProofRequest, ProofResponse, TProofIndex>,
+    ): ProverClient<ProofRequest, ProofResponse, TProofIndex> {
+      return when {
+        switchBlockNumberInclusive != null -> {
+          require(proverBConfig != null) {
+            "proverBConfig must be provided when switchBlockNumberInclusive is set"
+          }
+          ABProverClientRouter(
+            proverA = clientBuilder(proverAConfig),
+            proverB = clientBuilder(proverBConfig),
+            switchToProverBPredicate = StartBlockNumberBasedSwitchPredicate(switchBlockNumberInclusive)::invoke,
+          )
+        }
+        switchBlockTimestamp != null -> {
+          require(proverBConfig != null) {
+            "proverBConfig must be provided when switchBlockTimestamp is set"
+          }
+          ABProverClientRouter(
+            proverA = clientBuilder(proverAConfig),
+            proverB = clientBuilder(proverBConfig),
+            switchToProverBPredicate = StartBlockTimestampBasedSwitchPredicate(switchBlockTimestamp)::invoke,
+          )
+        }
+        else -> clientBuilder(proverAConfig)
+      }
+    }
+  }
 
   private fun getProver(proofRequestOrIndex: Any): ProverClient<ProofRequest, ProofResponse, TProofIndex> {
     return if (switchToProverBPredicate(proofRequestOrIndex)) {

--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/lineth/coordinator/clients/prover/ProverClientFactory.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/lineth/coordinator/clients/prover/ProverClientFactory.kt
@@ -5,13 +5,10 @@ import linea.clients.BlobCompressionProverClientV2
 import linea.clients.ExecutionProverClientV2
 import linea.clients.InvalidityProverClientV1
 import linea.clients.ProofAggregationProverClientV2
-import linea.clients.ProverClient
-import linea.domain.ProofIndex
 import lineth.metrics.LineaMetricsCategory
 import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.linea.metrics.micrometer.GaugeAggregator
 import org.apache.logging.log4j.Logger
-import kotlin.time.Instant
 
 class ProverClientFactory(
   private val vertx: Vertx,
@@ -52,7 +49,7 @@ class ProverClientFactory(
   }
 
   fun executionProverClient(log: Logger = FileBasedExecutionProverClientV2.LOG): ExecutionProverClientV2 {
-    return createClient(
+    return ABProverClientRouter.create(
       proverAConfig = config.proverA.execution,
       proverBConfig = config.proverB?.execution,
       switchBlockNumberInclusive = config.switchBlockNumberInclusive,
@@ -69,7 +66,7 @@ class ProverClientFactory(
   fun blobCompressionProverClient(
     log: Logger = FileBasedBlobCompressionProverClientV2.LOG,
   ): BlobCompressionProverClientV2 {
-    return createClient(
+    return ABProverClientRouter.create(
       proverAConfig = requireNotNull(config.proverA.blobCompression) {
         "proverA.blobCompression must be configured to use blobCompressionProverClient"
       },
@@ -89,7 +86,7 @@ class ProverClientFactory(
   fun proofAggregationProverClient(
     log: Logger = FileBasedProofAggregationClientV2.LOG,
   ): ProofAggregationProverClientV2 {
-    return createClient(
+    return ABProverClientRouter.create(
       proverAConfig = config.proverA,
       proverBConfig = config.proverB,
       switchBlockNumberInclusive = config.switchBlockNumberInclusive,
@@ -110,7 +107,7 @@ class ProverClientFactory(
       throw IllegalStateException("Invalidity prover config is not configured")
     }
 
-    return createClient(
+    return ABProverClientRouter.create(
       proverAConfig = config.proverA,
       proverBConfig = config.proverB,
       switchBlockNumberInclusive = config.switchBlockNumberInclusive,
@@ -121,41 +118,6 @@ class ProverClientFactory(
         vertx = vertx,
       )
         .also { invalidityWaitingResponsesMetric.addReporter(it) }
-    }
-  }
-
-  private fun <TProverConfig, ProofRequest, ProofResponse, TProofIndex> createClient(
-    proverAConfig: TProverConfig,
-    proverBConfig: TProverConfig?,
-    switchBlockNumberInclusive: ULong?,
-    switchBlockTimestamp: Instant?,
-    clientBuilder: (TProverConfig) -> ProverClient<ProofRequest, ProofResponse, TProofIndex>,
-  ): ProverClient<ProofRequest, ProofResponse, TProofIndex>
-    where ProofRequest : Any, TProofIndex : ProofIndex {
-    return when {
-      switchBlockNumberInclusive != null -> {
-        require(proverBConfig != null) {
-          "proverBConfig must be provided when switchBlockNumberInclusive is set"
-        }
-        val switchPredicate = StartBlockNumberBasedSwitchPredicate(switchBlockNumberInclusive)
-        ABProverClientRouter(
-          proverA = clientBuilder(proverAConfig),
-          proverB = clientBuilder(proverBConfig),
-          switchToProverBPredicate = switchPredicate::invoke,
-        )
-      }
-      switchBlockTimestamp != null -> {
-        require(proverBConfig != null) {
-          "proverBConfig must be provided when switchBlockTimestamp is set"
-        }
-        val switchPredicate = StartBlockTimestampBasedSwitchPredicate(switchBlockTimestamp)
-        ABProverClientRouter(
-          proverA = clientBuilder(proverAConfig),
-          proverB = clientBuilder(proverBConfig),
-          switchToProverBPredicate = switchPredicate::invoke,
-        )
-      }
-      else -> clientBuilder(proverAConfig)
     }
   }
 }

--- a/coordinator/clients/prover-client/riscv-client/build.gradle
+++ b/coordinator/clients/prover-client/riscv-client/build.gradle
@@ -7,6 +7,7 @@ dependencies {
   implementation project(':coordinator:core-interfaces')
   // Reused for GenericFileBasedProverClient and FileBasedProverConfig used by the file-based transport.
   implementation project(':coordinator:clients:prover-client:file-based-client')
+  implementation project(':jvm-libs:linea:metrics:micrometer')
   implementation project(':coordinator:utilities')
   implementation project(':jvm-libs:generic:http-rest')
   implementation "io.vertx:vertx-web-client"

--- a/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/RiscvProverClientFactory.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/RiscvProverClientFactory.kt
@@ -1,0 +1,72 @@
+package lineth.coordinator.clients.prover.riscv
+
+import io.vertx.core.Vertx
+import linea.clients.L2ExecutionProverClientV1
+import linea.domain.BlockIntervalProofIndex
+import lineth.coordinator.clients.prover.ABProverClientRouter
+import lineth.coordinator.clients.prover.FileBasedProverConfig
+import lineth.coordinator.clients.prover.ProversConfig
+import lineth.coordinator.clients.prover.serialization.JsonSerialization
+import lineth.fileio.FileReader
+import lineth.fileio.FileWriter
+import lineth.metrics.LineaMetricsCategory
+import net.consensys.linea.metrics.MetricsFacade
+import net.consensys.linea.metrics.micrometer.GaugeAggregator
+
+class RiscvProverClientFactory(
+  private val vertx: Vertx,
+  private val config: ProversConfig,
+  private val l2MessageServiceAddress: String,
+  private val coinbase: String,
+  metricsFacade: MetricsFacade,
+) {
+  private val executionWaitingResponsesMetric = GaugeAggregator()
+
+  init {
+    metricsFacade.createGauge(
+      category = LineaMetricsCategory.BATCH,
+      name = "prover.waiting",
+      description = "Number of RISC-V execution proof waiting responses",
+      measurementSupplier = executionWaitingResponsesMetric,
+    )
+  }
+
+  fun executionProverClient(): L2ExecutionProverClientV1 {
+    return ABProverClientRouter.create(
+      proverAConfig = config.proverA.execution,
+      proverBConfig = config.proverB?.execution,
+      switchBlockNumberInclusive = config.switchBlockNumberInclusive,
+      switchBlockTimestamp = config.switchBlockTimestamp,
+    ) { proverConfig ->
+      buildL2ExecutionProverClient(proverConfig)
+        .also { executionWaitingResponsesMetric.addReporter(it) }
+    }
+  }
+
+  private fun buildL2ExecutionProverClient(proverConfig: FileBasedProverConfig): L2ExecutionProverClient {
+    val transport = FileBasedProverProofTransport<
+      L2ExecutionProofRequestDto,
+      L2ExecutionProofResponseDto,
+      BlockIntervalProofIndex,
+      >(
+      config = proverConfig,
+      vertx = vertx,
+      fileWriter = FileWriter(vertx, JsonSerialization.proofResponseMapperV1),
+      fileReader = FileReader(
+        vertx,
+        JsonSerialization.proofResponseMapperV1,
+        L2ExecutionProofResponseDto::class.java,
+      ),
+      requestFileNameProvider = L2ExecutionProofFileNameProvider,
+      responseFileNameProvider = L2ExecutionProofFileNameProvider,
+    )
+    return L2ExecutionProverClient(
+      transport = transport,
+      guestProgramId = requireNotNull(proverConfig.guestProgramId) {
+        "guestProgramId must be configured for the RISC-V execution prover"
+      },
+      l2MessageServiceAddress = l2MessageServiceAddress,
+      coinbase = coinbase,
+    )
+  }
+}


### PR DESCRIPTION
## Summary

- Extracts `ABProverClientRouter.create()` as a companion method so the A/B routing logic is shared — `ProverClientFactory` call sites now invoke it directly with no private wrapper
- Adds `BlockInterval` as a fallback case in `StartBlockNumberBasedSwitchPredicate` to handle `L2ExecutionProofRequestV1` and `BlockIntervalProofIndex` without listing every RISC-V type explicitly
- Introduces `RiscvProverClientFactory` in `riscv-client` that creates a `L2ExecutionProverClient` backed by `FileBasedProverProofTransport`, with optional A/B routing and the same `GaugeAggregator` waiting-response metrics pattern as `ProverClientFactory`

## Test plan

- [ ] `./gradlew :coordinator:clients:prover-client:file-based-client:compileKotlin` passes
- [ ] `./gradlew :coordinator:clients:prover-client:riscv-client:compileKotlin` passes
- [ ] `./gradlew :coordinator:clients:prover-client:file-based-client:spotlessCheck :coordinator:clients:prover-client:riscv-client:spotlessCheck` passes
- [ ] `./gradlew :coordinator:clients:prover-client:file-based-client:test` passes
- [ ] `./gradlew :coordinator:clients:prover-client:riscv-client:test` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared prover A/B routing used by all file-based proof clients; misconfiguration of switch blocks or prover B could route production proof traffic incorrectly, though behavior is a refactor plus a new parallel RISC-V factory path.
> 
> **Overview**
> **Centralizes A/B prover switching** by moving the former `ProverClientFactory` `createClient` logic into `ABProverClientRouter.create()`, so file-based and RISC-V factories call the same helper with a config-specific `clientBuilder`.
> 
> **Extends block-number routing** so `StartBlockNumberBasedSwitchPredicate` treats `BlockInterval` like other proof types, letting RISC-V L2 execution requests/indexes participate in prover A→B cutover without adding one-off types.
> 
> **Adds `RiscvProverClientFactory`** in `riscv-client`: builds `L2ExecutionProverClient` over `FileBasedProverProofTransport` (JSON file I/O, `guestProgramId`, L2 message service + coinbase), optional A/B routing from `ProversConfig`, and a `BATCH` `prover.waiting` gauge wired through `GaugeAggregator`. The module gains a micrometer metrics dependency for that gauge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19607227f3299d8e0dd7e4407c1ea3fbbd20648b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->