### PR TITLE
feat(coordinator): update rollup proof domain types for flexible-blobs spec

### DIFF
--- a/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProofDtos.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProofDtos.kt
@@ -1,6 +1,6 @@
 package lineth.coordinator.clients.prover.riscv
 
-import linea.clients.BlobWitness
+import linea.clients.ConflationWitness
 import linea.clients.ForcedTransaction
 import linea.clients.L2ExecutionProofPublicInputs
 import linea.clients.L2ExecutionProofResponseV1
@@ -45,7 +45,7 @@ data class L2ExecutionProofPublicInputsDto(
   val txFromsHash: String,
 )
 
-/** The 15-field PI tuple emitted by a rollup / rollup-aggregation proof (rollup_spec §2.4). */
+/** The 20-field PI tuple emitted by a rollup / rollup-aggregation proof (rollup_spec §2.4). */
 data class RollupProofPublicInputsDto(
   val endBlockNumber: Long,
   val endBlockTimestamp: Long,
@@ -60,8 +60,13 @@ data class RollupProofPublicInputsDto(
   val endFtxRollingHash: String,
   val endProcessedFtxNumber: Long,
   val filteredAddressesHash: String,
-  val parentShnarf: String,
-  val endShnarf: String,
+  val parentDataRollingHash: String,
+  val endDataRollingHash: String,
+  val parentBlockHash: String,
+  val endBlockHash: String,
+  val startOffset: Int,
+  val endOffset: Int,
+  val programVks: List<String>,
 )
 
 data class MetaDataDto(
@@ -182,11 +187,7 @@ data class L2ExecutionProofResponseDto(
 // getZkRollupProof.request.json (§2.2)
 // ---------------------------------------------------------------------------------------------------------------------
 
-data class BlobWitnessDto(
-  val startBlockNumber: Long,
-  val endBlockNumber: Long,
-  val blobHash: String,
-  val blobKzgProof: String,
+data class ConflationWitnessDto(
   val blockRlps: List<String>,
 )
 
@@ -202,16 +203,26 @@ data class L2ExecutionProofDto(
 
 data class FileBasedRollupProofRequestParamsDto(
   val chainId: Long,
-  val blobs: List<BlobWitnessDto>,
-  val parentShnarf: String,
+  val conflations: List<ConflationWitnessDto>,
   val l2ExecutionProofs: List<L2ExecutionProofDto>,
+  val chunks: List<String>,
+  val parentDataRollingHash: String,
+  val startOffset: Int,
+  val opaquePrefixBytes: String? = null,
+  val opaqueSuffixBytes: String? = null,
+  val boundaryPrevDataRollingHash: String? = null,
 )
 
 data class RestfulRollupProofRequestParamsDto(
   val chainId: Long,
-  val blobs: List<BlobWitnessDto>,
-  val parentShnarf: String,
+  val conflations: List<ConflationWitnessDto>,
   val l2ExecutionProofIndexes: List<BlockIntervalProofIndex>,
+  val chunks: List<String>,
+  val parentDataRollingHash: String,
+  val startOffset: Int,
+  val opaquePrefixBytes: String? = null,
+  val opaqueSuffixBytes: String? = null,
+  val boundaryPrevDataRollingHash: String? = null,
 )
 
 data class FileBasedRollupProofRequestDto(
@@ -268,7 +279,7 @@ data class RestfulRollupAggregationProofRequestDto(
   val metadata: MetaDataDto,
 )
 
-/** Response of a rollup-aggregation proof: the aggregated proof bytes plus the 14-field PI tuple (§2.4). */
+/** Response of a rollup-aggregation proof: the aggregated proof bytes plus the 20-field PI tuple (§2.4). */
 data class RollupAggregationProofResponseDto(
   val proverVersion: String? = null,
   val startBlockNumber: Long,
@@ -386,7 +397,7 @@ internal fun ForcedTransaction.fromDomainObject(): ForcedTransactionDto {
 }
 
 /**
- * Maps the RISC-V 15-field PI tuple DTO onto its domain twin. Shared by the rollup and rollup-aggregation response
+ * Maps the RISC-V 20-field PI tuple DTO onto its domain twin. Shared by the rollup and rollup-aggregation response
  * mappers since both emit the same tuple (rollup_spec §2.4). Field names and types are identical, so it is a straight
  * field copy.
  */
@@ -405,8 +416,13 @@ internal fun RollupProofPublicInputsDto.toDomainObject(): RollupProofPublicInput
     endFtxRollingHash = endFtxRollingHash.decodeHex(),
     endFtxNumber = endProcessedFtxNumber.toULong(),
     filteredAddressesHash = filteredAddressesHash.decodeHex(),
-    parentShnarf = parentShnarf.decodeHex(),
-    endShnarf = endShnarf.decodeHex(),
+    parentDataRollingHash = parentDataRollingHash.decodeHex(),
+    endDataRollingHash = endDataRollingHash.decodeHex(),
+    parentBlockHash = parentBlockHash.decodeHex(),
+    endBlockHash = endBlockHash.decodeHex(),
+    startOffset = startOffset,
+    endOffset = endOffset,
+    programVks = programVks.map { it.decodeHex() },
   )
 }
 
@@ -425,20 +441,19 @@ internal fun RollupProofPublicInputs.fromDomainObject(): RollupProofPublicInputs
     endFtxRollingHash = endFtxRollingHash.encodeHex(),
     endProcessedFtxNumber = endFtxNumber.toLong(),
     filteredAddressesHash = filteredAddressesHash.encodeHex(),
-    parentShnarf = parentShnarf.encodeHex(),
-    endShnarf = endShnarf.encodeHex(),
+    parentDataRollingHash = parentDataRollingHash.encodeHex(),
+    endDataRollingHash = endDataRollingHash.encodeHex(),
+    parentBlockHash = parentBlockHash.encodeHex(),
+    endBlockHash = endBlockHash.encodeHex(),
+    startOffset = startOffset,
+    endOffset = endOffset,
+    programVks = programVks.map { it.encodeHex() },
   )
 }
 
-internal fun BlobWitness.fromDomainObject(): BlobWitnessDto {
-  return BlobWitnessDto(
-    startBlockNumber = startBlockNumber.toLong(),
-    endBlockNumber = endBlockNumber.toLong(),
-    blobHash = blobHash.encodeHex(),
-    blobKzgProof = blobKzgProof.encodeHex(),
-    blockRlps = blockRlps.map { blockRlp ->
-      blockRlp.encodeHex()
-    },
+internal fun ConflationWitness.fromDomainObject(): ConflationWitnessDto {
+  return ConflationWitnessDto(
+    blockRlps = blockRlps.map { it.encodeHex() },
   )
 }
 

--- a/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/RollupProverClient.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/RollupProverClient.kt
@@ -32,8 +32,7 @@ internal class FileBasedRollupProofRequestDtoMapper(
           guestProgramId = guestProgramId,
           proofRequest = FileBasedRollupProofRequestParamsDto(
             chainId = chainId,
-            blobs = request.blobs.map { it.fromDomainObject() },
-            parentShnarf = request.parentShnarf.encodeHex(),
+            conflations = request.conflations.map { it.fromDomainObject() },
             l2ExecutionProofs = l2ExecutionProofResponseDtos.mapIndexed { index, response ->
               val proofResponse = requireNotNull(response) {
                 "L2 execution proof response was not found for proofIndex=${request.l2Executions[index]}"
@@ -47,6 +46,12 @@ internal class FileBasedRollupProofRequestDtoMapper(
                 filteredAddresses = proofResponse.filteredAddresses,
               )
             },
+            chunks = request.chunks.map { it.encodeHex() },
+            parentDataRollingHash = request.parentDataRollingHash.encodeHex(),
+            startOffset = request.startOffset,
+            opaquePrefixBytes = request.opaquePrefixBytes.takeIf { it.isNotEmpty() }?.encodeHex(),
+            opaqueSuffixBytes = request.opaqueSuffixBytes.takeIf { it.isNotEmpty() }?.encodeHex(),
+            boundaryPrevDataRollingHash = request.boundaryPrevDataRollingHash?.encodeHex(),
           ),
           metadata = MetaDataDto(
             startBlockNumber = request.startBlockNumber.toLong(),
@@ -71,9 +76,14 @@ internal class RestfulRollupProofRequestDtoMapper(
       guestProgramId = guestProgramId,
       proofRequest = RestfulRollupProofRequestParamsDto(
         chainId = chainId,
-        blobs = request.blobs.map { it.fromDomainObject() },
-        parentShnarf = request.parentShnarf.encodeHex(),
+        conflations = request.conflations.map { it.fromDomainObject() },
         l2ExecutionProofIndexes = request.l2Executions,
+        chunks = request.chunks.map { it.encodeHex() },
+        parentDataRollingHash = request.parentDataRollingHash.encodeHex(),
+        startOffset = request.startOffset,
+        opaquePrefixBytes = request.opaquePrefixBytes.takeIf { it.isNotEmpty() }?.encodeHex(),
+        opaqueSuffixBytes = request.opaqueSuffixBytes.takeIf { it.isNotEmpty() }?.encodeHex(),
+        boundaryPrevDataRollingHash = request.boundaryPrevDataRollingHash?.encodeHex(),
       ),
       metadata = MetaDataDto(
         startBlockNumber = request.startBlockNumber.toLong(),

--- a/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/FileBasedRollupProverClientTest.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/FileBasedRollupProverClientTest.kt
@@ -6,8 +6,8 @@ import linea.domain.BlockIntervalProofIndex
 import lineth.coordinator.clients.prover.FileBasedProverConfig
 import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.CHAIN_ID
 import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.ROLLUP_GUEST_PROGRAM_ID
-import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.blobWitness
 import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.blockIntervalProofIndex
+import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.conflationWitness
 import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.fileBasedProverConfig
 import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.jsonMapper
 import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.rollupProofRequestV1
@@ -61,7 +61,7 @@ class FileBasedRollupProverClientTest {
   @Test
   fun `createProofRequest writes the request DTO to a json file`() {
     val request = rollupProofRequestV1(
-      blobs = listOf(blobWitness(1000501UL, 1000503UL)),
+      conflations = listOf(conflationWitness()),
       l2Executions = listOf(blockIntervalProofIndex(1000501UL, 1000503UL)),
     )
 

--- a/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProofRequestDtoMapperTest.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProofRequestDtoMapperTest.kt
@@ -1,7 +1,7 @@
 package lineth.coordinator.clients.prover.riscv
 
-import linea.clients.BlobWitness
 import linea.clients.ChainConfig
+import linea.clients.ConflationWitness
 import linea.clients.ExecutionInfo
 import linea.clients.ForcedTransaction
 import linea.clients.L2ExecutionProofRequestV1
@@ -107,18 +107,16 @@ class RiscVProofRequestDtoMapperTest {
   @Test
   fun `RestfulRollupProofRequestDtoMapper encodes every field`() {
     val l2Executions = listOf(blockIntervalProofIndex(1000501UL, 1000510UL))
-    val blob = BlobWitness(
-      startBlockNumber = 1000501UL,
-      endBlockNumber = 1000510UL,
-      blobHash = ByteArray(32) { 0x1a },
-      blobKzgProof = ByteArray(48) { 0x1b },
+    val conflation = ConflationWitness(
       blockRlps = listOf(byteArrayOf(0x0c), byteArrayOf(0x0d)),
     )
+    val chunks = listOf(ByteArray(32) { 0x1e })
     val request = RollupProofRequestV1(
-      blobs = listOf(blob),
-      parentShnarf = ByteArray(32) { 0x1c },
-      endShnarf = ByteArray(32) { 0x1d },
+      conflations = listOf(conflation),
       l2Executions = l2Executions,
+      chunks = chunks,
+      parentDataRollingHash = ByteArray(32) { 0x1c },
+      startOffset = 0,
     )
 
     val dto = RestfulRollupProofRequestDtoMapper(guestProgramId, chainId).invoke(request).get()
@@ -128,17 +126,15 @@ class RiscVProofRequestDtoMapperTest {
         guestProgramId = guestProgramId,
         proofRequest = RestfulRollupProofRequestParamsDto(
           chainId = chainId,
-          blobs = listOf(
-            BlobWitnessDto(
-              startBlockNumber = 1000501,
-              endBlockNumber = 1000510,
-              blobHash = blob.blobHash.encodeHex(),
-              blobKzgProof = blob.blobKzgProof.encodeHex(),
-              blockRlps = blob.blockRlps.map { it.encodeHex() },
+          conflations = listOf(
+            ConflationWitnessDto(
+              blockRlps = conflation.blockRlps.map { it.encodeHex() },
             ),
           ),
-          parentShnarf = request.parentShnarf.encodeHex(),
           l2ExecutionProofIndexes = l2Executions,
+          chunks = chunks.map { it.encodeHex() },
+          parentDataRollingHash = request.parentDataRollingHash.encodeHex(),
+          startOffset = 0,
         ),
         metadata = MetaDataDto(startBlockNumber = 1000501, endBlockNumber = 1000510),
       ),
@@ -167,18 +163,16 @@ class RiscVProofRequestDtoMapperTest {
       blockIntervalProofIndex(1000501UL, 1000510UL),
       blockIntervalProofIndex(1000511UL, 1000520UL),
     )
-    val blob = BlobWitness(
-      startBlockNumber = 1000501UL,
-      endBlockNumber = 1000520UL,
-      blobHash = ByteArray(32) { 0x1a },
-      blobKzgProof = ByteArray(48) { 0x1b },
+    val conflation = ConflationWitness(
       blockRlps = listOf(byteArrayOf(0x0c), byteArrayOf(0x0d)),
     )
+    val chunks = listOf(ByteArray(32) { 0x1e })
     val request = RollupProofRequestV1(
-      blobs = listOf(blob),
-      parentShnarf = ByteArray(32) { 0x1c },
-      endShnarf = ByteArray(32) { 0x1d },
+      conflations = listOf(conflation),
       l2Executions = l2Executions,
+      chunks = chunks,
+      parentDataRollingHash = ByteArray(32) { 0x1c },
+      startOffset = 0,
     )
     val l2ExecutionProofTransport = FakeL2ExecutionProofTransport()
 
@@ -190,16 +184,11 @@ class RiscVProofRequestDtoMapperTest {
         guestProgramId = guestProgramId,
         proofRequest = FileBasedRollupProofRequestParamsDto(
           chainId = chainId,
-          blobs = listOf(
-            BlobWitnessDto(
-              startBlockNumber = 1000501,
-              endBlockNumber = 1000520,
-              blobHash = blob.blobHash.encodeHex(),
-              blobKzgProof = blob.blobKzgProof.encodeHex(),
-              blockRlps = blob.blockRlps.map { it.encodeHex() },
+          conflations = listOf(
+            ConflationWitnessDto(
+              blockRlps = conflation.blockRlps.map { it.encodeHex() },
             ),
           ),
-          parentShnarf = request.parentShnarf.encodeHex(),
           l2ExecutionProofs = l2Executions.map { proofIndex ->
             val resolved = l2ExecutionProofTransport.findResponse(proofIndex).get()!!
             L2ExecutionProofDto(
@@ -211,6 +200,9 @@ class RiscVProofRequestDtoMapperTest {
               filteredAddresses = resolved.filteredAddresses,
             )
           },
+          chunks = chunks.map { it.encodeHex() },
+          parentDataRollingHash = request.parentDataRollingHash.encodeHex(),
+          startOffset = 0,
         ),
         metadata = MetaDataDto(startBlockNumber = 1000501, endBlockNumber = 1000520),
       ),
@@ -221,18 +213,11 @@ class RiscVProofRequestDtoMapperTest {
   fun `FileBasedRollupProofRequestDtoMapper reports a missing l2-execution proof`() {
     val proofIndex = blockIntervalProofIndex(1000501UL, 1000510UL)
     val request = RollupProofRequestV1(
-      blobs = listOf(
-        BlobWitness(
-          startBlockNumber = 1000501UL,
-          endBlockNumber = 1000510UL,
-          blobHash = ByteArray(32),
-          blobKzgProof = ByteArray(48),
-          blockRlps = emptyList(),
-        ),
-      ),
-      parentShnarf = ByteArray(32),
-      endShnarf = ByteArray(32),
+      conflations = listOf(ConflationWitness(blockRlps = emptyList())),
       l2Executions = listOf(proofIndex),
+      chunks = listOf(ByteArray(32)),
+      parentDataRollingHash = ByteArray(32),
+      startOffset = 0,
     )
     val transport = FakeL2ExecutionProofTransport(responseProvider = { null })
 

--- a/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProofResponseDtoMapperTest.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProofResponseDtoMapperTest.kt
@@ -72,8 +72,13 @@ class RiscVProofResponseDtoMapperTest {
     endFtxRollingHash = "0x16",
     endProcessedFtxNumber = 17,
     filteredAddressesHash = "0x18",
-    parentShnarf = "0x19",
-    endShnarf = "0x1a",
+    parentDataRollingHash = "0x19",
+    endDataRollingHash = "0x1a",
+    parentBlockHash = "0x1b",
+    endBlockHash = "0x1c",
+    startOffset = 0,
+    endOffset = 131072,
+    programVks = emptyList(),
   )
 
   private val expectedRollupPublicInputs = RollupProofPublicInputs(
@@ -90,8 +95,13 @@ class RiscVProofResponseDtoMapperTest {
     endFtxRollingHash = "0x16".decodeHex(),
     endFtxNumber = 17UL,
     filteredAddressesHash = "0x18".decodeHex(),
-    parentShnarf = "0x19".decodeHex(),
-    endShnarf = "0x1a".decodeHex(),
+    parentDataRollingHash = "0x19".decodeHex(),
+    endDataRollingHash = "0x1a".decodeHex(),
+    parentBlockHash = "0x1b".decodeHex(),
+    endBlockHash = "0x1c".decodeHex(),
+    startOffset = 0,
+    endOffset = 131072,
+    programVks = emptyList(),
   )
 
   @Test
@@ -242,8 +252,13 @@ class RiscVProofResponseDtoMapperTest {
           "endFtxRollingHash": "0x16",
           "endProcessedFtxNumber": 17,
           "filteredAddressesHash": "0x18",
-          "parentShnarf": "0x19",
-          "endShnarf": "0x1a"
+          "parentDataRollingHash": "0x19",
+          "endDataRollingHash": "0x1a",
+          "parentBlockHash": "0x1b",
+          "endBlockHash": "0x1c",
+          "startOffset": 0,
+          "endOffset": 131072,
+          "programVks": []
         },
         "l2L1Roots": ["0xaa"],
         "filteredAddresses": []

--- a/coordinator/clients/prover-client/riscv-client/src/testFixtures/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProverClientTestFixtures.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/testFixtures/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProverClientTestFixtures.kt
@@ -6,8 +6,8 @@ import io.vertx.core.Vertx
 import io.vertx.core.http.HttpVersion
 import io.vertx.core.http.PoolOptions
 import io.vertx.ext.web.client.WebClientOptions
-import linea.clients.BlobWitness
 import linea.clients.ChainConfig
+import linea.clients.ConflationWitness
 import linea.clients.ExecutionInfo
 import linea.clients.ForcedTransaction
 import linea.clients.L2ExecutionProofRequestV1
@@ -159,27 +159,24 @@ object RiscVProverClientTestFixtures {
     parentFtxNumber = parentFtxNumber,
   )
 
-  fun blobWitness(
-    startBlockNumber: ULong,
-    endBlockNumber: ULong,
-  ): BlobWitness = BlobWitness(
-    startBlockNumber = startBlockNumber,
-    endBlockNumber = endBlockNumber,
-    blobHash = ByteArray(32) { 0x3a },
-    blobKzgProof = ByteArray(48) { 0x3b },
-    blockRlps = listOf(byteArrayOf(0x3c)),
+  fun conflationWitness(
+    blockCount: Int = 1,
+  ): ConflationWitness = ConflationWitness(
+    blockRlps = List(blockCount) { byteArrayOf(0x3c) },
   )
 
   fun rollupProofRequestV1(
-    blobs: List<BlobWitness> = emptyList(),
-    parentShnarf: ByteArray = ByteArray(32) { 0x19 },
-    endShnarf: ByteArray = ByteArray(32) { 0x20 },
+    conflations: List<ConflationWitness> = emptyList(),
+    parentDataRollingHash: ByteArray = ByteArray(32) { 0x19 },
+    chunks: List<ByteArray> = listOf(ByteArray(32) { 0x20 }),
+    startOffset: Int = 0,
     l2Executions: List<BlockIntervalProofIndex> = listOf(blockIntervalProofIndex(1000501UL, 1000520UL)),
   ): RollupProofRequestV1 = RollupProofRequestV1(
-    blobs = blobs,
-    parentShnarf = parentShnarf,
-    endShnarf = endShnarf,
+    conflations = conflations,
     l2Executions = l2Executions,
+    chunks = chunks,
+    parentDataRollingHash = parentDataRollingHash,
+    startOffset = startOffset,
   )
 
   fun rollupAggregationProofRequestV1(
@@ -237,8 +234,13 @@ object RiscVProverClientTestFixtures {
     endFtxRollingHash = "0x16",
     endProcessedFtxNumber = 17,
     filteredAddressesHash = "0x18",
-    parentShnarf = "0x19",
-    endShnarf = "0x1a",
+    parentDataRollingHash = "0x19",
+    endDataRollingHash = "0x1a",
+    parentBlockHash = "0x1b",
+    endBlockHash = "0x1c",
+    startOffset = 0,
+    endOffset = 131072,
+    programVks = emptyList(),
   )
 
   fun rollupProofResponseDto(

--- a/coordinator/core-interfaces/src/main/kotlin/linea/clients/RollupProverRequestResponse.kt
+++ b/coordinator/core-interfaces/src/main/kotlin/linea/clients/RollupProverRequestResponse.kt
@@ -9,13 +9,16 @@ import linea.kotlin.byteArrayListHashCode
 import kotlin.time.Instant
 
 data class RollupProofRequestV1(
-  val blobs: List<BlobWitness>,
-  val parentShnarf: ByteArray,
-  val endShnarf: ByteArray,
+  val conflations: List<ConflationWitness>,
   val l2Executions: List<BlockIntervalProofIndex>,
+  val chunks: List<ByteArray>,
+  val parentDataRollingHash: ByteArray,
+  val startOffset: Int,
+  val opaquePrefixBytes: ByteArray = ByteArray(0),
+  val opaqueSuffixBytes: ByteArray = ByteArray(0),
+  val boundaryPrevDataRollingHash: ByteArray? = null,
 ) : BlockInterval, StartBlockTimestampProvider {
   init {
-    assertConsecutiveIntervals(blobs)
     assertConsecutiveIntervals(l2Executions)
   }
 
@@ -35,10 +38,14 @@ data class RollupProofRequestV1(
     if (startBlockNumber != other.startBlockNumber) return false
     if (endBlockNumber != other.endBlockNumber) return false
     if (startBlockTimestamp != other.startBlockTimestamp) return false
-    if (blobs != other.blobs) return false
-    if (!parentShnarf.contentEquals(other.parentShnarf)) return false
-    if (!endShnarf.contentEquals(other.endShnarf)) return false
+    if (conflations != other.conflations) return false
     if (l2Executions != other.l2Executions) return false
+    if (!chunks.byteArrayListEquals(other.chunks)) return false
+    if (!parentDataRollingHash.contentEquals(other.parentDataRollingHash)) return false
+    if (startOffset != other.startOffset) return false
+    if (!opaquePrefixBytes.contentEquals(other.opaquePrefixBytes)) return false
+    if (!opaqueSuffixBytes.contentEquals(other.opaqueSuffixBytes)) return false
+    if (!boundaryPrevDataRollingHash.contentEquals(other.boundaryPrevDataRollingHash)) return false
 
     return true
   }
@@ -47,48 +54,37 @@ data class RollupProofRequestV1(
     var result = startBlockNumber.hashCode()
     result = 31 * result + endBlockNumber.hashCode()
     result = 31 * result + startBlockTimestamp.hashCode()
-    result = 31 * result + blobs.hashCode()
-    result = 31 * result + parentShnarf.contentHashCode()
-    result = 31 * result + endShnarf.contentHashCode()
+    result = 31 * result + conflations.hashCode()
     result = 31 * result + l2Executions.hashCode()
+    result = 31 * result + chunks.byteArrayListHashCode()
+    result = 31 * result + parentDataRollingHash.contentHashCode()
+    result = 31 * result + startOffset.hashCode()
+    result = 31 * result + opaquePrefixBytes.contentHashCode()
+    result = 31 * result + opaqueSuffixBytes.contentHashCode()
+    result = 31 * result + (boundaryPrevDataRollingHash?.contentHashCode() ?: 0)
     return result
   }
 }
 
-data class BlobWitness(
-  override val startBlockNumber: ULong,
-  override val endBlockNumber: ULong,
-  val blobHash: ByteArray,
-  val blobKzgProof: ByteArray,
+data class ConflationWitness(
   val blockRlps: List<ByteArray>,
-) : BlockInterval {
+) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (javaClass != other?.javaClass) return false
 
-    other as BlobWitness
+    other as ConflationWitness
 
-    if (startBlockNumber != other.startBlockNumber) return false
-    if (endBlockNumber != other.endBlockNumber) return false
-    if (!blobHash.contentEquals(other.blobHash)) return false
-    if (!blobKzgProof.contentEquals(other.blobKzgProof)) return false
     if (!blockRlps.byteArrayListEquals(other.blockRlps)) return false
 
     return true
   }
 
-  override fun hashCode(): Int {
-    var result = startBlockNumber.hashCode()
-    result = 31 * result + endBlockNumber.hashCode()
-    result = 31 * result + blobHash.contentHashCode()
-    result = 31 * result + blobKzgProof.contentHashCode()
-    result = 31 * result + blockRlps.byteArrayListHashCode()
-    return result
-  }
+  override fun hashCode(): Int = blockRlps.byteArrayListHashCode()
 }
 
 /**
- * The 14-field PI tuple emitted by a rollup / rollup-aggregation proof (rollup_spec §2.4).
+ * The 20-field PI tuple emitted by a rollup / rollup-aggregation proof (rollup_spec §2.4).
  *
  * Domain twin of `lineth.coordinator.clients.prover.riscv.RollupPublicInputsDto`. Kept here (rather than reusing the
  * DTO) because this module is depended upon by the prover-client modules, not the other way around. Where the DTO
@@ -108,8 +104,13 @@ data class RollupProofPublicInputs(
   val endFtxNumber: ULong,
   val endFtxRollingHash: ByteArray,
   val filteredAddressesHash: ByteArray,
-  val parentShnarf: ByteArray,
-  val endShnarf: ByteArray,
+  val parentDataRollingHash: ByteArray,
+  val endDataRollingHash: ByteArray,
+  val parentBlockHash: ByteArray,
+  val endBlockHash: ByteArray,
+  val startOffset: Int,
+  val endOffset: Int,
+  val programVks: List<ByteArray>,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
@@ -130,8 +131,13 @@ data class RollupProofPublicInputs(
     if (!endFtxRollingHash.contentEquals(other.endFtxRollingHash)) return false
     if (endFtxNumber != other.endFtxNumber) return false
     if (!filteredAddressesHash.contentEquals(other.filteredAddressesHash)) return false
-    if (!parentShnarf.contentEquals(other.parentShnarf)) return false
-    if (!endShnarf.contentEquals(other.endShnarf)) return false
+    if (!parentDataRollingHash.contentEquals(other.parentDataRollingHash)) return false
+    if (!endDataRollingHash.contentEquals(other.endDataRollingHash)) return false
+    if (!parentBlockHash.contentEquals(other.parentBlockHash)) return false
+    if (!endBlockHash.contentEquals(other.endBlockHash)) return false
+    if (startOffset != other.startOffset) return false
+    if (endOffset != other.endOffset) return false
+    if (!programVks.byteArrayListEquals(other.programVks)) return false
 
     return true
   }
@@ -150,8 +156,13 @@ data class RollupProofPublicInputs(
     result = 31 * result + endFtxRollingHash.contentHashCode()
     result = 31 * result + endFtxNumber.hashCode()
     result = 31 * result + filteredAddressesHash.contentHashCode()
-    result = 31 * result + parentShnarf.contentHashCode()
-    result = 31 * result + endShnarf.contentHashCode()
+    result = 31 * result + parentDataRollingHash.contentHashCode()
+    result = 31 * result + endDataRollingHash.contentHashCode()
+    result = 31 * result + parentBlockHash.contentHashCode()
+    result = 31 * result + endBlockHash.contentHashCode()
+    result = 31 * result + startOffset.hashCode()
+    result = 31 * result + endOffset.hashCode()
+    result = 31 * result + programVks.byteArrayListHashCode()
     return result
   }
 }


### PR DESCRIPTION
## Summary

- Replaces `BlobWitness` with `ConflationWitness(blockRlps: List<ByteArray>)` — drops `startBlockNumber`, `endBlockNumber`, `blobHash`, `blobKzgProof`; block range is now carried by the paired `l2Executions` entry
- Reshapes `RollupProofRequestV1`: `blobs` → `conflations`, `parentShnarf` → `parentDataRollingHash`, `endShnarf` removed; adds `chunks`, `startOffset`, `opaquePrefixBytes`, `opaqueSuffixBytes`, `boundaryPrevDataRollingHash`
- Expands `RollupProofPublicInputs` from 15 to 20 fields: renames `parentShnarf`/`endShnarf` → `parentDataRollingHash`/`endDataRollingHash`; adds `parentBlockHash`, `endBlockHash`, `startOffset`, `endOffset`, `programVks`
- Updates `RiscVProofDtos` (DTOs + mappers), both file-based and RESTful request mappers, aggregation response mapper, and all tests/fixtures in `riscv-client` to match `rollup_spec/prover_io/schemas/`

## Test plan

- [x] `./gradlew :coordinator:core-interfaces:compileKotlin :coordinator:clients:prover-client:riscv-client:compileKotlin` — clean
- [x] `./gradlew :coordinator:core-interfaces:compileTestKotlin :coordinator:clients:prover-client:riscv-client:compileTestKotlin` — clean
- [x] `./gradlew :coordinator:clients:prover-client:riscv-client:spotlessCheck` — clean (after `spotlessApply`)
- [x] `./gradlew :coordinator:core-interfaces:test :coordinator:clients:prover-client:riscv-client:test` — all pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes prover request/response contracts and public inputs used for ZK rollup proofs; incorrect mapping would break prover jobs, but scope is limited to type/DTO layers with updated tests.
> 
> **Overview**
> Aligns coordinator rollup proof **domain types**, **RISC-V JSON DTOs**, and **request/response mappers** with the flexible-blobs `rollup_spec` prover I/O.
> 
> **`RollupProofRequestV1`** drops blob-centric fields (`blobs`, `parentShnarf`, `endShnarf`) in favor of **`conflations`** (`ConflationWitness` with only `blockRlps`), **`chunks`**, **`parentDataRollingHash`**, **`startOffset`**, and optional opaque/boundary byte fields. Consecutive-interval validation now applies only to **`l2Executions`** (block range comes from those entries, not per-blob metadata).
> 
> **`RollupProofPublicInputs`** grows from 15 to **20** fields: shnarf fields become **`parentDataRollingHash` / `endDataRollingHash`**, with new **`parentBlockHash`**, **`endBlockHash`**, **`startOffset`**, **`endOffset`**, and **`programVks`**. File-based and RESTful rollup request builders and DTO↔domain mappers are updated accordingly; tests and fixtures follow the new shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41ef970285d2c4db705e9d096bf96153fa715f8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->