### PR TITLE
perf(prover-ray): optimizes the CI test for the prover from 300 sec to 50 sec.

### DIFF
--- a/prover-ray/wiop/query_table_relation.go
+++ b/prover-ray/wiop/query_table_relation.go
@@ -2,6 +2,7 @@ package wiop
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/maths/koalabear/field"
 )
@@ -309,10 +310,17 @@ func (tr *TableRelationQuery) Round() *Round {
 // Check implements [Query]. Dispatches to [checkPermutation] or
 // [checkInclusion] depending on [TableRelationQuery.Kind].
 func (tr *TableRelationQuery) Check(rt *Runtime) error {
+	return tr.checkWith(rt, newInclusionSetCache())
+}
+
+// checkWith is [TableRelationQuery.Check] with a caller-supplied B-side set
+// cache, so that a caller checking many queries in one pass can share the work
+// of building the target sets. See [inclusionSetCache].
+func (tr *TableRelationQuery) checkWith(rt *Runtime, cache *inclusionSetCache) error {
 	if tr.Kind == KindPermutation {
 		return tr.checkPermutation(rt)
 	}
-	return tr.checkInclusion(rt)
+	return tr.checkInclusion(rt, cache)
 }
 
 // checkPermutation verifies that A and B, treated as multisets of rows, are
@@ -369,11 +377,12 @@ func (tr *TableRelationQuery) checkPermutation(rt *Runtime) error {
 // checkInclusion verifies that every selected row of A appears in the union of
 // selected rows across all B fragments.
 //
-// This is a probabilistic check: a random extension-field scalar alpha is
-// sampled and used to hash rows via Horner's rule. A hash collision causes a
+// This is a probabilistic check: an extension-field scalar alpha drawn at
+// random is used to hash rows via Horner's rule. A hash collision causes a
 // false negative with probability at most (total rows) / |field|, which is
-// negligible for realistic table sizes. B's selected rows populate a set; each
-// selected A row is then probed against it.
+// negligible for realistic table sizes. B's selected rows populate a set (taken
+// from cache, which may serve one built for an earlier query over the same
+// target tables); each selected A row is then probed against it.
 //
 // When all column views and the selector in a table have zero shift and the
 // module has directional padding, all padding rows produce the same row hash
@@ -381,18 +390,106 @@ func (tr *TableRelationQuery) checkPermutation(rt *Runtime) error {
 // rows, the first padding row (the anchor) is probed once: if selected and
 // absent from B, the check fails immediately; if present, every other selected
 // padding row is also satisfied.
-func (tr *TableRelationQuery) checkInclusion(rt *Runtime) error {
-	alpha := field.RandomElemExt()
-	bSet := make(map[field.Ext]struct{})
-	for _, tab := range tr.B {
-		inclusionBuildSet(bSet, alpha, rt, tab)
-	}
+func (tr *TableRelationQuery) checkInclusion(rt *Runtime, cache *inclusionSetCache) error {
+	bSet := cache.setFor(rt, tr.B)
 	for _, tab := range tr.A {
-		if err := inclusionCheckSet(bSet, alpha, rt, tab, tr.context.Path()); err != nil {
+		if err := inclusionCheckSet(bSet, cache.alpha, rt, tab, tr.context.Path()); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// inclusionSetCache memoises the B-side row-hash sets of inclusion checks,
+// keyed by the identity of the target tables. Lookups routinely share a target
+// — a range-check column is the B side of every query that range-checks
+// something — and building that set is O(target size) while the A side probing
+// it is often a handful of rows. Rebuilding it per query is what makes
+// [System.checkUnreducedQueries] expensive on lookup-heavy systems.
+//
+// Every entry shares the one alpha drawn when the cache is created; that is
+// what makes the sets interchangeable between queries. It costs nothing in
+// detection power: a query still misses a bad witness only when alpha lands on
+// a hash collision, and a union bound over the queries sharing the cache is the
+// same bound as drawing alpha afresh each time.
+//
+// A cache is only valid while the assignments it read stay put, so it belongs
+// to a single check pass and must be discarded with it.
+type inclusionSetCache struct {
+	alpha field.Gen
+	sets  map[string]map[field.Ext]struct{}
+}
+
+// newInclusionSetCache returns an empty cache with a freshly drawn alpha.
+func newInclusionSetCache() *inclusionSetCache {
+	return &inclusionSetCache{
+		alpha: field.RandomElemExt(),
+		sets:  make(map[string]map[field.Ext]struct{}),
+	}
+}
+
+// setFor returns the set of row hashes of all selected rows across tables,
+// building it on first use. The returned map is shared with future callers and
+// must not be mutated.
+func (c *inclusionSetCache) setFor(rt *Runtime, tables []Table) map[field.Ext]struct{} {
+	key, keyable := inclusionSetKey(tables)
+	if keyable {
+		if set, ok := c.sets[key]; ok {
+			return set
+		}
+	}
+	set := make(map[field.Ext]struct{})
+	for _, tab := range tables {
+		inclusionBuildSet(set, c.alpha, rt, tab)
+	}
+	if keyable {
+		c.sets[key] = set
+	}
+	return set
+}
+
+// inclusionSetKey encodes the identity of a group of tables as the registered
+// ID and shift of every column view and selector they hold. Two groups with
+// equal keys yield the same set of row hashes under the same runtime, since the
+// IDs pin the assignments read and the modules whose size and padding drive the
+// iteration.
+//
+// It reports false if any column is unregistered (a zero [ObjectID]), which
+// leaves it without a stable identity to key on; the caller must then skip the
+// cache rather than risk conflating two distinct tables.
+func inclusionSetKey(tables []Table) (string, bool) {
+	var (
+		key []byte
+		ok  bool
+	)
+	for _, tab := range tables {
+		for _, cv := range tab.Columns {
+			if key, ok = appendColumnViewKey(key, cv); !ok {
+				return "", false
+			}
+		}
+		key = append(key, ';')
+		if tab.Selector != nil {
+			if key, ok = appendColumnViewKey(key, tab.Selector); !ok {
+				return "", false
+			}
+		}
+		key = append(key, '|')
+	}
+	return string(key), true
+}
+
+// appendColumnViewKey appends cv's identity to key, reporting false if cv's
+// column carries no registered ID.
+func appendColumnViewKey(key []byte, cv *ColumnView) ([]byte, bool) {
+	id := cv.Column.Context.ID
+	if id == 0 {
+		return nil, false
+	}
+	key = strconv.AppendUint(key, uint64(id), 36)
+	key = append(key, ':')
+	key = strconv.AppendInt(key, int64(cv.ShiftingOffset), 36)
+	return append(key, ','), true
 }
 
 // inclusionBuildSet adds the hashes of all selected rows of tab to bSet.

--- a/prover-ray/wiop/query_table_relation_cache_internal_test.go
+++ b/prover-ray/wiop/query_table_relation_cache_internal_test.go
@@ -1,0 +1,103 @@
+package wiop
+
+import (
+	"testing"
+
+	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/maths/koalabear/field"
+	"github.com/stretchr/testify/require"
+)
+
+// constVec builds a PaddingDirectionNone ConcreteVector of length n whose every
+// element is val.
+func constVec(n int, val uint64) *ConcreteVector {
+	elems := make([]field.Element, n)
+	for i := range elems {
+		elems[i].SetUint64(val)
+	}
+	return &ConcreteVector{Plain: field.VecFromBase(elems)}
+}
+
+// TestInclusionSetCache_SharedAcrossQueries pins the behaviour
+// [inclusionSetCache] has to get right when [System.checkUnreducedQueries]
+// hands the same cache to every table relation of a pass: a set may only be
+// reused by a query whose target tables are the ones it was built from.
+//
+// Reuse is keyed on column identity, so the failure mode to guard against is a
+// key that conflates two distinct targets — it would make a query pass or fail
+// on another query's data. The three queries below share one cache and cover
+// both directions: a second target must get its own set (or the passing query
+// over it would fail), and a genuinely absent row must still be caught after a
+// passing query has warmed the cache with the same target.
+//
+// It is white-box because the cache and checkWith are unexported; the public
+// [TableRelationQuery.Check] always allocates a fresh cache and so never
+// exercises sharing.
+func TestInclusionSetCache_SharedAcrossQueries(t *testing.T) {
+	sys := NewSystemf("incl-cache")
+	r0 := sys.NewRound()
+	mod := sys.NewSizedModule(sys.Context.Childf("mod"), 4, PaddingDirectionNone)
+
+	target1 := mod.NewColumn(sys.Context.Childf("target1"), r0)
+	target2 := mod.NewColumn(sys.Context.Childf("target2"), r0)
+	inTarget1 := mod.NewColumn(sys.Context.Childf("inTarget1"), r0)
+	inTarget2 := mod.NewColumn(sys.Context.Childf("inTarget2"), r0)
+	inNeither := mod.NewColumn(sys.Context.Childf("inNeither"), r0)
+
+	newInc := func(name string, a, b *Column) *TableRelationQuery {
+		return sys.NewInclusion(
+			sys.Context.Childf("%s", name),
+			[]Table{NewTable(a.View())},
+			[]Table{NewTable(b.View())},
+		)
+	}
+	incFirst := newInc("incFirst", inTarget1, target1)
+	incOtherTarget := newInc("incOtherTarget", inTarget2, target2)
+	incSameTarget := newInc("incSameTarget", inNeither, target1)
+
+	rt := NewRuntime(sys)
+	rt.AssignColumn(target1, constVec(4, 1))
+	rt.AssignColumn(target2, constVec(4, 2))
+	rt.AssignColumn(inTarget1, constVec(4, 1))
+	rt.AssignColumn(inTarget2, constVec(4, 2))
+	rt.AssignColumn(inNeither, constVec(4, 3))
+
+	cache := newInclusionSetCache()
+
+	require.NoError(t, incFirst.checkWith(rt, cache),
+		"first query must pass on its own target")
+	require.NoError(t, incOtherTarget.checkWith(rt, cache),
+		"a query over a different target must not be served the first target's set")
+	require.Error(t, incSameTarget.checkWith(rt, cache),
+		"a row absent from the target must still be caught once the cache is warm")
+
+	require.Len(t, cache.sets, 2,
+		"the two distinct targets must yield exactly two cached sets, one reused by the third query")
+}
+
+// TestInclusionSetCache_ReusesSetForSharedTarget is the memoisation half of the
+// contract: several queries over one target build that target's set once. This
+// is the case that dominates lookup-heavy systems, where a single range-check
+// column is the target of hundreds of queries.
+func TestInclusionSetCache_ReusesSetForSharedTarget(t *testing.T) {
+	sys := NewSystemf("incl-cache-reuse")
+	r0 := sys.NewRound()
+	mod := sys.NewSizedModule(sys.Context.Childf("mod"), 4, PaddingDirectionNone)
+
+	target := mod.NewColumn(sys.Context.Childf("target"), r0)
+	rt := NewRuntime(sys)
+	rt.AssignColumn(target, constVec(4, 1))
+
+	cache := newInclusionSetCache()
+	for i := range 3 {
+		source := mod.NewColumn(sys.Context.Childf("source%d", i), r0)
+		rt.AssignColumn(source, constVec(4, 1))
+		inc := sys.NewInclusion(
+			sys.Context.Childf("inc%d", i),
+			[]Table{NewTable(source.View())},
+			[]Table{NewTable(target.View())},
+		)
+		require.NoError(t, inc.checkWith(rt, cache))
+	}
+
+	require.Len(t, cache.sets, 1, "one target must be built once, however many queries read it")
+}

--- a/prover-ray/wiop/wiop_prove_verify.go
+++ b/prover-ray/wiop/wiop_prove_verify.go
@@ -365,8 +365,16 @@ func (sys *System) checkUnreducedQueries(rt *Runtime) error {
 			return err
 		}
 	}
+	// The table relations share one B-side set cache for the whole pass. On
+	// lookup-heavy systems this is the difference between rebuilding a
+	// range-check target once and rebuilding it once per query that ranges over
+	// it, which is otherwise the bulk of this function's cost.
+	inclCache := newInclusionSetCache()
 	for _, q := range sys.TableRelations {
-		if err := check(q); err != nil {
+		if q.IsReduced() {
+			continue
+		}
+		if err := q.checkWith(rt, inclCache); err != nil {
 			return err
 		}
 	}

--- a/prover-ray/zkcdriver/example_test.go
+++ b/prover-ray/zkcdriver/example_test.go
@@ -50,7 +50,7 @@ func TestRunZKCExamples(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to compile binary constraints: %v", err)
 			}
-			inputs, _, err := parseTestCase(tc, binF)
+			inputs, _, err := parseTestCase(tc, binF, !testing.Short())
 			if err != nil {
 				t.Fatalf("failed to parse test case: %v", err)
 			}

--- a/prover-ray/zkcdriver/native_modules_test.go
+++ b/prover-ray/zkcdriver/native_modules_test.go
@@ -41,7 +41,7 @@ func runZkcCase(t *testing.T, zkcPath string) {
 		ZkcFilePath: zkcInputPath,
 		InputStr:    string(inputBytes),
 	}
-	inputs, _, err := parseTestCase(tc, binf)
+	inputs, _, err := parseTestCase(tc, binf, !testing.Short())
 	if err != nil {
 		t.Fatalf("failed to parse test case: %v", err)
 	}

--- a/prover-ray/zkcdriver/r5_test.go
+++ b/prover-ray/zkcdriver/r5_test.go
@@ -31,7 +31,7 @@ func BenchmarkRisc5Arithmetization(b *testing.B) {
 		b.Fatalf("failed to compile zkc source: %v", err)
 	}
 	b.Logf("tracing zkc")
-	outputs, err := traceZkc(binf, constraints.DEFAULT_TRACE_CONFIG, inputsMap)
+	outputs, err := traceZkc(binf, constraints.DEFAULT_TRACE_CONFIG, inputsMap, false)
 	if err != nil {
 		b.Fatalf("failed to parse test case: %v", err)
 	}

--- a/prover-ray/zkcdriver/sync_test.go
+++ b/prover-ray/zkcdriver/sync_test.go
@@ -97,14 +97,24 @@ func TestZkcIntegrationTestSynced(t *testing.T) {
 				l := lineNr
 				t.Run(fmt.Sprintf("case=%d", lineNr), func(t *testing.T) {
 					t.Parallel()
-					zkcInput, zkcOutputs, err := parseTestCase(zkcTestCase{ZkcFilePath: f, InputStr: line}, binF)
-					if err != nil {
-						fatalIfNotKnown(t, failures, baseName, l, failReasonParse, "failed to parse test case: %v", err)
+					// The reason we early-abort on parsing errors is that they
+					// may result from tests that are skipped in short testing
+					// mode. Early aborting allow us to ensure, the case does
+					// not break down the road at a later stage.
+					if isKnownError(failures, baseName, l, failReasonParse) {
 						return
+					}
+					zkcInput, zkcOutputs, err := parseTestCase(zkcTestCase{ZkcFilePath: f, InputStr: line}, binF, !testing.Short())
+					if err != nil {
+						logrus.Panicf("failed to parse test case: %v", err)
 					}
 					for outputName, expectedOutput := range zkcOutputs {
 						if !bytes.Equal(expectedOutput, zkcInput.Inputs[outputName]) {
-							fatalIfNotKnown(t, failures, baseName, l, failReasonOutputMismatch, "output mismatch for %s: expected %x, got %x", outputName, expectedOutput, zkcInput.Inputs[outputName])
+							fatalIfNotKnown(
+								t, failures, baseName, l, failReasonOutputMismatch,
+								"output mismatch for %s: expected %x, got %x",
+								outputName, expectedOutput, zkcInput.Inputs[outputName],
+							)
 							return
 						}
 					}
@@ -146,6 +156,20 @@ func fatalIfNotKnown(t *testing.T, knownFailures knownFailures, unitName string,
 	//
 	// the negative case number indicate input file reading and compiling. We're still not in subtest cases
 	t.Fatalf(msg, args...)
+}
+
+func isKnownError(knownFailure knownFailures, unitName string, caseNr int, reason zkcFailReason) bool {
+	failuresMapMutex.RLock()
+	if unitFailures, ok := knownFailure[unitName]; ok {
+		if knownReason, ok := unitFailures[caseNr]; ok {
+			if knownReason == reason {
+				failuresMapMutex.RUnlock()
+				return true
+			}
+		}
+	}
+	failuresMapMutex.RUnlock()
+	return false
 }
 
 type zkcFailReason string

--- a/prover-ray/zkcdriver/zkcdriver_test.go
+++ b/prover-ray/zkcdriver/zkcdriver_test.go
@@ -68,7 +68,11 @@ func compileBinaryConstraints(srcPath string) (binfile *constraints.BinaryFile[k
 
 // parseTestCase creates a system and the corresponding zkc-driver running the
 // given zkcTestCase. The function also sanity-checks the inputs of the testcase.
-func parseTestCase(scenario zkcTestCase, binF *constraints.BinaryFile[koalabear.Element]) (
+func parseTestCase(
+	scenario zkcTestCase,
+	binF *constraints.BinaryFile[koalabear.Element],
+	withTraceCheck bool,
+) (
 	inputs *zkcdriver.PreReadInputs,
 	outputs map[string][]byte,
 	err error,
@@ -86,7 +90,7 @@ func parseTestCase(scenario zkcTestCase, binF *constraints.BinaryFile[koalabear.
 	filteredInputs := vm.FilterInputs(binF.Program(), inputs.Inputs)
 
 	// This sanity-checks the corset inputs of the test-case
-	outputs, err = traceZkc(binF, constraints.DEFAULT_TRACE_CONFIG, filteredInputs)
+	outputs, err = traceZkc(binF, constraints.DEFAULT_TRACE_CONFIG, filteredInputs, withTraceCheck)
 	if err != nil {
 		return nil, nil, fmt.Errorf("constraint check failed: %w", err)
 	}
@@ -98,6 +102,7 @@ func traceZkc(
 	binFile *constraints.BinaryFile[koalabear.Element],
 	tracingCfg constraints.TraceConfig,
 	input map[string][]byte,
+	withCheck bool,
 ) (outputs map[string][]byte, err error) {
 	// recover panics. ZKC tends to panic when it fails tracing, so we want to catch those and return them as errors.
 	defer func() {
@@ -112,14 +117,17 @@ func traceZkc(
 		return nil, fmt.Errorf("could not trace the binary file: %w", errors.Join(errs...))
 	}
 
-	// check the traces work
-	if errsSchema := binFile.Check(tr, tracingCfg); len(errsSchema) > 0 {
-		errs := make([]error, len(errsSchema))
-		for i, e := range errsSchema {
-			errs[i] = errors.New(e.Message())
+	if withCheck {
+		// check the traces work
+		if errsSchema := binFile.Check(tr, tracingCfg); len(errsSchema) > 0 {
+			errs := make([]error, len(errsSchema))
+			for i, e := range errsSchema {
+				errs[i] = errors.New(e.Message())
+			}
+			return nil, fmt.Errorf("constraint check failed: %w", errors.Join(errs...))
 		}
-		return nil, fmt.Errorf("constraint check failed: %w", errors.Join(errs...))
 	}
+
 	return outputs, nil
 }
 


### PR DESCRIPTION
This PR optimizes the CI tests of the prover

- Skip the tracer check when running the CI in short mode
- Optimize the lookups checking function (not in the critical path of the full prover)