### PR TITLE
chore(misc): rollup_spec add programVk to execution response

### DIFF
--- a/rollup_spec/src/rollup_spec/proof_io_v1.py
+++ b/rollup_spec/src/rollup_spec/proof_io_v1.py
@@ -263,11 +263,18 @@ def decode_request_json(text: str | bytes) -> L2ExecutionProofPrivateInput:
 # ── response: guest dataclass -> JSON dict ────────────────────────────────────
 
 
-def encode_response(proof: L2ExecutionProof, prover_version: str) -> dict:
+def encode_response(proof: L2ExecutionProof, prover_version: str, *, program_vk: Hash32) -> dict:
     """
     Convert the guest's `L2ExecutionProof` into a
     `getZkL2ExecutionProofV1.response.json` object the coordinator's Jackson
     mapper consumes directly.
+
+    §ProgramVK anchoring: `program_vk` is host-attached metadata (like `proof`
+    and `prover_version`) — the guest cannot attest its own VK, so it is not
+    part of `L2ExecutionProof`/`public_inputs`, but the prover knows which
+    guest binary it ran and carries the VK on the wire response so the
+    coordinator can echo it, unchanged, into the rollup request's embedded
+    l2-execution proof (see `_decode_l2_execution_proof`).
     """
     pi = proof.public_inputs
     return {
@@ -299,23 +306,28 @@ def encode_response(proof: L2ExecutionProof, prover_version: str) -> dict:
         "l2L1Messages": [_hx(h) for h in proof.l2_l1_messages],
         "txFroms": [_hx(a) for a in proof.tx_froms],
         "filteredAddresses": [_hx(a) for a in proof.filtered_addresses],
+        "programVk": _hx(program_vk),
     }
 
 
 def encode_response_json(
-    proof: L2ExecutionProof, prover_version: str, *, indent: int | None = None
+    proof: L2ExecutionProof,
+    prover_version: str,
+    *,
+    program_vk: Hash32,
+    indent: int | None = None,
 ) -> str:
-    return json.dumps(encode_response(proof, prover_version), indent=indent)
+    return json.dumps(encode_response(proof, prover_version, program_vk=program_vk), indent=indent)
 
 
 # ── prover entrypoint ─────────────────────────────────────────────────────────
 
 
-def run_from_request_json(text: str | bytes, prover_version: str) -> dict:
+def run_from_request_json(text: str | bytes, prover_version: str, *, program_vk: Hash32) -> dict:
     """Full host flow: parse request JSON, run the guest, return response JSON dict."""
     execution_input = decode_request_json(text)
     proof = run_l2_execution_guest(execution_input)
-    return encode_response(proof, prover_version)
+    return encode_response(proof, prover_version, program_vk=program_vk)
 
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/rollup_spec/src/rollup_spec/prover_io/schemas/getZkL2ExecutionProofV1.response.schema.json
+++ b/rollup_spec/src/rollup_spec/prover_io/schemas/getZkL2ExecutionProofV1.response.schema.json
@@ -12,7 +12,8 @@
     "publicInputs",
     "l2L1Messages",
     "txFroms",
-    "filteredAddresses"
+    "filteredAddresses",
+    "programVk"
   ],
   "properties": {
     "proverVersion": { "type": "string" },
@@ -69,7 +70,8 @@
     "filteredAddresses": {
       "type": "array",
       "items": { "$ref": "#/$defs/address" }
-    }
+    },
+    "programVk": { "$ref": "#/$defs/hash32" }
   },
   "$defs": {
     "uint": { "type": "integer", "minimum": 0 },

--- a/rollup_spec/src/rollup_spec/prover_io/testdata/10-11-getZkL2ExecutionProofV1.response.json
+++ b/rollup_spec/src/rollup_spec/prover_io/testdata/10-11-getZkL2ExecutionProofV1.response.json
@@ -29,5 +29,6 @@
   ],
   "filteredAddresses": [
     "0x0909090909090909090909090909090909090909"
-  ]
+  ],
+  "programVk": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 }

--- a/rollup_spec/tests/test_proof_io_v1.py
+++ b/rollup_spec/tests/test_proof_io_v1.py
@@ -218,12 +218,12 @@ def test_encode_response_matches_fixture_exactly() -> None:
     # The testdata request/response pair is mutually consistent: _sample_proof()
     # is the L2ExecutionProof a guest run over the request fixture would yield,
     # so its encoding must equal the response fixture (dict equality).
-    out = encode_response(_sample_proof(), prover_version=_PROVER_VERSION)
+    out = encode_response(_sample_proof(), prover_version=_PROVER_VERSION, program_vk=_EXEC_VK)
     assert out == _expected_response()
 
 
 def test_encode_response_shape_and_values() -> None:
-    out = encode_response(_sample_proof(), prover_version="4.0.0-riscv")
+    out = encode_response(_sample_proof(), prover_version="4.0.0-riscv", program_vk=_EXEC_VK)
 
     assert out["proverVersion"] == "4.0.0-riscv"
     assert out["proof"] == "0xdeadbeef"
@@ -252,12 +252,19 @@ def test_encode_response_shape_and_values() -> None:
     assert out["l2L1Messages"] == ["0x" + ("08" * 32)]
     assert out["txFroms"] == ["0x" + ("01" * 20), "0x" + ("02" * 20)]
     assert out["filteredAddresses"] == ["0x" + ("09" * 20)]
+    # §ProgramVK anchoring: the exec guest's own VK, carried on the proof
+    # (host-attached, not part of publicInputs — a guest cannot attest its own VK).
+    assert out["programVk"] == "0x" + ("aa" * 32)
+    assert set(out.keys()) == {
+        "proverVersion", "proof", "startBlockNumber", "publicInputs",
+        "l2L1Messages", "txFroms", "filteredAddresses", "programVk",
+    }
 
 
 def test_empty_proof_bytes_encode_as_0x() -> None:
     proof = _sample_proof()
     proof.proof = b""
-    out = encode_response(proof, prover_version="v")
+    out = encode_response(proof, prover_version="v", program_vk=_EXEC_VK)
     assert out["proof"] == "0x"
 
 


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking wire-contract change for L2 execution proof responses; coordinators and provers must supply and consume `programVk`, but it aligns encode with existing rollup decode expectations for program VK anchoring.
> 
> **Overview**
> Adds **required** `programVk` to the `getZkL2ExecutionProofV1` response JSON so the coordinator can carry the execution guest’s verification key alongside the proof.
> 
> The prover host now accepts a `program_vk` argument on `encode_response`, `encode_response_json`, and `run_from_request_json`, and serializes it as top-level `programVk` (host metadata like `proof`, not in `publicInputs`). That matches how rollup requests already decode embedded execution proofs via `_decode_l2_execution_proof`.
> 
> The response JSON schema, golden fixture, and encode tests were updated for the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 910ac7a1f15464a7da6fa691a27c7f65c8861f80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->