### PR TITLE
feat(prover-ray): rename guestProgramId to programVk

### DIFF
--- a/prover-ray/backend/jobadapter/request.go
+++ b/prover-ray/backend/jobadapter/request.go
@@ -11,10 +11,10 @@ import (
 )
 
 const (
-	guestProgramIDKey = "guestProgramId"
-	chainIDKey        = "chainId"
-	forkNameKey       = "forkName"
-	payloadsKey       = "payloads"
+	programVkKey = "programVk"
+	chainIDKey   = "chainId"
+	forkNameKey  = "forkName"
+	payloadsKey  = "payloads"
 
 	proofRequestKey            = "proofRequest"
 	chainConfigKey             = "chainConfig"
@@ -33,7 +33,7 @@ const (
 	deadlineKey                = "deadline"
 	signedTxRlpKey             = "signedTxRlp"
 	acceptanceKey              = "acceptance"
-	guestProgramIDByteSize     = 32
+	programVkByteSize          = 32
 	hashByteSize               = 32
 	addressByteSize            = 20
 
@@ -66,13 +66,13 @@ type L2ExecutionPayload struct {
 // block. The block range is implied by the payloads (their
 // executionPayload.blockNumber), as in the reference decoder.
 type L2ExecutionRequest struct {
-	// GuestProgramID is routing metadata; this decoder validates its shape but
+	// ProgramVk is routing metadata; this decoder validates its shape but
 	// does not verify it against the configured guest ELF (open question #6 in
 	// wiki backend-overview.md).
-	GuestProgramID []byte
-	ChainID        uint64
-	ForkName       string
-	Payloads       []L2ExecutionPayload
+	ProgramVk []byte
+	ChainID   uint64
+	ForkName  string
+	Payloads  []L2ExecutionPayload
 }
 
 // DecodeL2ExecutionRequest parses a getZkL2ExecutionProofV1 request body and
@@ -88,20 +88,20 @@ func DecodeL2ExecutionRequest(data []byte) (*L2ExecutionRequest, error) {
 		return nil, fmt.Errorf("DecodeL2ExecutionRequest: parsing JSON: %w", err)
 	}
 
-	gpidRaw, err := requireField(env, guestProgramIDKey, "")
+	programVkRaw, err := requireField(env, programVkKey, "")
 	if err != nil {
 		return nil, err
 	}
-	guestProgramID, err := hexString(gpidRaw, guestProgramIDKey)
+	programVk, err := hexString(programVkRaw, programVkKey)
 	if err != nil {
 		return nil, err
 	}
-	if len(guestProgramID) != guestProgramIDByteSize {
+	if len(programVk) != programVkByteSize {
 		return nil, fmt.Errorf(
 			"DecodeL2ExecutionRequest: %s must be %d bytes, got %d",
-			guestProgramIDKey,
-			guestProgramIDByteSize,
-			len(guestProgramID),
+			programVkKey,
+			programVkByteSize,
+			len(programVk),
 		)
 	}
 
@@ -163,10 +163,10 @@ func DecodeL2ExecutionRequest(data []byte) (*L2ExecutionRequest, error) {
 	}
 
 	return &L2ExecutionRequest{
-		GuestProgramID: guestProgramID,
-		ChainID:        chainConfig.chainID,
-		ForkName:       chainConfig.forkName,
-		Payloads:       payloads,
+		ProgramVk: programVk,
+		ChainID:   chainConfig.chainID,
+		ForkName:  chainConfig.forkName,
+		Payloads:  payloads,
 	}, nil
 }
 

--- a/prover-ray/backend/jobadapter/request_test.go
+++ b/prover-ray/backend/jobadapter/request_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// guestProgramID is the routing id in the request fixtures.
-const guestProgramID = "0x17d2e0660946012c80c5fe6bbecc2076a6f6f5aa58606efe66a14426d2ffe46f"
+// programVk is the routing id in the request fixtures.
+const programVk = "0x17d2e0660946012c80c5fe6bbecc2076a6f6f5aa58606efe66a14426d2ffe46f"
 
 const invalidNumber = "not-a-number"
 
@@ -37,9 +37,9 @@ func TestDecodeL2ExecutionRequest_SingleBlock(t *testing.T) {
 	assert.Equal(t, uint64(59144), req.ChainID)
 	assert.Equal(t, "Amsterdam", req.ForkName)
 
-	wantID, err := hex.DecodeString(strings.TrimPrefix(guestProgramID, "0x"))
+	wantID, err := hex.DecodeString(strings.TrimPrefix(programVk, "0x"))
 	require.NoError(t, err)
-	assert.Equal(t, wantID, req.GuestProgramID)
+	assert.Equal(t, wantID, req.ProgramVk)
 
 	require.Len(t, req.Payloads, 1)
 	assert.Equal(t, uint64(1000501), req.Payloads[0].BlockNumber)
@@ -122,9 +122,9 @@ func TestDecodeL2ExecutionRequest_InvalidRequestShape(t *testing.T) {
 		mutate  func(o map[string]any)
 		wantErr string
 	}{
-		{"MissingGuestProgramID",
-			func(o map[string]any) { delete(o, guestProgramIDKey) },
-			guestProgramIDKey},
+		{"MissingProgramVk",
+			func(o map[string]any) { delete(o, programVkKey) },
+			programVkKey},
 		{"MissingProofRequest",
 			func(o map[string]any) { delete(o, proofRequestKey) },
 			proofRequestKey},
@@ -263,18 +263,18 @@ func TestDecodeL2ExecutionRequest_InvalidRequestShape(t *testing.T) {
 		{"ExecutionRequestsNull",
 			func(o map[string]any) { npr(o)[executionRequestsKey] = nil },
 			executionRequestsKey},
-		{"GuestProgramIDNotString",
-			func(o map[string]any) { o[guestProgramIDKey] = 123 },
-			guestProgramIDKey},
-		{"GuestProgramIDNoPrefix",
-			func(o map[string]any) { o[guestProgramIDKey] = strings.TrimPrefix(guestProgramID, "0x") },
-			guestProgramIDKey},
-		{"GuestProgramIDBadHex",
-			func(o map[string]any) { o[guestProgramIDKey] = "0xzz" },
-			guestProgramIDKey},
-		{"GuestProgramIDWrongLength",
-			func(o map[string]any) { o[guestProgramIDKey] = "0x1234" },
-			guestProgramIDKey},
+		{"ProgramVkNotString",
+			func(o map[string]any) { o[programVkKey] = 123 },
+			programVkKey},
+		{"ProgramVkNoPrefix",
+			func(o map[string]any) { o[programVkKey] = strings.TrimPrefix(programVk, "0x") },
+			programVkKey},
+		{"ProgramVkBadHex",
+			func(o map[string]any) { o[programVkKey] = "0xzz" },
+			programVkKey},
+		{"ProgramVkWrongLength",
+			func(o map[string]any) { o[programVkKey] = "0x1234" },
+			programVkKey},
 		{"ChainIDNotParseable",
 			func(o map[string]any) { chainConfig(o)[chainIDKey] = invalidNumber },
 			chainIDKey},

--- a/prover-ray/backend/jobadapter/response.go
+++ b/prover-ray/backend/jobadapter/response.go
@@ -51,7 +51,9 @@ type failureResponseBody struct {
 	Error       string      `json:"error,omitempty"`
 }
 
-func newExecutionResponse(result backend.Result, startBlockNumber uint64, proverVersion string, programVk []byte) executionResponse {
+func newExecutionResponse(
+	result backend.Result, startBlockNumber uint64, proverVersion string, programVk []byte,
+) executionResponse {
 	return executionResponse{
 		ProverVersion:     proverVersion,
 		ProofHex:          hexBytes(result.ProofBytes),

--- a/prover-ray/backend/jobadapter/response.go
+++ b/prover-ray/backend/jobadapter/response.go
@@ -19,6 +19,7 @@ type executionResponse struct {
 	L2L1Messages      []string              `json:"l2L1Messages"`
 	TxFroms           []string              `json:"txFroms"`
 	FilteredAddresses []string              `json:"filteredAddresses"`
+	ProgramVk         string                `json:"programVk"`
 }
 
 type executionPublicInputs struct {
@@ -50,7 +51,7 @@ type failureResponseBody struct {
 	Error       string      `json:"error,omitempty"`
 }
 
-func newExecutionResponse(result backend.Result, startBlockNumber uint64, proverVersion string) executionResponse {
+func newExecutionResponse(result backend.Result, startBlockNumber uint64, proverVersion string, programVk []byte) executionResponse {
 	return executionResponse{
 		ProverVersion:     proverVersion,
 		ProofHex:          hexBytes(result.ProofBytes),
@@ -59,6 +60,7 @@ func newExecutionResponse(result backend.Result, startBlockNumber uint64, prover
 		L2L1Messages:      []string{},
 		TxFroms:           []string{},
 		FilteredAddresses: []string{},
+		ProgramVk:         hexBytes(programVk),
 	}
 }
 

--- a/prover-ray/backend/jobadapter/response_test.go
+++ b/prover-ray/backend/jobadapter/response_test.go
@@ -36,11 +36,14 @@ func TestNewExecutionResponse_MapsV1Fields(t *testing.T) {
 		},
 	}
 
-	resp := newExecutionResponse(result, 1000501, "test-version")
+	vkArr := filledHash(0xbb)
+	vk := vkArr[:]
+	resp := newExecutionResponse(result, 1000501, "test-version", vk)
 
 	assert.Equal(t, "test-version", resp.ProverVersion)
 	assert.Equal(t, "0xcafe", resp.ProofHex)
 	assert.Equal(t, uint64(1000501), resp.StartBlockNumber)
+	assert.Equal(t, repeatHex(0xbb), resp.ProgramVk)
 	assert.Empty(t, resp.L2L1Messages)
 	assert.Empty(t, resp.TxFroms)
 	assert.Empty(t, resp.FilteredAddresses)
@@ -65,7 +68,7 @@ func TestNewExecutionResponse_MapsV1Fields(t *testing.T) {
 }
 
 func TestNewExecutionResponse_MatchesReferenceResponseShape(t *testing.T) {
-	raw, err := jsonMarshalObject(newExecutionResponse(backend.Result{}, 42, "test-version"))
+	raw, err := jsonMarshalObject(newExecutionResponse(backend.Result{}, 42, "test-version", make([]byte, 32)))
 	require.NoError(t, err)
 
 	assertResponseShapeMatchesReference(t, raw)
@@ -81,7 +84,7 @@ func TestNewExecutionResponse_MatchesReferenceResponseValues(t *testing.T) {
 	// backend result.
 	t.Skip("enable after proof serialization, public-input extraction, and l2L1Messages/txFroms/filteredAddresses response arrays are wired")
 
-	got, err := jsonMarshalObject(newExecutionResponse(backend.Result{}, 1000501, ""))
+	got, err := jsonMarshalObject(newExecutionResponse(backend.Result{}, 1000501, "", make([]byte, 32)))
 	require.NoError(t, err)
 
 	assert.Equal(t, readReferenceResponse(t), got)

--- a/prover-ray/backend/jobadapter/runner.go
+++ b/prover-ray/backend/jobadapter/runner.go
@@ -120,7 +120,7 @@ func (r *Runner) runL2Execution(ctx context.Context, runReq RunRequest) RunResul
 		return failedRunResult(runReq.ID, FailureCodeInternalError, err)
 	}
 	return RunResult{
-		ResponseBody: newExecutionResponse(result, payload.BlockNumber, r.proverVersion),
+		ResponseBody: newExecutionResponse(result, payload.BlockNumber, r.proverVersion, req.ProgramVk),
 		Status:       RunStatusSuccess,
 	}
 }

--- a/prover-ray/backend/jobadapter/testdata/request_multi_block.json
+++ b/prover-ray/backend/jobadapter/testdata/request_multi_block.json
@@ -1,5 +1,5 @@
 {
-  "guestProgramId": "0x17d2e0660946012c80c5fe6bbecc2076a6f6f5aa58606efe66a14426d2ffe46f",
+  "programVk": "0x17d2e0660946012c80c5fe6bbecc2076a6f6f5aa58606efe66a14426d2ffe46f",
   "metadata": {
     "startBlockNumber": 1000501,
     "endBlockNumber": 1000502

--- a/prover-ray/backend/jobadapter/testdata/request_single_block.json
+++ b/prover-ray/backend/jobadapter/testdata/request_single_block.json
@@ -1,5 +1,5 @@
 {
-  "guestProgramId": "0x17d2e0660946012c80c5fe6bbecc2076a6f6f5aa58606efe66a14426d2ffe46f",
+  "programVk": "0x17d2e0660946012c80c5fe6bbecc2076a6f6f5aa58606efe66a14426d2ffe46f",
   "metadata": {
     "startBlockNumber": 1000501,
     "endBlockNumber": 1000501

--- a/rollup_spec/src/rollup_spec/prover_io/testdata/10-11-getZkL2ExecutionProofV1.request.json
+++ b/rollup_spec/src/rollup_spec/prover_io/testdata/10-11-getZkL2ExecutionProofV1.request.json
@@ -1,5 +1,5 @@
 {
-  "guestProgramId": "0x17d2e0660946012c80c5fe6bbecc2076a6f6f5aa58606efe66a14426d2ffe46f",
+  "programVk": "0x17d2e0660946012c80c5fe6bbecc2076a6f6f5aa58606efe66a14426d2ffe46f",
   "metadata": {
     "startBlockNumber": 10,
     "endBlockNumber": 11


### PR DESCRIPTION
## Summary

- Renames `guestProgramId` → `programVk` in the prover-ray Go decoder (`request.go`), matching the rollup_spec wire contract rename (companion to the rollup_spec PR)
- Adds `programVk` field to the execution response (`response.go`) and threads `req.ProgramVk` through `newExecutionResponse` in `runner.go` — echoing the routing metadata back in the response as required by the updated spec
- Updates local request testdata fixtures (`request_single_block.json`, `request_multi_block.json`)
- Syncs the shared rollup_spec reference fixture (`10-11-getZkL2ExecutionProofV1.request.json`) to use the new key so `TestDecodeL2ExecutionRequest_ReferenceFixture` stays green

## Test plan

- [ ] `go test ./backend/jobadapter/...` passes (all 3 previously-failing tests now green: `TestDecodeL2ExecutionRequest_ReferenceFixture`, `TestNewExecutionResponse_MatchesReferenceResponseShape`, `TestAdapter_SingleBlock_Success`)
- [ ] No other prover-ray packages affected (`go build ./...` clean)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contract rename and response field addition in the job adapter only; behavior is unchanged aside from JSON key names and echoing the VK clients already send.
> 
> **Overview**
> Aligns **prover-ray** `getZkL2ExecutionProofV1` I/O with the updated rollup_spec wire contract by renaming **`guestProgramId` → `programVk`** on requests and in Go types (`L2ExecutionRequest.ProgramVk`, decoder keys, and validation errors).
> 
> Success responses now include **`programVk`** (hex), populated from the decoded request via **`newExecutionResponse`** and **`runner.go`**, so routing metadata is echoed back per spec. Local and shared **JSON fixtures** were updated to the new field name; tests were renamed accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53f0fe9bca0773de4caa71ad9838aca7fec62a58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->