### PR TITLE
feat(misc): add programVk to rollup proof response schema and testdata

### DIFF
--- a/rollup_spec/src/rollup_spec/proof_io_v1.py
+++ b/rollup_spec/src/rollup_spec/proof_io_v1.py
@@ -526,13 +526,18 @@ def _encode_rollup_public_inputs(pi: RollupPublicInput) -> dict:
     }
 
 
-def encode_rollup_response(proof: RollupProof, prover_version: str) -> dict:
+def encode_rollup_response(proof: RollupProof, prover_version: str, *, program_vk: Hash32) -> dict:
     """
     Convert the guest's `RollupProof` into a `getZkRollupProofV1.response.json`
     object the coordinator's Jackson mapper consumes directly.
+
+    §ProgramVK anchoring: `program_vk` is host-attached metadata the coordinator
+    supplies from the request envelope and the prover echoes on the response —
+    mirroring the L2-execution response pattern.
     """
     return {
         "proverVersion": prover_version,
+        "programVk": _hx(program_vk),
         "proof": _hx(proof.proof),
         "startBlockNumber": int(proof.start_block_number),
         "publicInputs": _encode_rollup_public_inputs(proof.public_inputs),
@@ -542,19 +547,19 @@ def encode_rollup_response(proof: RollupProof, prover_version: str) -> dict:
 
 
 def encode_rollup_response_json(
-    proof: RollupProof, prover_version: str, *, indent: int | None = None
+    proof: RollupProof, prover_version: str, *, program_vk: Hash32, indent: int | None = None
 ) -> str:
-    return json.dumps(encode_rollup_response(proof, prover_version), indent=indent)
+    return json.dumps(encode_rollup_response(proof, prover_version, program_vk=program_vk), indent=indent)
 
 
 # ── rollup prover entrypoint ──────────────────────────────────────────────────
 
 
-def run_rollup_from_request_json(text: str | bytes, prover_version: str) -> dict:
+def run_rollup_from_request_json(text: str | bytes, prover_version: str, *, program_vk: Hash32) -> dict:
     """Full host flow: parse rollup request JSON, run the guest, return response JSON dict."""
     rollup_input = decode_rollup_request_json(text)
     proof = run_rollup_guest(rollup_input)
-    return encode_rollup_response(proof, prover_version)
+    return encode_rollup_response(proof, prover_version, program_vk=program_vk)
 
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/rollup_spec/src/rollup_spec/prover_io/schemas/getZkRollupProofV1.response.schema.json
+++ b/rollup_spec/src/rollup_spec/prover_io/schemas/getZkRollupProofV1.response.schema.json
@@ -7,6 +7,7 @@
   "additionalProperties": false,
   "required": [
     "proverVersion",
+    "programVk",
     "proof",
     "startBlockNumber",
     "publicInputs",
@@ -15,6 +16,7 @@
   ],
   "properties": {
     "proverVersion": { "type": "string" },
+    "programVk": { "$ref": "#/$defs/hash32" },
     "proof": { "$ref": "#/$defs/hex" },
     "startBlockNumber": { "$ref": "#/$defs/uint" },
     "publicInputs": {

--- a/rollup_spec/src/rollup_spec/prover_io/testdata/10-14-getZkRollupProofV1.response.json
+++ b/rollup_spec/src/rollup_spec/prover_io/testdata/10-14-getZkRollupProofV1.response.json
@@ -1,5 +1,6 @@
 {
   "proverVersion": "4.0.0-riscv",
+  "programVk": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
   "proof": "0xdeadbeef",
   "startBlockNumber": 1000501,
   "publicInputs": {

--- a/rollup_spec/tests/test_proof_io_v1.py
+++ b/rollup_spec/tests/test_proof_io_v1.py
@@ -415,12 +415,12 @@ def test_decode_rollup_request_json_round_trips() -> None:
 
 
 def test_encode_rollup_response_matches_fixture_exactly() -> None:
-    out = encode_rollup_response(_sample_rollup_proof(), prover_version=_PROVER_VERSION)
+    out = encode_rollup_response(_sample_rollup_proof(), prover_version=_PROVER_VERSION, program_vk=_ROLLUP_VK)
     assert out == _expected_rollup_response()
 
 
 def test_encode_rollup_response_shape_and_values() -> None:
-    out = encode_rollup_response(_sample_rollup_proof(), prover_version="4.0.0-riscv")
+    out = encode_rollup_response(_sample_rollup_proof(), prover_version="4.0.0-riscv", program_vk=_ROLLUP_VK)
 
     assert out["proverVersion"] == "4.0.0-riscv"
     assert out["proof"] == "0xdeadbeef"
@@ -453,6 +453,7 @@ def test_encode_rollup_response_shape_and_values() -> None:
         "startOffset", "endOffset", "programVks",
     }
 
+    assert out["programVk"] == "0x" + ("bb" * 32)
     assert out["l2L1Roots"] == ["0x" + ("77" * 32), "0x" + ("88" * 32)]
     assert out["filteredAddresses"] == ["0x" + ("03" * 20), "0x" + ("04" * 20)]
 


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the versioned coordinator–prover JSON contract and breaks callers of the rollup encode entrypoints until they pass `program_vk`; correctness of program-VK anchoring in downstream rollup/aggregation flows depends on provers echoing the request envelope correctly.
> 
> **Overview**
> **Rollup proof responses** now carry a top-level **`programVk`** (32-byte hash), aligned with the existing L2-execution response pattern for §ProgramVK anchoring.
> 
> The V1 codec **`encode_rollup_response`**, **`encode_rollup_response_json`**, and **`run_rollup_from_request_json`** take a new required keyword argument **`program_vk`** and echo it on the wire; the guest `RollupProof` type is unchanged. **`getZkRollupProofV1.response.schema.json`** lists **`programVk`** as required, and the rollup response golden fixture plus **`test_proof_io_v1`** assertions were updated accordingly.
> 
> This is a **breaking wire/API change** for anything that builds or validates rollup responses without supplying **`programVk`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e379f9c9c1d12109aa1aeeb1b4ce35fae0468604. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->