### PR TITLE
feat(coordinator): add programVk to L2 execution and rollup proof response chain

### DIFF
--- a/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/L2ExecutionProverClient.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/L2ExecutionProverClient.kt
@@ -84,6 +84,7 @@ internal object L2ExecutionProofResponseDtoMapper : (
       l2L1Messages = responseDto.l2L1Messages.map { it.decodeHex() },
       txFroms = responseDto.txFroms.map { it.decodeHex() },
       filteredAddresses = responseDto.filteredAddresses.map { it.decodeHex() },
+      programVk = responseDto.programVk.decodeHex(),
     )
   }
 }

--- a/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProofDtos.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProofDtos.kt
@@ -181,6 +181,7 @@ data class L2ExecutionProofResponseDto(
   val l2L1Messages: List<String>,
   val txFroms: List<String>,
   val filteredAddresses: List<String>,
+  val programVk: String,
 )
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -199,6 +200,7 @@ data class L2ExecutionProofDto(
   val l2L1Messages: List<String>,
   val txFroms: List<String>,
   val filteredAddresses: List<String>,
+  val programVk: String,
 )
 
 data class FileBasedRollupProofRequestParamsDto(
@@ -244,6 +246,7 @@ data class RollupProofResponseDto(
   val publicInputs: RollupProofPublicInputsDto,
   val l2L1Roots: List<String>,
   val filteredAddresses: List<String>,
+  val programVk: String,
 )
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -257,6 +260,7 @@ data class RollupProofDto(
   val publicInputs: RollupProofPublicInputsDto,
   val l2L1Roots: List<String>,
   val filteredAddresses: List<String>,
+  val programVk: String,
 )
 
 data class FileBasedRollupAggregationProofRequestParamsDto(
@@ -465,6 +469,7 @@ internal fun L2ExecutionProofResponseV1.fromDomainObject(): L2ExecutionProofDto 
     l2L1Messages = l2L1Messages.map { it.encodeHex() },
     txFroms = txFroms.map { it.encodeHex() },
     filteredAddresses = filteredAddresses.map { it.encodeHex() },
+    programVk = programVk.encodeHex(),
   )
 }
 
@@ -475,5 +480,6 @@ internal fun RollupProofResponseV1.fromDomainObject(): RollupProofDto {
     publicInputs = publicInputs.fromDomainObject(),
     l2L1Roots = l2L1Roots.map { it.encodeHex() },
     filteredAddresses = filteredAddresses.map { it.encodeHex() },
+    programVk = programVk.encodeHex(),
   )
 }

--- a/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProofDtos.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProofDtos.kt
@@ -12,7 +12,7 @@ import linea.ethapi.ExecutionWitness
 import linea.forcedtx.ForcedTransactionInclusionResult
 import linea.kotlin.decodeHex
 import linea.kotlin.encodeHex
-import java.math.BigInteger
+import linea.kotlin.toHexString
 import kotlin.time.Instant
 
 /**
@@ -115,7 +115,7 @@ data class ExecutionPayloadDto(
   val gasUsed: Long,
   val timestamp: Long,
   val extraData: String,
-  val baseFeePerGas: BigInteger,
+  val baseFeePerGas: String,
   val blockHash: String,
   val transactions: List<String>,
   val withdrawals: List<WithdrawalDto>,
@@ -174,7 +174,7 @@ data class L2ExecutionProofRequestDto(
 )
 
 data class L2ExecutionProofResponseDto(
-  val proverVersion: String? = null,
+  val proverVersion: String,
   val startBlockNumber: Long,
   val proof: String,
   val publicInputs: L2ExecutionProofPublicInputsDto,
@@ -240,7 +240,7 @@ data class RestfulRollupProofRequestDto(
 )
 
 data class RollupProofResponseDto(
-  val proverVersion: String? = null,
+  val proverVersion: String,
   val startBlockNumber: Long,
   val proof: String,
   val publicInputs: RollupProofPublicInputsDto,
@@ -285,7 +285,7 @@ data class RestfulRollupAggregationProofRequestDto(
 
 /** Response of a rollup-aggregation proof: the aggregated proof bytes plus the 20-field PI tuple (§2.4). */
 data class RollupAggregationProofResponseDto(
-  val proverVersion: String? = null,
+  val proverVersion: String,
   val startBlockNumber: Long,
   val proof: String,
   val publicInputs: RollupProofPublicInputsDto,
@@ -353,7 +353,7 @@ internal fun ExecutionPayload.fromDomainObject(): ExecutionPayloadDto {
     gasUsed = gasUsed.toLong(),
     timestamp = timestamp.toLong(),
     extraData = extraData.encodeHex(),
-    baseFeePerGas = baseFeePerGas,
+    baseFeePerGas = baseFeePerGas.toHexString(),
     blockHash = blockHash.encodeHex(),
     transactions = transactions.map { it.encodeHex() },
     withdrawals = withdrawals.map {

--- a/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/RollupAggregationProverClient.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/RollupAggregationProverClient.kt
@@ -39,6 +39,7 @@ internal class FileBasedRollupAggregationProofRequestDtoMapper(
                 publicInputs = proofResponse.publicInputs,
                 l2L1Roots = proofResponse.l2L1Roots,
                 filteredAddresses = proofResponse.filteredAddresses,
+                programVk = proofResponse.programVk,
               )
             },
           ),

--- a/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/RollupProverClient.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/RollupProverClient.kt
@@ -44,6 +44,7 @@ internal class FileBasedRollupProofRequestDtoMapper(
                 l2L1Messages = proofResponse.l2L1Messages,
                 txFroms = proofResponse.txFroms,
                 filteredAddresses = proofResponse.filteredAddresses,
+                programVk = proofResponse.programVk,
               )
             },
             chunks = request.chunks.map { it.encodeHex() },
@@ -113,6 +114,7 @@ internal object RollupProofResponseDtoMapper : (
       publicInputs = responseDto.publicInputs.toDomainObject(),
       l2L1Roots = responseDto.l2L1Roots.map { it.decodeHex() },
       filteredAddresses = responseDto.filteredAddresses.map { it.decodeHex() },
+      programVk = responseDto.programVk.decodeHex(),
     )
   }
 }

--- a/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProofRequestDtoMapperTest.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProofRequestDtoMapperTest.kt
@@ -13,6 +13,7 @@ import linea.domain.Withdrawal
 import linea.ethapi.ExecutionWitness
 import linea.forcedtx.ForcedTransactionInclusionResult
 import linea.kotlin.encodeHex
+import linea.kotlin.toHexString
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -341,7 +342,7 @@ class RiscVProofRequestDtoMapperTest {
     gasUsed = payload.gasUsed.toLong(),
     timestamp = payload.timestamp.toLong(),
     extraData = payload.extraData.encodeHex(),
-    baseFeePerGas = payload.baseFeePerGas,
+    baseFeePerGas = payload.baseFeePerGas.toHexString(),
     blockHash = payload.blockHash.encodeHex(),
     transactions = payload.transactions.map { it.encodeHex() },
     withdrawals = payload.withdrawals.map {

--- a/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProofRequestDtoMapperTest.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProofRequestDtoMapperTest.kt
@@ -198,6 +198,7 @@ class RiscVProofRequestDtoMapperTest {
               l2L1Messages = resolved.l2L1Messages,
               txFroms = resolved.txFroms,
               filteredAddresses = resolved.filteredAddresses,
+              programVk = resolved.programVk,
             )
           },
           chunks = chunks.map { it.encodeHex() },
@@ -252,6 +253,7 @@ class RiscVProofRequestDtoMapperTest {
               publicInputs = resolved.publicInputs,
               l2L1Roots = resolved.l2L1Roots,
               filteredAddresses = resolved.filteredAddresses,
+              programVk = resolved.programVk,
             )
           },
         ),

--- a/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProofResponseDtoMapperTest.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProofResponseDtoMapperTest.kt
@@ -106,6 +106,7 @@ class RiscVProofResponseDtoMapperTest {
 
   @Test
   fun `L2ExecutionProofResponseDtoMapper decodes every field`() {
+    val programVkHex = "0x" + "dd".repeat(32)
     val dto = L2ExecutionProofResponseDto(
       proverVersion = "4.0.0-riscv",
       startBlockNumber = 1000500L,
@@ -114,6 +115,7 @@ class RiscVProofResponseDtoMapperTest {
       l2L1Messages = listOf("0xaa"),
       txFroms = listOf("0xbb"),
       filteredAddresses = listOf("0xcc"),
+      programVk = programVkHex,
     )
 
     assertThat(
@@ -127,12 +129,14 @@ class RiscVProofResponseDtoMapperTest {
         l2L1Messages = listOf("0xaa".decodeHex()),
         txFroms = listOf("0xbb".decodeHex()),
         filteredAddresses = listOf("0xcc".decodeHex()),
+        programVk = programVkHex.decodeHex(),
       ),
     )
   }
 
   @Test
   fun `RollupProofResponseDtoMapper decodes every field`() {
+    val programVkHex = "0x" + "bb".repeat(32)
     val dto = RollupProofResponseDto(
       proverVersion = "4.0.0-riscv",
       startBlockNumber = 1000500L,
@@ -140,6 +144,7 @@ class RiscVProofResponseDtoMapperTest {
       publicInputs = rollupPublicInputsDto,
       l2L1Roots = listOf("0xaa"),
       filteredAddresses = listOf("0xbb"),
+      programVk = programVkHex,
     )
 
     assertThat(
@@ -152,6 +157,7 @@ class RiscVProofResponseDtoMapperTest {
         publicInputs = expectedRollupPublicInputs,
         l2L1Roots = listOf("0xaa".decodeHex()),
         filteredAddresses = listOf("0xbb".decodeHex()),
+        programVk = programVkHex.decodeHex(),
       ),
     )
   }
@@ -210,7 +216,8 @@ class RiscVProofResponseDtoMapperTest {
         },
         "l2L1Messages": ["0xaa"],
         "txFroms": ["0xbb"],
-        "filteredAddresses": []
+        "filteredAddresses": [],
+        "programVk": "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
       }
     """.trimIndent()
 
@@ -227,6 +234,7 @@ class RiscVProofResponseDtoMapperTest {
         l2L1Messages = listOf("0xaa".decodeHex()),
         txFroms = listOf("0xbb".decodeHex()),
         filteredAddresses = emptyList(),
+        programVk = ByteArray(32) { 0xdd.toByte() },
       ),
     )
   }
@@ -261,7 +269,8 @@ class RiscVProofResponseDtoMapperTest {
           "programVks": []
         },
         "l2L1Roots": ["0xaa"],
-        "filteredAddresses": []
+        "filteredAddresses": [],
+        "programVk": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
       }
     """.trimIndent()
 
@@ -276,6 +285,7 @@ class RiscVProofResponseDtoMapperTest {
         publicInputs = expectedRollupPublicInputs,
         l2L1Roots = listOf("0xaa".decodeHex()),
         filteredAddresses = emptyList(),
+        programVk = ByteArray(32) { 0xbb.toByte() },
       ),
     )
   }

--- a/coordinator/clients/prover-client/riscv-client/src/testFixtures/kotlin/lineth/coordinator/clients/prover/riscv/FakeProverProofTransports.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/testFixtures/kotlin/lineth/coordinator/clients/prover/riscv/FakeProverProofTransports.kt
@@ -20,6 +20,7 @@ class FakeL2ExecutionProofTransport(
     l2L1Messages = listOf(ByteArray(32) { 0x4a }.encodeHex()),
     txFroms = listOf(ByteArray(20) { 0x4b }.encodeHex()),
     filteredAddresses = listOf(ByteArray(20) { 0x4c }.encodeHex()),
+    programVk = ByteArray(32) { 0xaa.toByte() }.encodeHex(),
   )
   override fun isRequestAlreadySubmitted(proofIndex: BlockIntervalProofIndex): SafeFuture<Boolean> =
     SafeFuture.completedFuture(true)
@@ -65,6 +66,7 @@ class FakeRollupProofTransport(
     publicInputs = RiscVProverClientTestFixtures.rollupProofPublicInputsDto(2L),
     l2L1Roots = listOf(ByteArray(32) { 0x5a }.encodeHex()),
     filteredAddresses = listOf(ByteArray(20) { 0x5b }.encodeHex()),
+    programVk = ByteArray(32) { 0xbb.toByte() }.encodeHex(),
   )
   override fun isRequestAlreadySubmitted(proofIndex: BlockIntervalProofIndex): SafeFuture<Boolean> =
     SafeFuture.completedFuture(true)

--- a/coordinator/clients/prover-client/riscv-client/src/testFixtures/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProverClientTestFixtures.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/testFixtures/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProverClientTestFixtures.kt
@@ -216,6 +216,7 @@ object RiscVProverClientTestFixtures {
     l2L1Messages = listOf("0xaa"),
     txFroms = listOf("0xbb"),
     filteredAddresses = emptyList(),
+    programVk = L2_EXECUTION_PROGRAM_VK,
   )
 
   fun rollupProofPublicInputsDto(
@@ -253,6 +254,7 @@ object RiscVProverClientTestFixtures {
     publicInputs = rollupProofPublicInputsDto(endBlockNumber),
     l2L1Roots = listOf("0xaa"),
     filteredAddresses = emptyList(),
+    programVk = ROLLUP_PROGRAM_VK,
   )
 
   fun rollupAggregationProofResponseDto(

--- a/coordinator/core-interfaces/src/main/kotlin/linea/clients/L2ExecutionProverRequestResponse.kt
+++ b/coordinator/core-interfaces/src/main/kotlin/linea/clients/L2ExecutionProverRequestResponse.kt
@@ -228,7 +228,7 @@ data class L2ExecutionProofResponseV1(
   val l2L1Messages: List<ByteArray>,
   val txFroms: List<ByteArray>,
   val filteredAddresses: List<ByteArray>,
-
+  val programVk: ByteArray,
 ) : BlockInterval {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
@@ -243,6 +243,7 @@ data class L2ExecutionProofResponseV1(
     if (!l2L1Messages.byteArrayListEquals(other.l2L1Messages)) return false
     if (!txFroms.byteArrayListEquals(other.txFroms)) return false
     if (!filteredAddresses.byteArrayListEquals(other.filteredAddresses)) return false
+    if (!programVk.contentEquals(other.programVk)) return false
 
     return true
   }
@@ -255,6 +256,7 @@ data class L2ExecutionProofResponseV1(
     result = 31 * result + l2L1Messages.byteArrayListHashCode()
     result = 31 * result + txFroms.byteArrayListHashCode()
     result = 31 * result + filteredAddresses.byteArrayListHashCode()
+    result = 31 * result + programVk.contentHashCode()
     return result
   }
 }

--- a/coordinator/core-interfaces/src/main/kotlin/linea/clients/RollupProverRequestResponse.kt
+++ b/coordinator/core-interfaces/src/main/kotlin/linea/clients/RollupProverRequestResponse.kt
@@ -181,6 +181,7 @@ data class RollupProofResponseV1(
   val publicInputs: RollupProofPublicInputs,
   val l2L1Roots: List<ByteArray>,
   val filteredAddresses: List<ByteArray>,
+  val programVk: ByteArray,
 ) : BlockInterval {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
@@ -194,6 +195,7 @@ data class RollupProofResponseV1(
     if (publicInputs != other.publicInputs) return false
     if (!l2L1Roots.byteArrayListEquals(other.l2L1Roots)) return false
     if (!filteredAddresses.byteArrayListEquals(other.filteredAddresses)) return false
+    if (!programVk.contentEquals(other.programVk)) return false
 
     return true
   }
@@ -205,6 +207,7 @@ data class RollupProofResponseV1(
     result = 31 * result + publicInputs.hashCode()
     result = 31 * result + l2L1Roots.byteArrayListHashCode()
     result = 31 * result + filteredAddresses.byteArrayListHashCode()
+    result = 31 * result + programVk.contentHashCode()
     return result
   }
 }

--- a/jvm-libs/generic/extensions/kotlin/src/main/kotlin/linea/kotlin/TypingsExtensions.kt
+++ b/jvm-libs/generic/extensions/kotlin/src/main/kotlin/linea/kotlin/TypingsExtensions.kt
@@ -33,6 +33,9 @@ fun BigInteger.toKWei(): BigDecimal = this.toBigDecimal().toKWei()
 inline val BigInteger.kwei: BigInteger get() = this.multiply(OneKWei.toBigInteger())
 fun BigInteger.toULong(): ULong = this.toString().toULong()
 fun BigInteger.toUInt(): UInt = this.toString().toUInt()
+fun BigInteger.toHexString(hexPrefix: Boolean = true): String = toString(16).let {
+  if (hexPrefix) "0x$it" else it
+}
 
 // ULong extensions
 


### PR DESCRIPTION
## Summary

- Threads `programVk` (32-byte verifying-key hash) end-to-end through the proof chain:
  - Added `programVk: ByteArray` to `L2ExecutionProofResponseV1` and `RollupProofResponseV1` domain types
  - Added `programVk: String` to `L2ExecutionProofResponseDto`, `RollupProofResponseDto`, `L2ExecutionProofDto`, and `RollupProofDto`
  - Wired through `L2ExecutionProofResponseDtoMapper`, `RollupProofResponseDtoMapper`, `FileBasedRollupProofRequestDtoMapper`, and `FileBasedRollupAggregationProofRequestDtoMapper`
- Fixed `ExecutionPayloadDto.baseFeePerGas` type from `BigInteger` to `String` (hex-encoded `quantity`) to match the rollup_spec schema
- Made `proverVersion` non-nullable in all three response DTOs to match the `required` constraint in the rollup_spec response schemas
- Added `BigInteger.toHexString()` extension to `TypingsExtensions` (mirrors `ULong.toHexString`)

## Test plan

- [ ] `RiscVProofResponseDtoMapperTest` — L2 execution and rollup mapper tests verify `programVk` decode
- [ ] `RiscVProofRequestDtoMapperTest` — rollup and aggregation request mapper tests verify `programVk` is threaded into embedded proof DTOs; `baseFeePerGas` encodes as hex
- [ ] All riscv-client tests pass locally (`./gradlew :coordinator:clients:prover-client:riscv-client:test`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes proof pipeline types and JSON/DTO contracts; missing `programVk` or `proverVersion` from provers will break deserialization, and `baseFeePerGas` encoding changes affect execution payload wire format.
> 
> **Overview**
> Threads **`programVk`** (the 32-byte program verifying-key hash) through L2 execution and rollup proof responses and into downstream rollup/aggregation requests.
> 
> **`programVk` on domain and DTOs:** `L2ExecutionProofResponseV1` and `RollupProofResponseV1` gain required `programVk: ByteArray`. Matching hex `programVk` fields are added on response DTOs and on inlined `L2ExecutionProofDto` / `RollupProofDto`. Response mappers decode it; file-based rollup and rollup-aggregation request builders copy it from stored proof responses when inlining proofs.
> 
> **Schema alignment:** `ExecutionPayloadDto.baseFeePerGas` is now a hex `String` (via new `BigInteger.toHexString()`), not `BigInteger`. `proverVersion` is required on L2 execution, rollup, and rollup-aggregation response DTOs.
> 
> Tests and fakes are updated for the new fields and encoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20df29687ad7b1edcb2712ed665864c9dccc289f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->