### PR TITLE
feat(contracts): add Forge contract deployer

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -17,6 +17,9 @@ on:
       coordinator_changed:
         required: true
         type: string
+      contract_deployer_changed:
+        required: true
+        type: string
       native_yield_automation_service_changed:
         required: true
         type: string
@@ -54,6 +57,14 @@ jobs:
     with:
       image_tag: ${{ inputs.commit_tag }}
       develop_tag: ${{ inputs.develop_tag }}
+      push_image: false
+    secrets: inherit
+
+  contract_deployer:
+    uses: ./.github/workflows/contracts-forge-deployer-build-and-publish.yml
+    if: ${{ inputs.contract_deployer_changed == 'true' }}
+    with:
+      image_tag: ${{ inputs.commit_tag }}
       push_image: false
     secrets: inherit
 
@@ -124,7 +135,7 @@ jobs:
   # If all jobs are skipped, the workflow will still succeed.
   always_succeed:
     runs-on: ubuntu-24.04
-    needs: [coordinator, postman, prover, transaction_exclusion_api, native_yield_automation_service, maru, linea_besu_package_build_and_upload]
+    needs: [coordinator, contract_deployer, postman, prover, transaction_exclusion_api, native_yield_automation_service, maru, linea_besu_package_build_and_upload]
     if: ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'success') && !contains(needs.*.result, 'cancelled') }}
     steps:
       - name: Ensure Workflow Success

--- a/.github/workflows/contracts-forge-deployer-build-and-publish.yml
+++ b/.github/workflows/contracts-forge-deployer-build-and-publish.yml
@@ -1,0 +1,135 @@
+name: contracts-forge-deployer-build-and-publish
+
+permissions:
+  contents: read
+  actions: read
+  packages: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: Immutable image tag to publish
+        required: true
+        type: string
+      image_name:
+        description: Docker image repository
+        required: false
+        type: string
+        default: consensys/lineth-contract-deployer
+      push_image:
+        description: Publish to Docker Hub after tests and scanning
+        required: true
+        type: boolean
+        default: true
+  workflow_call:
+    inputs:
+      image_tag:
+        required: true
+        type: string
+      image_name:
+        required: false
+        type: string
+        default: consensys/lineth-contract-deployer
+      push_image:
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: false
+      DOCKERHUB_TOKEN:
+        required: false
+
+concurrency:
+  group: contracts-forge-deployer-build-and-publish-${{ inputs.image_name }}-${{ inputs.image_tag }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  build-scan-and-publish:
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
+    name: Forge contract deployer build
+    env:
+      IMAGE_TAG: ${{ inputs.image_tag }}
+      IMAGE_NAME: ${{ inputs.image_name }}
+      PUSH_IMAGE: ${{ inputs.push_image }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Get Node.js version
+        id: get-node-version
+        uses: ./.github/actions/get-node-version
+
+      - name: Validate immutable image tag
+        run: |
+          if [[ ! "${IMAGE_TAG}" =~ ^[0-9a-f]{7,40}$ ]]; then
+            echo "image_tag must be a 7-40 character lowercase Git commit SHA, got ${IMAGE_TAG}" >&2
+            exit 1
+          fi
+          source_sha="$(git rev-parse HEAD)"
+          if [[ "${source_sha:0:${#IMAGE_TAG}}" != "${IMAGE_TAG}" ]]; then
+            echo "image_tag ${IMAGE_TAG} does not identify checked-out commit ${source_sha}" >&2
+            exit 1
+          fi
+
+      - name: Build image for tests and security scan
+        uses: ./.github/actions/docker-build-publish
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_tags: ${{ env.IMAGE_TAG }}
+          develop_tag: ''
+          push_image: false
+          dockerfile_path: ./contracts/forge-deployer/Dockerfile
+          build_args: |
+            NODE_VERSION=${{ steps.get-node-version.outputs.node-version }}
+          save_artifact: true
+          artifact_name: lineth-contract-deployer
+
+      - name: Load image
+        run: gzip -dc lineth-contract-deployer-docker-image.tar.gz | docker load
+
+      - name: Run two-chain deployment and rerun test
+        run: DEPLOYER_IMAGE="${IMAGE_NAME}:${IMAGE_TAG}" bash contracts/forge-deployer/test/integration/two-chain.sh
+
+      - name: Scan image for high and critical vulnerabilities
+        run: |
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            aquasec/trivy@sha256:62b1e65e8869bc4b4c6aa4fa2b21595256c7c2f6018a9d9ad61caf87187c1969 image \
+            --exit-code 1 \
+            --ignore-unfixed \
+            --severity HIGH,CRITICAL \
+            "${IMAGE_NAME}:${IMAGE_TAG}"
+
+      - name: Login to Docker Hub
+        if: ${{ env.PUSH_IMAGE == 'true' }}
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Verify immutable image tag is unused
+        if: ${{ env.PUSH_IMAGE == 'true' }}
+        run: |
+          set +e
+          inspect_output="$(docker manifest inspect "${IMAGE_NAME}:${IMAGE_TAG}" 2>&1)"
+          inspect_status=$?
+          set -e
+          if [[ $inspect_status -eq 0 ]]; then
+            echo "${IMAGE_NAME}:${IMAGE_TAG} already exists; refusing to overwrite an immutable tag" >&2
+            exit 1
+          fi
+          inspect_output_lower="${inspect_output,,}"
+          if [[ "${inspect_output_lower}" != *"no such manifest"* && "${inspect_output_lower}" != *"manifest unknown"* ]]; then
+            echo "Could not verify whether ${IMAGE_NAME}:${IMAGE_TAG} exists: ${inspect_output}" >&2
+            exit 1
+          fi
+
+      - name: Publish tested and scanned image
+        if: ${{ env.PUSH_IMAGE == 'true' }}
+        run: docker push "${IMAGE_NAME}:${IMAGE_TAG}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,7 @@ jobs:
       coordinator: ${{ steps.filter.outputs.coordinator }}
       staterecovery: ${{ steps.filter.outputs.staterecovery }}
       postman: ${{ steps.filter.outputs.postman }}
+      contract-deployer: ${{ steps.filter.outputs.contract-deployer }}
       prover: ${{ steps.filter.outputs.prover }}
       prover-ray: ${{ steps.filter.outputs.prover-ray }}
       rollup-spec: ${{ steps.filter.outputs.rollup-spec }}
@@ -98,6 +99,19 @@ jobs:
               - 'ts-libs/linea-native-libs/**'
               - 'ts-libs/linea-shared-utils/**'
               - '.github/workflows/postman-*.yml'
+              - '.github/workflows/build-and-publish.yml'
+              - '.github/workflows/main.yml'
+              - '.nvmrc'
+            contract-deployer:
+              - 'contracts/forge-deployer/**'
+              - 'contracts/common/**'
+              - 'contracts/local-deployments-artifacts/**'
+              - 'contracts/package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'scripts/docker/**'
+              - '.github/actions/docker-build-publish/**'
+              - '.github/workflows/contracts-forge-deployer-*.yml'
               - '.github/workflows/build-and-publish.yml'
               - '.github/workflows/main.yml'
               - '.nvmrc'
@@ -257,6 +271,7 @@ jobs:
       commit_tag: ${{ needs.compute-commit-tags.outputs.commit_tag }}
       develop_tag: ${{ needs.compute-commit-tags.outputs.develop_tag }}
       coordinator_changed: ${{ needs.filter-commit-changes.outputs.coordinator }}
+      contract_deployer_changed: ${{ needs.filter-commit-changes.outputs.contract-deployer }}
       postman_changed: ${{ needs.filter-commit-changes.outputs.postman }}
       prover_changed: ${{ needs.filter-commit-changes.outputs.prover }}
       transaction_exclusion_api_changed: ${{ needs.filter-commit-changes.outputs.transaction-exclusion-api }}

--- a/.github/workflows/run-smc-tests.yml
+++ b/.github/workflows/run-smc-tests.yml
@@ -57,6 +57,12 @@ jobs:
       - name: Check JS formatting
         run: pnpm -F contracts run lint:ts
 
+      - name: Test Forge contract deployer
+        run: |
+          pnpm --filter @lfdt-lineth/forge-contract-deployer test
+          pnpm --filter @lfdt-lineth/forge-contract-deployer typecheck
+          pnpm --filter @lfdt-lineth/forge-contract-deployer build
+
       # Required for hardhat commands due to @nomicfoundation/hardhat-foundry package
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d #v1.8.0

--- a/contracts/common/helpers/deploymentRecord.ts
+++ b/contracts/common/helpers/deploymentRecord.ts
@@ -1,0 +1,81 @@
+export interface DeploymentRecordInput {
+  contractName: string;
+  address: string;
+  transactionHash: string;
+  blockNumber: number;
+  chainId: bigint | string;
+}
+
+export interface ParsedDeploymentRecord {
+  contractName: string;
+  address: string;
+  transactionHash: string;
+  blockNumber: number;
+  chainId: string;
+}
+
+interface DeploymentRecordAcknowledgement {
+  type: "lineth-deployment-record-ack";
+  id: string;
+  error?: string;
+}
+
+const DEPLOYMENT_RECORD_PATTERN =
+  /^contract=(\S+) deployed: address=(0x[0-9a-fA-F]{40}) blockNumber=(\d+) chainId=(\d+) txHash=(0x[0-9a-fA-F]{64})$/;
+let recordSequence = 0;
+
+export function formatDeploymentRecord(record: DeploymentRecordInput): string {
+  return (
+    `contract=${record.contractName} deployed: address=${record.address} ` +
+    `blockNumber=${record.blockNumber} chainId=${record.chainId.toString()} txHash=${record.transactionHash}`
+  );
+}
+
+export function parseDeploymentRecord(line: string): ParsedDeploymentRecord | undefined {
+  const match = line.trim().match(DEPLOYMENT_RECORD_PATTERN);
+  if (!match) return undefined;
+
+  return {
+    contractName: match[1]!,
+    address: match[2]!,
+    transactionHash: match[5]!,
+    blockNumber: Number(match[3]),
+    chainId: match[4]!,
+  };
+}
+
+function isAcknowledgement(message: unknown, id: string): message is DeploymentRecordAcknowledgement {
+  if (typeof message !== "object" || message === null) return false;
+  const candidate = message as Partial<DeploymentRecordAcknowledgement>;
+  return candidate.type === "lineth-deployment-record-ack" && candidate.id === id;
+}
+
+export async function awaitParentCheckpoint(record: ParsedDeploymentRecord): Promise<void> {
+  if (!process.send || !process.connected) return;
+
+  const id = `${process.pid}-${recordSequence++}`;
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      process.off("message", onMessage);
+      process.off("disconnect", onDisconnect);
+    };
+    const onMessage = (message: unknown) => {
+      if (!isAcknowledgement(message, id)) return;
+      cleanup();
+      if (message.error) reject(new Error(message.error));
+      else resolve();
+    };
+    const onDisconnect = () => {
+      cleanup();
+      reject(new Error("checkpoint parent disconnected before acknowledging deployment"));
+    };
+
+    process.on("message", onMessage);
+    process.once("disconnect", onDisconnect);
+    process.send?.({ type: "lineth-deployment-record", id, record }, (error) => {
+      if (!error) return;
+      cleanup();
+      reject(error);
+    });
+  });
+}

--- a/contracts/common/helpers/deployments.ts
+++ b/contracts/common/helpers/deployments.ts
@@ -2,6 +2,7 @@ import { ethers, AbstractSigner, Interface, InterfaceAbi, BaseContract } from "e
 import fs from "fs";
 import path from "path";
 
+import { awaitParentCheckpoint, formatDeploymentRecord } from "./deploymentRecord";
 import { normalizeAddressArgs } from "./normalize-address-args";
 import { clearSignerUiWorkflowStatus, setSignerUiWorkflowStatus } from "./signerUiWorkflowStatus";
 import {
@@ -185,9 +186,15 @@ export async function LogContractDeployment(contractName: string, contract: Base
 
   const contractAddress = await contract.getAddress();
   const chainId = (await deploymentTx.provider.getNetwork()).chainId;
-  console.log(
-    `contract=${contractName} deployed: address=${contractAddress} blockNumber=${txReceipt.blockNumber} chainId=${chainId}`,
-  );
+  const record = {
+    contractName,
+    address: contractAddress,
+    transactionHash: txReceipt.hash,
+    blockNumber: txReceipt.blockNumber,
+    chainId: chainId.toString(),
+  };
+  await awaitParentCheckpoint(record);
+  console.log(formatDeploymentRecord(record));
 }
 
 /**

--- a/contracts/common/helpers/feeOverrides.ts
+++ b/contracts/common/helpers/feeOverrides.ts
@@ -1,7 +1,5 @@
 import { ethers } from "ethers";
 
-import { get1559Fees } from "../../scripts/utils";
-
 // A transaction fee override that must describe exactly one fee model: either a
 // legacy `gasPrice`, or a complete EIP-1559 pair, never a mix of both.
 export type FeeOverrides = {
@@ -50,6 +48,13 @@ export const LOCAL_L2_DEPLOY_FEE_OVERRIDES: FeeOverrides = assertSingleFeeModel(
   maxPriorityFeePerGas: 7_000_000_000_000n,
 });
 
+// Keep the existing local-dev fee model unless an operator explicitly selects
+// a legacy gas price. Forge uses this override with `0` for gas-free L2s.
+export function resolveL2DeployFeeOverrides(): FeeOverrides {
+  const gasPrice = parseGasPriceWeiEnv("L2_DEPLOY_GAS_PRICE_WEI");
+  return gasPrice === undefined ? { ...LOCAL_L2_DEPLOY_FEE_OVERRIDES } : assertSingleFeeModel({ gasPrice });
+}
+
 // Effective per-gas price used to size a value+gas budget: the legacy gasPrice
 // when legacy fees are selected, otherwise the EIP-1559 ceiling maxFeePerGas.
 export function feeBudgetPricePerGas(fees: FeeOverrides): bigint {
@@ -78,16 +83,19 @@ export async function resolveOneModelFeeOverrides(
     }
   }
 
-  const { gasPrice, maxFeePerGas, maxPriorityFeePerGas } = await get1559Fees(provider);
-  if (maxFeePerGas !== undefined && maxPriorityFeePerGas !== undefined) {
+  const { gasPrice, maxFeePerGas, maxPriorityFeePerGas } = await provider.getFeeData();
+  const hasMaxFee = maxFeePerGas !== null && maxFeePerGas !== undefined;
+  const hasPriorityFee = maxPriorityFeePerGas !== null && maxPriorityFeePerGas !== undefined;
+  const hasGasPrice = gasPrice !== null && gasPrice !== undefined;
+  if (hasMaxFee && hasPriorityFee) {
     return assertSingleFeeModel({ maxFeePerGas, maxPriorityFeePerGas });
   }
-  if (gasPrice !== undefined) {
+  if (hasGasPrice) {
     return assertSingleFeeModel({ gasPrice });
   }
 
   const hint = explicitGasPriceEnvName ? ` Set ${explicitGasPriceEnvName} explicitly.` : "";
-  if (maxFeePerGas !== undefined || maxPriorityFeePerGas !== undefined) {
+  if (hasMaxFee || hasPriorityFee) {
     throw new Error(`Provider returned incomplete EIP-1559 deploy fee data.${hint}`);
   }
   throw new Error(`Provider returned no usable deploy fee data.${hint}`);

--- a/contracts/common/helpers/signerUiWorkflowStatus.ts
+++ b/contracts/common/helpers/signerUiWorkflowStatus.ts
@@ -6,10 +6,11 @@ type SignerUiBridgeWorkflowApi = {
 };
 
 let signerUiBridgeWorkflowApiPromise: Promise<SignerUiBridgeWorkflowApi | null> | undefined;
+const SIGNER_UI_BRIDGE_MODULE = "../../scripts/hardhat/signer-ui-bridge.js";
 
 async function loadSignerUiBridgeWorkflowApi(): Promise<SignerUiBridgeWorkflowApi | null> {
   if (!signerUiBridgeWorkflowApiPromise) {
-    signerUiBridgeWorkflowApiPromise = import("../../scripts/hardhat/signer-ui-bridge.js")
+    signerUiBridgeWorkflowApiPromise = import(SIGNER_UI_BRIDGE_MODULE)
       .then((mod) => ({
         setUiWorkflowStatus: mod.setUiWorkflowStatus,
         clearUiWorkflowStatus: mod.clearUiWorkflowStatus,

--- a/contracts/forge-deployer/Dockerfile
+++ b/contracts/forge-deployer/Dockerfile
@@ -1,0 +1,41 @@
+ARG NODE_VERSION=24.18.0
+
+FROM node:${NODE_VERSION}-bookworm-slim AS build
+
+ENV PNPM_HOME=/pnpm
+ENV PATH=${PNPM_HOME}:${PATH}
+RUN corepack enable && corepack prepare pnpm@11.9.0 --activate
+
+WORKDIR /workspace
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json .npmrc ./
+COPY patches ./patches
+COPY ts-libs/eslint-config ./ts-libs/eslint-config
+COPY contracts ./contracts
+
+RUN pnpm install --frozen-lockfile --filter @lfdt-lineth/forge-contract-deployer...
+RUN pnpm --filter @lfdt-lineth/forge-contract-deployer build
+
+FROM node:${NODE_VERSION}-bookworm-slim AS runtime
+
+ENV NODE_ENV=production
+WORKDIR /app
+
+# The runner only needs the Node.js binary. Remove bundled package managers
+# and their dependency trees from the runtime attack surface.
+RUN rm -rf \
+  /opt/yarn-* \
+  /usr/local/lib/node_modules/corepack \
+  /usr/local/lib/node_modules/npm \
+  /usr/local/bin/corepack \
+  /usr/local/bin/npm \
+  /usr/local/bin/npx \
+  /usr/local/bin/yarn \
+  /usr/local/bin/yarnpkg
+
+COPY --from=build --chown=node:node /workspace/contracts/forge-deployer/dist ./dist
+COPY --from=build --chown=node:node \
+  /workspace/contracts/local-deployments-artifacts/dynamic-artifacts/IntegrationTestTrueVerifier.json \
+  ./dist/artifacts/dynamic-artifacts/IntegrationTestTrueVerifier.json
+
+USER node
+ENTRYPOINT ["node", "dist/cli.js"]

--- a/contracts/forge-deployer/README.md
+++ b/contracts/forge-deployer/README.md
@@ -1,0 +1,70 @@
+# Forge contract deployer
+
+One-shot, dev/test-only deployer for the Lineth Forge chart. It packages the
+four boot-critical deployment steps used by the Lineth Stack quickstart:
+
+1. L1 `IntegrationTestTrueVerifier` and `LinethRollupV8`
+2. L2 `L2MessageService`
+3. L1 `BridgedToken` and `TokenBridge`
+4. L2 `BridgedToken` and `TokenBridge`
+
+It intentionally does not deploy coordinator, prover, postman, demo-token, or
+Forced Transaction Gateway contracts.
+
+## Required inputs
+
+- `L1_RPC_URL`
+- `L2_RPC_URL`
+- `L1_DEPLOYER_PRIVATE_KEY`
+- `L2_DEPLOYER_PRIVATE_KEY`
+- `INITIAL_L2_STATE_ROOT_HASH` (32-byte hex)
+
+The L1 endpoint is operator-defined. For an external fee-paying L1, fund the L1
+deployer before starting the Job. Forge L2 networks are gas-free by default;
+set `L2_DEPLOY_GAS_PRICE_WEI=0` explicitly in the chart.
+
+`L2_GENESIS_TIMESTAMP` is optional and otherwise comes from L2 block 0.
+`L1_DEPLOYER_ADDRESS` and `L2_DEPLOYER_ADDRESS` can be supplied to assert that
+the mounted keys derive the bootstrap/operator-published identities.
+`EXPECTED_L1_CHAIN_ID` and `EXPECTED_L2_CHAIN_ID` fail before deployment when
+an RPC endpoint points at the wrong network.
+Dev/test role addresses default to their chain deployer. Override them with
+`L1_SECURITY_COUNCIL`, `LINETH_ROLLUP_OPERATORS`,
+`L2_SECURITY_COUNCIL`, and
+`L2_MESSAGE_SERVICE_L1L2_MESSAGE_SETTER`.
+
+Optional fee inputs are `L1_DEPLOY_GAS_PRICE_WEI` and
+`L2_DEPLOY_GAS_PRICE_WEI`. Rate limits default to one day and 1000 ETH and can
+be changed with `CONTRACT_RATE_LIMIT_PERIOD` and
+`CONTRACT_RATE_LIMIT_AMOUNT`. RPC readiness is bounded by
+`RPC_READY_TIMEOUT_MS` (default: five minutes). Kubernetes output defaults to
+the service account namespace and can be set with `POD_NAMESPACE` and
+`CHECKPOINT_CONFIG_MAP_NAME`.
+
+## Durable output and reruns
+
+In Kubernetes the Lineth chart creates the `lineth-contract-addresses`
+placeholder ConfigMap and the deployer updates it using resource-version
+guards. Its `checkpoint.json` contains chain IDs, signer addresses, starting
+nonces, deterministic expected addresses, the public deployment-configuration
+hash, transaction hashes, and block numbers. It never contains private keys or
+RPC URLs. `addresses.json` exposes the same versioned, secret-free deployment
+record, while four top-level keys expose the completed primary contract
+addresses.
+
+Every deployment receipt is persisted and acknowledged before the child deploy
+script can submit its next transaction. Reruns validate checkpoint identity and on-chain bytecode, skip fully
+verified steps, and send zero deployment transactions for a complete stack.
+Partial deployments or unexplained signer nonce drift fail closed.
+
+For local runs, set `CHECKPOINT_FILE=/path/to/checkpoint.json` instead of using
+the Kubernetes API.
+
+## Development
+
+```bash
+pnpm --dir contracts/forge-deployer test
+pnpm --dir contracts/forge-deployer typecheck
+pnpm --dir contracts/forge-deployer build
+make docker-build-contract-deployer
+```

--- a/contracts/forge-deployer/eslint.config.mjs
+++ b/contracts/forge-deployer/eslint.config.mjs
@@ -1,0 +1,16 @@
+import { node } from "@lfdt-lineth/eslint-config/node";
+
+export default [
+  {
+    ignores: ["dist/**"],
+  },
+  ...node,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: "./tsconfig.json",
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+];

--- a/contracts/forge-deployer/package.json
+++ b/contracts/forge-deployer/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@lfdt-lineth/forge-contract-deployer",
+  "version": "0.1.0",
+  "private": true,
+  "license": "(MIT OR Apache-2.0)",
+  "type": "commonjs",
+  "engines": {
+    "node": ">=24.18.0",
+    "pnpm": ">=11.9.0"
+  },
+  "scripts": {
+    "build": "NODE_PATH=$PWD/node_modules tsup --config tsup.config.ts",
+    "lint": "NODE_PATH=./node_modules eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "start": "node dist/cli.js",
+    "test": "NODE_PATH=./node_modules node --import tsx --test test/*.test.ts",
+    "test:integration": "bash test/integration/two-chain.sh",
+    "typecheck": "NODE_PATH=./node_modules tsc --noEmit"
+  },
+  "dependencies": {
+    "dotenv": "catalog:",
+    "ethers": "catalog:"
+  },
+  "devDependencies": {
+    "@lfdt-lineth/eslint-config": "workspace:*",
+    "@types/node": "24.13.2",
+    "eslint": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/contracts/forge-deployer/prettier.config.mjs
+++ b/contracts/forge-deployer/prettier.config.mjs
@@ -1,0 +1,1 @@
+export { default } from "../../prettier.config.mjs";

--- a/contracts/forge-deployer/src/address-plan.ts
+++ b/contracts/forge-deployer/src/address-plan.ts
@@ -1,0 +1,102 @@
+import { getAddress, getCreateAddress } from "ethers";
+
+export type ChainName = "l1" | "l2";
+export type StepId = "l1-rollup" | "l2-message-service" | "l1-token-bridge" | "l2-token-bridge";
+
+export interface PlannedDeployment {
+  key: string;
+  contractName: string;
+  nonce: number;
+  expectedAddress: string;
+}
+
+export interface DeploymentStep {
+  id: StepId;
+  chain: ChainName;
+  startingNonce: number;
+  script: "l1-rollup" | "l2-message-service" | "token-bridge";
+  deployments: PlannedDeployment[];
+}
+
+interface AddressPlanInput {
+  l1Signer: string;
+  l2Signer: string;
+  l1StartingNonce: number;
+  l2StartingNonce: number;
+}
+
+function assertNonce(value: number, name: string): void {
+  if (!Number.isSafeInteger(value) || value < 0) throw new Error(`${name} must be a non-negative safe integer`);
+}
+
+function planStep(
+  id: StepId,
+  chain: ChainName,
+  signer: string,
+  startingNonce: number,
+  script: DeploymentStep["script"],
+  contracts: Array<[suffix: string, contractName: string]>,
+): DeploymentStep {
+  return {
+    id,
+    chain,
+    startingNonce,
+    script,
+    deployments: contracts.map(([suffix, contractName], index) => ({
+      key: `${id}.${suffix}`,
+      contractName,
+      nonce: startingNonce + index,
+      expectedAddress: getCreateAddress({ from: signer, nonce: startingNonce + index }),
+    })),
+  };
+}
+
+export function buildAddressPlan(input: AddressPlanInput): DeploymentStep[] {
+  assertNonce(input.l1StartingNonce, "L1 starting nonce");
+  assertNonce(input.l2StartingNonce, "L2 starting nonce");
+  const l1Signer = getAddress(input.l1Signer);
+  const l2Signer = getAddress(input.l2Signer);
+
+  const l1Rollup = planStep("l1-rollup", "l1", l1Signer, input.l1StartingNonce, "l1-rollup", [
+    ["verifier", "IntegrationTestTrueVerifier"],
+    ["implementation", "LinethRollupV8Implementation"],
+    ["proxy-admin", "ProxyAdmin"],
+    ["address-filter", "AddressFilter"],
+    ["proxy", "LinethRollupV8"],
+  ]);
+  const l2MessageService = planStep("l2-message-service", "l2", l2Signer, input.l2StartingNonce, "l2-message-service", [
+    ["implementation", "L2MessageServiceImplementation"],
+    ["proxy-admin", "ProxyAdmin"],
+    ["proxy", "L2MessageService"],
+  ]);
+  const l1TokenBridge = planStep(
+    "l1-token-bridge",
+    "l1",
+    l1Signer,
+    input.l1StartingNonce + l1Rollup.deployments.length,
+    "token-bridge",
+    [
+      ["bridged-token", "BridgedToken"],
+      ["implementation", "tokenBridgeContractImplementation"],
+      ["proxy-admin", "ProxyAdmin"],
+      ["beacon", "UpgradeableBeacon"],
+      ["proxy", "TokenBridge"],
+    ],
+  );
+  const l2TokenBridge = planStep(
+    "l2-token-bridge",
+    "l2",
+    l2Signer,
+    input.l2StartingNonce + l2MessageService.deployments.length,
+    "token-bridge",
+    [
+      ["bridged-token", "BridgedToken"],
+      ["implementation", "tokenBridgeContractImplementation"],
+      ["proxy-admin", "ProxyAdmin"],
+      ["beacon", "UpgradeableBeacon"],
+      ["proxy", "TokenBridge"],
+    ],
+  );
+
+  return [l1Rollup, l2MessageService, l1TokenBridge, l2TokenBridge];
+}

--- a/contracts/forge-deployer/src/checkpoint.ts
+++ b/contracts/forge-deployer/src/checkpoint.ts
@@ -1,0 +1,174 @@
+import { getAddress, isAddress, keccak256, toUtf8Bytes } from "ethers";
+
+import { ChainName, DeploymentStep, StepId } from "./address-plan";
+
+export const SCHEMA_VERSION = 1;
+export const DEPLOYMENT_PROFILE = "forge-dev-v1";
+
+export interface CheckpointIdentity {
+  profile: string;
+  schemaVersion: number;
+  initialL2StateRootHash: string;
+  l2GenesisTimestamp: number;
+  chainIds: { l1: string; l2: string };
+  signers: { l1: string; l2: string };
+  configurationHash: string;
+}
+
+interface DeploymentConfiguration {
+  rateLimitPeriod: string;
+  rateLimitAmount: string;
+  roles: {
+    l1SecurityCouncil: string;
+    l1RollupOperators: string[];
+    l2SecurityCouncil: string;
+    l1L2MessageSetter: string;
+  };
+}
+
+export interface ExpectedDeployment {
+  stepId: StepId;
+  chain: ChainName;
+  contractName: string;
+  nonce: number;
+  expectedAddress: string;
+}
+
+export interface CompletedDeployment {
+  address: string;
+  transactionHash: string;
+  blockNumber: number;
+  chainId: string;
+  recovered: boolean;
+}
+
+export interface DeploymentCheckpoint extends CheckpointIdentity {
+  startingNonces: { l1: number; l2: number };
+  expectedDeployments: Record<string, ExpectedDeployment>;
+  deployments: Record<string, CompletedDeployment>;
+  completedSteps: StepId[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface CreateCheckpointInput extends CheckpointIdentity {
+  startingNonces: { l1: number; l2: number };
+  plan: DeploymentStep[];
+}
+
+export function deploymentConfigurationHash(configuration: DeploymentConfiguration): string {
+  const normalized = {
+    rateLimitPeriod: BigInt(configuration.rateLimitPeriod).toString(),
+    rateLimitAmount: BigInt(configuration.rateLimitAmount).toString(),
+    roles: {
+      l1SecurityCouncil: getAddress(configuration.roles.l1SecurityCouncil),
+      l1RollupOperators: configuration.roles.l1RollupOperators.map((address) => getAddress(address)),
+      l2SecurityCouncil: getAddress(configuration.roles.l2SecurityCouncil),
+      l1L2MessageSetter: getAddress(configuration.roles.l1L2MessageSetter),
+    },
+  };
+  return keccak256(toUtf8Bytes(JSON.stringify(normalized)));
+}
+
+function normalizeIdentity(identity: CheckpointIdentity): CheckpointIdentity {
+  return {
+    ...identity,
+    initialL2StateRootHash: identity.initialL2StateRootHash.toLowerCase(),
+    configurationHash: identity.configurationHash.toLowerCase(),
+    signers: {
+      l1: getAddress(identity.signers.l1),
+      l2: getAddress(identity.signers.l2),
+    },
+  };
+}
+
+export function createCheckpoint(input: CreateCheckpointInput): DeploymentCheckpoint {
+  const identity = normalizeIdentity(input);
+  const now = new Date().toISOString();
+  const expectedDeployments = Object.fromEntries(
+    input.plan.flatMap((step) =>
+      step.deployments.map((deployment) => [
+        deployment.key,
+        {
+          stepId: step.id,
+          chain: step.chain,
+          contractName: deployment.contractName,
+          nonce: deployment.nonce,
+          expectedAddress: deployment.expectedAddress,
+        },
+      ]),
+    ),
+  );
+
+  return {
+    ...identity,
+    startingNonces: input.startingNonces,
+    expectedDeployments,
+    deployments: {},
+    completedSteps: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function assertEqual(actual: string | number, expected: string | number, label: string): void {
+  if (actual !== expected) throw new Error(`checkpoint ${label} mismatch: expected ${expected}, found ${actual}`);
+}
+
+export function assertCheckpointCompatible(checkpoint: DeploymentCheckpoint, identity: CheckpointIdentity): void {
+  const expected = normalizeIdentity(identity);
+  assertEqual(checkpoint.schemaVersion, expected.schemaVersion, "schema version");
+  assertEqual(checkpoint.profile, expected.profile, "deployment profile");
+  assertEqual(
+    checkpoint.initialL2StateRootHash.toLowerCase(),
+    expected.initialL2StateRootHash,
+    "initial L2 state root",
+  );
+  assertEqual(checkpoint.l2GenesisTimestamp, expected.l2GenesisTimestamp, "L2 genesis timestamp");
+  assertEqual(checkpoint.chainIds.l1, expected.chainIds.l1, "L1 chain ID");
+  assertEqual(checkpoint.chainIds.l2, expected.chainIds.l2, "L2 chain ID");
+  assertEqual(getAddress(checkpoint.signers.l1), expected.signers.l1, "L1 signer");
+  assertEqual(getAddress(checkpoint.signers.l2), expected.signers.l2, "L2 signer");
+  assertEqual(checkpoint.configurationHash.toLowerCase(), expected.configurationHash, "deployment configuration");
+}
+
+export function parseCheckpoint(raw: string): DeploymentCheckpoint {
+  const parsed: unknown = JSON.parse(raw);
+  if (!parsed || typeof parsed !== "object") throw new Error("checkpoint JSON must contain an object");
+  const candidate = parsed as Partial<DeploymentCheckpoint>;
+  if (
+    typeof candidate.profile !== "string" ||
+    typeof candidate.schemaVersion !== "number" ||
+    typeof candidate.initialL2StateRootHash !== "string" ||
+    typeof candidate.configurationHash !== "string" ||
+    typeof candidate.l2GenesisTimestamp !== "number" ||
+    !candidate.chainIds ||
+    !candidate.signers ||
+    !candidate.startingNonces ||
+    !candidate.expectedDeployments ||
+    !candidate.deployments ||
+    !Array.isArray(candidate.completedSteps)
+  ) {
+    throw new Error("checkpoint JSON is missing required fields");
+  }
+  for (const [key, record] of Object.entries(candidate.deployments)) {
+    if (
+      typeof record !== "object" ||
+      record === null ||
+      !isAddress(record.address) ||
+      !/^0x[0-9a-fA-F]{64}$/.test(record.transactionHash) ||
+      !Number.isSafeInteger(record.blockNumber) ||
+      record.blockNumber < 0 ||
+      typeof record.chainId !== "string" ||
+      !/^[0-9]+$/.test(record.chainId) ||
+      typeof record.recovered !== "boolean"
+    ) {
+      throw new Error(`checkpoint contains invalid deployment record ${key}`);
+    }
+  }
+  return candidate as DeploymentCheckpoint;
+}
+
+export function touchCheckpoint(checkpoint: DeploymentCheckpoint): void {
+  checkpoint.updatedAt = new Date().toISOString();
+}

--- a/contracts/forge-deployer/src/cli.ts
+++ b/contracts/forge-deployer/src/cli.ts
@@ -1,0 +1,26 @@
+import { loadConfig, sanitizeText } from "./config";
+import { runDeployment } from "./runner";
+import { createCheckpointStore } from "./store";
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+  const store = await createCheckpointStore(config);
+  const checkpoint = await runDeployment(config, store);
+  const publicAddresses = {
+    linethRollup: checkpoint.deployments["l1-rollup.proxy"]?.address,
+    l2MessageService: checkpoint.deployments["l2-message-service.proxy"]?.address,
+    l1TokenBridge: checkpoint.deployments["l1-token-bridge.proxy"]?.address,
+    l2TokenBridge: checkpoint.deployments["l2-token-bridge.proxy"]?.address,
+  };
+  console.log(`Contract deployment complete: ${JSON.stringify(publicAddresses)}`);
+}
+
+main().catch((error: unknown) => {
+  const sensitiveValues: string[] = [];
+  for (const name of ["L1_DEPLOYER_PRIVATE_KEY", "L2_DEPLOYER_PRIVATE_KEY", "L1_RPC_URL", "L2_RPC_URL"]) {
+    if (process.env[name]) sensitiveValues.push(process.env[name]!);
+  }
+  const detail = error instanceof Error ? (error.stack ?? error.message) : String(error);
+  console.error(sanitizeText(detail, sensitiveValues));
+  process.exitCode = 1;
+});

--- a/contracts/forge-deployer/src/config.ts
+++ b/contracts/forge-deployer/src/config.ts
@@ -1,0 +1,177 @@
+import { getAddress, isAddress, ZeroAddress } from "ethers";
+
+const UINT256_MAX = (1n << 256n) - 1n;
+
+export interface DeployerConfig {
+  l1RpcUrl: string;
+  l2RpcUrl: string;
+  l1PrivateKey: string;
+  l2PrivateKey: string;
+  initialL2StateRootHash: string;
+  rateLimitPeriod: string;
+  rateLimitAmount: string;
+  sensitiveValues: string[];
+  expectedL1DeployerAddress?: string;
+  expectedL2DeployerAddress?: string;
+  expectedL1ChainId?: string;
+  expectedL2ChainId?: string;
+  l1SecurityCouncilOverride?: string;
+  l1RollupOperatorsOverride?: string[];
+  l2SecurityCouncilOverride?: string;
+  l1L2MessageSetterOverride?: string;
+  l2GenesisTimestampOverride?: string;
+  l1DeployGasPriceWei?: string;
+  l2DeployGasPriceWei?: string;
+  checkpointFile?: string;
+}
+
+export interface RoleConfig {
+  l1SecurityCouncil: string;
+  l1RollupOperators: string[];
+  l2SecurityCouncil: string;
+  l1L2MessageSetter: string;
+}
+
+function requireValue(env: NodeJS.ProcessEnv, name: string): string {
+  const value = env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function optionalValue(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const value = env[name]?.trim();
+  return value ? value : undefined;
+}
+
+function assertUint256(value: string, name: string, allowZero = true): string {
+  if (!/^[0-9]+$/.test(value)) throw new Error(`${name} must be a non-negative integer`);
+  const parsed = BigInt(value);
+  if (!allowZero && parsed === 0n) throw new Error(`${name} must be greater than zero`);
+  if (parsed > UINT256_MAX) throw new Error(`${name} must fit uint256`);
+  return value;
+}
+
+function assertRpcUrl(value: string, name: string): string {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") throw new Error("unsupported protocol");
+  } catch {
+    throw new Error(`${name} must be an HTTP(S) URL`);
+  }
+  return value;
+}
+
+function optionalAddress(env: NodeJS.ProcessEnv, name: string, allowZero = true): string | undefined {
+  const value = optionalValue(env, name);
+  if (value === undefined) return undefined;
+  if (!isAddress(value)) throw new Error(`${name} must be an Ethereum address`);
+  const address = getAddress(value);
+  if (!allowZero && address === ZeroAddress) throw new Error(`${name} must not be the zero address`);
+  return address;
+}
+
+function optionalAddressList(env: NodeJS.ProcessEnv, name: string, allowZero = true): string[] | undefined {
+  const value = optionalValue(env, name);
+  if (value === undefined) return undefined;
+  const addresses = value.split(",").map((address) => address.trim());
+  if (addresses.some((address) => !isAddress(address))) {
+    throw new Error(`${name} must be a comma-separated list of Ethereum addresses`);
+  }
+  return addresses.map((address) => {
+    const normalized = getAddress(address);
+    if (!allowZero && normalized === ZeroAddress) throw new Error(`${name} must not contain the zero address`);
+    return normalized;
+  });
+}
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): DeployerConfig {
+  const profile = optionalValue(env, "DEPLOYMENT_PROFILE");
+  if (profile !== undefined && profile !== "forge-dev-v1") {
+    throw new Error(`DEPLOYMENT_PROFILE must be forge-dev-v1`);
+  }
+
+  const initialL2StateRootHash = requireValue(env, "INITIAL_L2_STATE_ROOT_HASH");
+  if (!/^0x[0-9a-fA-F]{64}$/.test(initialL2StateRootHash)) {
+    throw new Error("INITIAL_L2_STATE_ROOT_HASH must be a 32-byte hex value");
+  }
+
+  const l1RpcUrl = assertRpcUrl(requireValue(env, "L1_RPC_URL"), "L1_RPC_URL");
+  const l2RpcUrl = assertRpcUrl(requireValue(env, "L2_RPC_URL"), "L2_RPC_URL");
+  const l1PrivateKey = requireValue(env, "L1_DEPLOYER_PRIVATE_KEY");
+  const l2PrivateKey = requireValue(env, "L2_DEPLOYER_PRIVATE_KEY");
+  const rateLimitPeriod = assertUint256(
+    optionalValue(env, "CONTRACT_RATE_LIMIT_PERIOD") ?? "86400",
+    "CONTRACT_RATE_LIMIT_PERIOD",
+    false,
+  );
+  const rateLimitAmount = assertUint256(
+    optionalValue(env, "CONTRACT_RATE_LIMIT_AMOUNT") ?? "1000000000000000000000",
+    "CONTRACT_RATE_LIMIT_AMOUNT",
+    false,
+  );
+
+  const config: DeployerConfig = {
+    l1RpcUrl,
+    l2RpcUrl,
+    l1PrivateKey,
+    l2PrivateKey,
+    initialL2StateRootHash,
+    rateLimitPeriod,
+    rateLimitAmount,
+    sensitiveValues: [l1PrivateKey, l2PrivateKey, l1RpcUrl, l2RpcUrl],
+  };
+
+  const optionalEntries: Array<[keyof DeployerConfig, string | string[] | undefined]> = [
+    ["expectedL1DeployerAddress", optionalAddress(env, "L1_DEPLOYER_ADDRESS")],
+    ["expectedL2DeployerAddress", optionalAddress(env, "L2_DEPLOYER_ADDRESS")],
+    ["expectedL1ChainId", optionalValue(env, "EXPECTED_L1_CHAIN_ID")],
+    ["expectedL2ChainId", optionalValue(env, "EXPECTED_L2_CHAIN_ID")],
+    ["l1SecurityCouncilOverride", optionalAddress(env, "L1_SECURITY_COUNCIL", false)],
+    ["l1RollupOperatorsOverride", optionalAddressList(env, "LINETH_ROLLUP_OPERATORS", false)],
+    ["l2SecurityCouncilOverride", optionalAddress(env, "L2_SECURITY_COUNCIL", false)],
+    ["l1L2MessageSetterOverride", optionalAddress(env, "L2_MESSAGE_SERVICE_L1L2_MESSAGE_SETTER", false)],
+    ["l2GenesisTimestampOverride", optionalValue(env, "L2_GENESIS_TIMESTAMP")],
+    ["l1DeployGasPriceWei", optionalValue(env, "L1_DEPLOY_GAS_PRICE_WEI")],
+    ["l2DeployGasPriceWei", optionalValue(env, "L2_DEPLOY_GAS_PRICE_WEI")],
+    ["checkpointFile", optionalValue(env, "CHECKPOINT_FILE")],
+  ];
+  for (const [key, value] of optionalEntries) {
+    if (value !== undefined) Object.assign(config, { [key]: value });
+  }
+
+  if (config.l1DeployGasPriceWei !== undefined) {
+    assertUint256(config.l1DeployGasPriceWei, "L1_DEPLOY_GAS_PRICE_WEI");
+  }
+  if (config.l2DeployGasPriceWei !== undefined) {
+    assertUint256(config.l2DeployGasPriceWei, "L2_DEPLOY_GAS_PRICE_WEI");
+  }
+  if (config.expectedL1ChainId !== undefined) {
+    assertUint256(config.expectedL1ChainId, "EXPECTED_L1_CHAIN_ID", false);
+  }
+  if (config.expectedL2ChainId !== undefined) {
+    assertUint256(config.expectedL2ChainId, "EXPECTED_L2_CHAIN_ID", false);
+  }
+
+  return config;
+}
+
+export function resolveRoleConfig(config: DeployerConfig, l1Deployer: string, l2Deployer: string): RoleConfig {
+  if (!isAddress(l1Deployer) || !isAddress(l2Deployer)) {
+    throw new Error("deployer addresses must be valid Ethereum addresses");
+  }
+  const normalizedL1 = getAddress(l1Deployer);
+  const normalizedL2 = getAddress(l2Deployer);
+  return {
+    l1SecurityCouncil: config.l1SecurityCouncilOverride ?? normalizedL1,
+    l1RollupOperators: config.l1RollupOperatorsOverride ?? [normalizedL1],
+    l2SecurityCouncil: config.l2SecurityCouncilOverride ?? normalizedL2,
+    l1L2MessageSetter: config.l1L2MessageSetterOverride ?? normalizedL2,
+  };
+}
+
+export function sanitizeText(text: string, sensitiveValues: readonly string[]): string {
+  return [...new Set(sensitiveValues)]
+    .filter(Boolean)
+    .sort((left, right) => right.length - left.length)
+    .reduce((sanitized, value) => sanitized.split(value).join("[REDACTED]"), text);
+}

--- a/contracts/forge-deployer/src/decision.ts
+++ b/contracts/forge-deployer/src/decision.ts
@@ -1,0 +1,54 @@
+import { DeploymentStep } from "./address-plan";
+import { DeploymentCheckpoint } from "./checkpoint";
+
+export type StepAction = { action: "deploy" | "recover" | "skip" };
+
+interface DecideStepActionInput {
+  step: DeploymentStep;
+  checkpoint: DeploymentCheckpoint;
+  codeByKey: Record<string, boolean>;
+  currentNonce: number;
+}
+
+export function decideStepAction(input: DecideStepActionInput): StepAction {
+  const { step, checkpoint, codeByKey, currentNonce } = input;
+  const records = step.deployments.map((deployment) => checkpoint.deployments[deployment.key]);
+
+  for (const [index, record] of records.entries()) {
+    if (!record) continue;
+    const expected = step.deployments[index]!;
+    if (record.address.toLowerCase() !== expected.expectedAddress.toLowerCase()) {
+      throw new Error(
+        `checkpointed deployment ${expected.key} has address ${record.address}, expected ${expected.expectedAddress}`,
+      );
+    }
+    if (!codeByKey[expected.key]) {
+      throw new Error(`checkpointed deployment ${expected.key} has no bytecode at ${record.address}`);
+    }
+  }
+
+  const codeStates = step.deployments.map((deployment) => Boolean(codeByKey[deployment.key]));
+  const hasAnyCode = codeStates.some(Boolean);
+  const hasAllCode = codeStates.every(Boolean);
+  const hasAllRecords = records.every((record) => record !== undefined);
+
+  if (hasAllCode) {
+    if (!hasAllRecords) {
+      throw new Error(`uncheckpointed code detected for ${step.id}; refusing to infer contract identity`);
+    }
+    return checkpoint.completedSteps.includes(step.id) ? { action: "skip" } : { action: "recover" };
+  }
+  if (hasAnyCode) {
+    throw new Error(`partial deployment detected for ${step.id}; refusing to create a second contract stack`);
+  }
+  if (checkpoint.completedSteps.includes(step.id)) {
+    throw new Error(`checkpoint marks ${step.id} complete but its bytecode is missing`);
+  }
+  if (currentNonce !== step.startingNonce) {
+    throw new Error(
+      `nonce drift for ${step.id}: expected ${step.startingNonce}, found ${currentNonce}; refusing deployment`,
+    );
+  }
+
+  return { action: "deploy" };
+}

--- a/contracts/forge-deployer/src/funds.ts
+++ b/contracts/forge-deployer/src/funds.ts
@@ -1,0 +1,25 @@
+import { feeBudgetPricePerGas, FeeOverrides } from "../../common/helpers/feeOverrides";
+
+export function assertDeployerCanPay(
+  chain: "L1" | "L2",
+  deployerAddress: string,
+  balance: bigint,
+  fees: FeeOverrides,
+  gasBudget = 1n,
+): void {
+  const pricePerGas = feeBudgetPricePerGas(fees);
+  const requiredBalance = pricePerGas * gasBudget;
+  if (requiredBalance === 0n || balance >= requiredBalance) return;
+
+  const l2Hint = chain === "L2" ? " or set L2_DEPLOY_GAS_PRICE_WEI=0 for a gas-free Forge network" : "";
+  throw new Error(
+    `Fund ${chain} deployer ${deployerAddress}; deployment requires at least ${requiredBalance} wei${l2Hint}`,
+  );
+}
+
+export function formatInsufficientFundsError(chain: "L1" | "L2", deployerAddress: string, error: unknown): Error {
+  const detail = error instanceof Error ? error.message : String(error);
+  return new Error(`Fund ${chain} deployer ${deployerAddress}; deployment failed with: ${detail}`, {
+    cause: error,
+  });
+}

--- a/contracts/forge-deployer/src/genesis.ts
+++ b/contracts/forge-deployer/src/genesis.ts
@@ -1,0 +1,21 @@
+export interface GenesisBlockProvider {
+  getBlock(blockNumber: number): Promise<{ timestamp: number } | null>;
+}
+
+function parseTimestamp(raw: string): number {
+  if (!/^[0-9]+$/.test(raw)) throw new Error("L2_GENESIS_TIMESTAMP must be a non-negative integer");
+  const timestamp = Number(raw);
+  if (!Number.isSafeInteger(timestamp)) throw new Error("L2_GENESIS_TIMESTAMP must be a safe non-negative integer");
+  return timestamp;
+}
+
+export async function resolveGenesisTimestamp(
+  provider: GenesisBlockProvider,
+  override: string | undefined,
+): Promise<number> {
+  if (override !== undefined) return parseTimestamp(override);
+
+  const genesisBlock = await provider.getBlock(0);
+  if (!genesisBlock) throw new Error("L2 RPC did not return genesis block 0");
+  return parseTimestamp(String(genesisBlock.timestamp));
+}

--- a/contracts/forge-deployer/src/process-runner.ts
+++ b/contracts/forge-deployer/src/process-runner.ts
@@ -1,0 +1,143 @@
+import { getAddress } from "ethers";
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+
+import { DeploymentStep } from "./address-plan";
+import { DeploymentCheckpoint } from "./checkpoint";
+import { sanitizeText } from "./config";
+import { CheckpointStore } from "./store";
+import { ParsedDeploymentRecord } from "../../common/helpers/deploymentRecord";
+
+interface RunStepScriptInput {
+  scriptPath: string;
+  environment: NodeJS.ProcessEnv;
+  step: DeploymentStep;
+  checkpoint: DeploymentCheckpoint;
+  store: CheckpointStore;
+  sensitiveValues: readonly string[];
+}
+
+interface DeploymentRecordMessage {
+  type: "lineth-deployment-record";
+  id: string;
+  record: ParsedDeploymentRecord;
+}
+
+const INHERITED_CHILD_ENVIRONMENT = [
+  "HOME",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NODE_EXTRA_CA_CERTS",
+  "NO_PROXY",
+  "PATH",
+  "SSL_CERT_FILE",
+  "TMPDIR",
+  "TZ",
+] as const;
+
+export function childEnvironment(
+  environment: NodeJS.ProcessEnv,
+  parentEnvironment: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const inherited = Object.fromEntries(
+    INHERITED_CHILD_ENVIRONMENT.flatMap((name) => {
+      const value = parentEnvironment[name];
+      return value === undefined ? [] : [[name, value]];
+    }),
+  );
+  return { ...inherited, ...environment };
+}
+
+function isDeploymentRecordMessage(message: unknown): message is DeploymentRecordMessage {
+  if (typeof message !== "object" || message === null) return false;
+  const candidate = message as Partial<DeploymentRecordMessage>;
+  return candidate.type === "lineth-deployment-record" && typeof candidate.id === "string" && !!candidate.record;
+}
+
+export async function runStepScript(input: RunStepScriptInput): Promise<void> {
+  const child = spawn(process.execPath, [input.scriptPath], {
+    env: childEnvironment(input.environment),
+    stdio: ["ignore", "pipe", "pipe", "ipc"],
+  });
+  const { stdout, stderr } = child;
+  if (!stdout || !stderr) throw new Error(`failed to capture output for ${input.step.id}`);
+
+  const closePromise = new Promise<number>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code) => resolve(code ?? 1));
+  });
+  const stderrPromise = (async () => {
+    for await (const line of createInterface({ input: stderr })) {
+      console.error(sanitizeText(line, input.sensitiveValues));
+    }
+  })();
+
+  const recordedKeys = new Set<string>();
+  let recordProcessing = Promise.resolve();
+  let recordProcessingError: unknown;
+  child.on("message", (message: unknown) => {
+    if (!isDeploymentRecordMessage(message)) return;
+    recordProcessing = recordProcessing
+      .then(async () => {
+        const { id, record } = message;
+        try {
+          const expected = input.step.deployments.find((deployment) => deployment.contractName === record.contractName);
+          if (!expected) throw new Error(`${input.step.id} emitted unexpected deployment ${record.contractName}`);
+          if (recordedKeys.has(expected.key)) throw new Error(`${input.step.id} emitted ${record.contractName} twice`);
+          if (getAddress(record.address) !== getAddress(expected.expectedAddress)) {
+            throw new Error(
+              `${input.step.id} deployed ${record.contractName} at ${record.address}; expected ${expected.expectedAddress}`,
+            );
+          }
+          const expectedChainId = input.checkpoint.chainIds[input.step.chain];
+          if (record.chainId !== expectedChainId) {
+            throw new Error(
+              `${input.step.id} emitted chain ID ${record.chainId} for ${record.contractName}; expected ${expectedChainId}`,
+            );
+          }
+
+          input.checkpoint.deployments[expected.key] = {
+            address: getAddress(record.address),
+            transactionHash: record.transactionHash,
+            blockNumber: record.blockNumber,
+            chainId: record.chainId,
+            recovered: false,
+          };
+          await input.store.save(input.checkpoint);
+          recordedKeys.add(expected.key);
+          child.send({ type: "lineth-deployment-record-ack", id });
+        } catch (error) {
+          child.send({
+            type: "lineth-deployment-record-ack",
+            id,
+            error: "deployment checkpoint persistence failed",
+          });
+          throw error;
+        }
+      })
+      .catch((error: unknown) => {
+        recordProcessingError ??= error;
+        child.kill("SIGTERM");
+      });
+  });
+
+  try {
+    for await (const line of createInterface({ input: stdout })) {
+      console.log(sanitizeText(line, input.sensitiveValues));
+    }
+  } catch (error) {
+    child.kill("SIGTERM");
+    await Promise.allSettled([closePromise, stderrPromise]);
+    throw error;
+  }
+
+  const [exitCode] = await Promise.all([closePromise, stderrPromise]);
+  await recordProcessing;
+  if (recordProcessingError) throw recordProcessingError;
+  if (exitCode !== 0) throw new Error(`${input.step.id} deploy script exited with code ${exitCode}`);
+  if (recordedKeys.size !== input.step.deployments.length) {
+    throw new Error(
+      `${input.step.id} emitted ${recordedKeys.size} deployment records; expected ${input.step.deployments.length}`,
+    );
+  }
+}

--- a/contracts/forge-deployer/src/runner.ts
+++ b/contracts/forge-deployer/src/runner.ts
@@ -1,0 +1,318 @@
+import { JsonRpcProvider, Wallet } from "ethers";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+
+import { buildAddressPlan, DeploymentStep, PlannedDeployment } from "./address-plan";
+import {
+  assertCheckpointCompatible,
+  CheckpointIdentity,
+  createCheckpoint,
+  DEPLOYMENT_PROFILE,
+  deploymentConfigurationHash,
+  DeploymentCheckpoint,
+  SCHEMA_VERSION,
+} from "./checkpoint";
+import { DeployerConfig, resolveRoleConfig, RoleConfig } from "./config";
+import { decideStepAction } from "./decision";
+import { assertDeployerCanPay } from "./funds";
+import { resolveGenesisTimestamp } from "./genesis";
+import { runStepScript } from "./process-runner";
+import { CheckpointStore } from "./store";
+import {
+  feeBudgetPricePerGas,
+  resolveL2DeployFeeOverrides,
+  resolveOneModelFeeOverrides,
+} from "../../common/helpers/feeOverrides";
+
+interface ChainContext {
+  l1Provider: JsonRpcProvider;
+  l2Provider: JsonRpcProvider;
+  chainIds: { l1: string; l2: string };
+  signers: { l1: string; l2: string };
+}
+
+const PROFILE_DEPLOY_GAS_BUDGET = 50_000_000n;
+
+async function waitForRpc(provider: JsonRpcProvider, label: string): Promise<void> {
+  const timeoutMs = Number(process.env.RPC_READY_TIMEOUT_MS ?? "300000");
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new Error("RPC_READY_TIMEOUT_MS must be a positive integer");
+  }
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      await provider.getBlockNumber();
+      return;
+    } catch (error) {
+      lastError = error;
+      await delay(3000);
+    }
+  }
+  throw new Error(`${label} RPC was not ready within ${timeoutMs}ms`, { cause: lastError });
+}
+
+export function assertDistinctChainIds(l1ChainId: string, l2ChainId: string): void {
+  if (l1ChainId === l2ChainId) throw new Error("L1 and L2 chain IDs must differ");
+}
+
+async function createChainContext(config: DeployerConfig): Promise<ChainContext> {
+  const l1Provider = new JsonRpcProvider(config.l1RpcUrl);
+  const l2Provider = new JsonRpcProvider(config.l2RpcUrl);
+  await Promise.all([waitForRpc(l1Provider, "L1"), waitForRpc(l2Provider, "L2")]);
+
+  const l1Wallet = new Wallet(config.l1PrivateKey, l1Provider);
+  const l2Wallet = new Wallet(config.l2PrivateKey, l2Provider);
+  const [l1Network, l2Network, l1Signer, l2Signer] = await Promise.all([
+    l1Provider.getNetwork(),
+    l2Provider.getNetwork(),
+    l1Wallet.getAddress(),
+    l2Wallet.getAddress(),
+  ]);
+  if (config.expectedL1DeployerAddress && config.expectedL1DeployerAddress !== l1Signer) {
+    throw new Error(`L1_DEPLOYER_PRIVATE_KEY does not derive L1_DEPLOYER_ADDRESS`);
+  }
+  if (config.expectedL2DeployerAddress && config.expectedL2DeployerAddress !== l2Signer) {
+    throw new Error(`L2_DEPLOYER_PRIVATE_KEY does not derive L2_DEPLOYER_ADDRESS`);
+  }
+  if (config.expectedL1ChainId && config.expectedL1ChainId !== l1Network.chainId.toString()) {
+    throw new Error(`L1 RPC chain ID does not match EXPECTED_L1_CHAIN_ID`);
+  }
+  if (config.expectedL2ChainId && config.expectedL2ChainId !== l2Network.chainId.toString()) {
+    throw new Error(`L2 RPC chain ID does not match EXPECTED_L2_CHAIN_ID`);
+  }
+  assertDistinctChainIds(l1Network.chainId.toString(), l2Network.chainId.toString());
+
+  return {
+    l1Provider,
+    l2Provider,
+    chainIds: { l1: l1Network.chainId.toString(), l2: l2Network.chainId.toString() },
+    signers: { l1: l1Signer, l2: l2Signer },
+  };
+}
+
+function assertPlanMatchesCheckpoint(checkpoint: DeploymentCheckpoint, plan: DeploymentStep[]): void {
+  const planned = plan.flatMap((step) => step.deployments);
+  if (Object.keys(checkpoint.expectedDeployments).length !== planned.length) {
+    throw new Error("checkpoint expected deployment count does not match the current profile");
+  }
+  for (const deployment of planned) {
+    const expected = checkpoint.expectedDeployments[deployment.key];
+    if (
+      !expected ||
+      expected.contractName !== deployment.contractName ||
+      expected.nonce !== deployment.nonce ||
+      expected.expectedAddress.toLowerCase() !== deployment.expectedAddress.toLowerCase()
+    ) {
+      throw new Error(`checkpoint address plan mismatch for ${deployment.key}`);
+    }
+  }
+}
+
+async function inspectCode(
+  provider: JsonRpcProvider,
+  deployments: PlannedDeployment[],
+): Promise<Record<string, boolean>> {
+  return Object.fromEntries(
+    await Promise.all(
+      deployments.map(async (deployment) => [
+        deployment.key,
+        (await provider.getCode(deployment.expectedAddress)) !== "0x",
+      ]),
+    ),
+  );
+}
+
+function findDeployment(plan: DeploymentStep[], key: string): PlannedDeployment {
+  const deployment = plan.flatMap((step) => step.deployments).find((item) => item.key === key);
+  if (!deployment) throw new Error(`deployment plan is missing ${key}`);
+  return deployment;
+}
+
+function optionalEnvironment(name: string, value: string | undefined): NodeJS.ProcessEnv {
+  return value === undefined ? {} : { [name]: value };
+}
+
+function buildStepEnvironment(
+  step: DeploymentStep,
+  config: DeployerConfig,
+  roles: RoleConfig,
+  context: ChainContext,
+  checkpoint: DeploymentCheckpoint,
+  plan: DeploymentStep[],
+): NodeJS.ProcessEnv {
+  const common: NodeJS.ProcessEnv = {
+    NETWORK: "custom",
+    DEPLOY_FORCED_TRANSACTION_GATEWAY: "false",
+    L1_SECURITY_COUNCIL: roles.l1SecurityCouncil,
+    LINETH_ROLLUP_OPERATORS: roles.l1RollupOperators.join(","),
+    L2_SECURITY_COUNCIL: roles.l2SecurityCouncil,
+    L2_MESSAGE_SERVICE_L1L2_MESSAGE_SETTER: roles.l1L2MessageSetter,
+    LINETH_ROLLUP_RATE_LIMIT_PERIOD: config.rateLimitPeriod,
+    LINETH_ROLLUP_RATE_LIMIT_AMOUNT: config.rateLimitAmount,
+    L2_MESSAGE_SERVICE_RATE_LIMIT_PERIOD: config.rateLimitPeriod,
+    L2_MESSAGE_SERVICE_RATE_LIMIT_AMOUNT: config.rateLimitAmount,
+    LINETH_ROLLUP_ADDRESS: findDeployment(plan, "l1-rollup.proxy").expectedAddress,
+    L2_MESSAGE_SERVICE_ADDRESS: findDeployment(plan, "l2-message-service.proxy").expectedAddress,
+    CONTRACT_DEPLOY_ARTIFACTS_DIR: path.join(__dirname, "artifacts", "dynamic-artifacts"),
+    ...optionalEnvironment("L1_DEPLOY_GAS_PRICE_WEI", config.l1DeployGasPriceWei),
+    ...optionalEnvironment("L2_DEPLOY_GAS_PRICE_WEI", config.l2DeployGasPriceWei),
+  };
+
+  if (step.id === "l1-rollup") {
+    return {
+      ...common,
+      RPC_URL: config.l1RpcUrl,
+      DEPLOYER_PRIVATE_KEY: config.l1PrivateKey,
+      VERIFIER_CONTRACT_NAME: "IntegrationTestTrueVerifier",
+      INITIAL_L2_STATE_ROOT_HASH: config.initialL2StateRootHash,
+      INITIAL_L2_BLOCK_NUMBER: "0",
+      L2_GENESIS_TIMESTAMP: checkpoint.l2GenesisTimestamp.toString(),
+      L1_NONCE: step.startingNonce.toString(),
+    };
+  }
+  if (step.id === "l2-message-service") {
+    return {
+      ...common,
+      RPC_URL: config.l2RpcUrl,
+      DEPLOYER_PRIVATE_KEY: config.l2PrivateKey,
+      L2_MESSAGE_SERVICE_CONTRACT_NAME: "L2MessageService",
+      L2_NONCE: step.startingNonce.toString(),
+    };
+  }
+
+  const deployOnL1 = step.chain === "l1";
+  return {
+    ...common,
+    RPC_URL: deployOnL1 ? config.l1RpcUrl : config.l2RpcUrl,
+    DEPLOYER_PRIVATE_KEY: deployOnL1 ? config.l1PrivateKey : config.l2PrivateKey,
+    TOKEN_BRIDGE_L1: deployOnL1 ? "true" : "false",
+    [deployOnL1 ? "L1_NONCE" : "L2_NONCE"]: step.startingNonce.toString(),
+    REMOTE_CHAIN_ID: deployOnL1 ? context.chainIds.l2 : context.chainIds.l1,
+    REMOTE_TOKEN_BRIDGE_ADDRESS: deployOnL1
+      ? findDeployment(plan, "l2-token-bridge.proxy").expectedAddress
+      : findDeployment(plan, "l1-token-bridge.proxy").expectedAddress,
+  };
+}
+
+function recoverStep(checkpoint: DeploymentCheckpoint, step: DeploymentStep, chainId: string): void {
+  for (const deployment of step.deployments) {
+    const record = checkpoint.deployments[deployment.key];
+    if (!record) throw new Error(`cannot recover ${step.id} without checkpoint record ${deployment.key}`);
+    if (record.chainId !== chainId) {
+      throw new Error(
+        `cannot recover ${step.id}; ${deployment.key} has chain ID ${record.chainId}, expected ${chainId}`,
+      );
+    }
+  }
+  if (!checkpoint.completedSteps.includes(step.id)) checkpoint.completedSteps.push(step.id);
+}
+
+export async function runDeployment(config: DeployerConfig, store: CheckpointStore): Promise<DeploymentCheckpoint> {
+  const context = await createChainContext(config);
+  const roles = resolveRoleConfig(config, context.signers.l1, context.signers.l2);
+  const l2GenesisTimestamp = await resolveGenesisTimestamp(context.l2Provider, config.l2GenesisTimestampOverride);
+  const identity: CheckpointIdentity = {
+    profile: DEPLOYMENT_PROFILE,
+    schemaVersion: SCHEMA_VERSION,
+    initialL2StateRootHash: config.initialL2StateRootHash,
+    l2GenesisTimestamp,
+    chainIds: context.chainIds,
+    signers: context.signers,
+    configurationHash: deploymentConfigurationHash({
+      rateLimitPeriod: config.rateLimitPeriod,
+      rateLimitAmount: config.rateLimitAmount,
+      roles,
+    }),
+  };
+
+  let checkpoint = await store.load();
+  if (checkpoint) {
+    assertCheckpointCompatible(checkpoint, identity);
+  } else {
+    const [l1StartingNonce, l2StartingNonce] = await Promise.all([
+      context.l1Provider.getTransactionCount(context.signers.l1, "pending"),
+      context.l2Provider.getTransactionCount(context.signers.l2, "pending"),
+    ]);
+    const startingNonces = { l1: l1StartingNonce, l2: l2StartingNonce };
+    checkpoint = createCheckpoint({
+      ...identity,
+      startingNonces,
+      plan: buildAddressPlan({
+        l1Signer: context.signers.l1,
+        l2Signer: context.signers.l2,
+        l1StartingNonce,
+        l2StartingNonce,
+      }),
+    });
+    await store.save(checkpoint);
+  }
+
+  const plan = buildAddressPlan({
+    l1Signer: context.signers.l1,
+    l2Signer: context.signers.l2,
+    l1StartingNonce: checkpoint.startingNonces.l1,
+    l2StartingNonce: checkpoint.startingNonces.l2,
+  });
+  assertPlanMatchesCheckpoint(checkpoint, plan);
+
+  const fundingVerified = { l1: false, l2: false };
+  for (const step of plan) {
+    const provider = step.chain === "l1" ? context.l1Provider : context.l2Provider;
+    const signer = step.chain === "l1" ? context.signers.l1 : context.signers.l2;
+    const chainId = step.chain === "l1" ? context.chainIds.l1 : context.chainIds.l2;
+    const [codeByKey, currentNonce] = await Promise.all([
+      inspectCode(provider, step.deployments),
+      provider.getTransactionCount(signer, "pending"),
+    ]);
+    const decision = decideStepAction({ step, checkpoint, codeByKey, currentNonce });
+
+    if (decision.action === "skip") {
+      console.log(`Verified ${step.id}; skipping deployment`);
+      continue;
+    }
+    if (decision.action === "recover") {
+      recoverStep(checkpoint, step, chainId);
+      await store.save(checkpoint);
+      console.log(`Recovered ${step.id} from deterministic on-chain addresses`);
+      continue;
+    }
+
+    if (!fundingVerified[step.chain]) {
+      if (step.chain === "l1") {
+        const [fees, balance] = await Promise.all([
+          resolveOneModelFeeOverrides(context.l1Provider, "L1_DEPLOY_GAS_PRICE_WEI"),
+          context.l1Provider.getBalance(context.signers.l1),
+        ]);
+        assertDeployerCanPay("L1", context.signers.l1, balance, fees, PROFILE_DEPLOY_GAS_BUDGET);
+      } else {
+        const fees = resolveL2DeployFeeOverrides();
+        const balance =
+          feeBudgetPricePerGas(fees) === 0n ? 0n : await context.l2Provider.getBalance(context.signers.l2);
+        assertDeployerCanPay("L2", context.signers.l2, balance, fees, PROFILE_DEPLOY_GAS_BUDGET);
+      }
+      fundingVerified[step.chain] = true;
+    }
+
+    console.log(`Deploying ${step.id}`);
+    await runStepScript({
+      scriptPath: path.join(__dirname, "steps", `${step.script}.js`),
+      environment: buildStepEnvironment(step, config, roles, context, checkpoint, plan),
+      step,
+      checkpoint,
+      store,
+      sensitiveValues: config.sensitiveValues,
+    });
+    const verifiedCode = await inspectCode(provider, step.deployments);
+    if (!Object.values(verifiedCode).every(Boolean)) {
+      throw new Error(`${step.id} script completed but one or more expected addresses have no bytecode`);
+    }
+    if (!step.deployments.every((deployment) => checkpoint.deployments[deployment.key])) {
+      throw new Error(`${step.id} script completed without a durable record for every deployment`);
+    }
+    checkpoint.completedSteps.push(step.id);
+    await store.save(checkpoint);
+  }
+
+  return checkpoint;
+}

--- a/contracts/forge-deployer/src/steps/l1-rollup.ts
+++ b/contracts/forge-deployer/src/steps/l1-rollup.ts
@@ -1,0 +1,1 @@
+import "../../../local-deployments-artifacts/deployPlonkVerifierAndLinethRollupV8";

--- a/contracts/forge-deployer/src/steps/l2-message-service.ts
+++ b/contracts/forge-deployer/src/steps/l2-message-service.ts
@@ -1,0 +1,1 @@
+import "../../../local-deployments-artifacts/deployL2MessageServiceV1";

--- a/contracts/forge-deployer/src/steps/token-bridge.ts
+++ b/contracts/forge-deployer/src/steps/token-bridge.ts
@@ -1,0 +1,140 @@
+// Forge-safe fork of the local TokenBridge deployment. Deployments are
+// serialized before advancing the planned nonce, and the remote TokenBridge
+// address comes from the runner's deterministic plan.
+import { ethers } from "ethers";
+
+import {
+  TOKEN_BRIDGE_PAUSE_TYPES_ROLES,
+  TOKEN_BRIDGE_ROLES,
+  TOKEN_BRIDGE_UNPAUSE_TYPES_ROLES,
+} from "../../../common/constants";
+import {
+  deployContractFromArtifacts,
+  getDeployNonceFromEnv,
+  getInitializerData,
+} from "../../../common/helpers/deployments";
+import { getEnvVarOrDefault, getRequiredEnvVar } from "../../../common/helpers/environment";
+import {
+  FeeOverrides,
+  resolveL2DeployFeeOverrides,
+  resolveOneModelFeeOverrides,
+} from "../../../common/helpers/feeOverrides";
+import { generateRoleAssignments } from "../../../common/helpers/roles";
+import {
+  contractName as BridgedTokenContractName,
+  abi as BridgedTokenAbi,
+  bytecode as BridgedTokenBytecode,
+} from "../../../local-deployments-artifacts/dynamic-artifacts/BridgedToken.json";
+import {
+  contractName as TokenBridgeContractName,
+  abi as TokenBridgeAbi,
+  bytecode as TokenBridgeBytecode,
+} from "../../../local-deployments-artifacts/dynamic-artifacts/TokenBridgeV1_1.json";
+import {
+  contractName as ProxyAdminContractName,
+  abi as ProxyAdminAbi,
+  bytecode as ProxyAdminBytecode,
+} from "../../../local-deployments-artifacts/static-artifacts/ProxyAdmin.json";
+import {
+  abi as TransparentUpgradeableProxyAbi,
+  bytecode as TransparentUpgradeableProxyBytecode,
+} from "../../../local-deployments-artifacts/static-artifacts/TransparentUpgradeableProxy.json";
+import {
+  contractName as UpgradeableBeaconContractName,
+  abi as UpgradeableBeaconAbi,
+  bytecode as UpgradeableBeaconBytecode,
+} from "../../../local-deployments-artifacts/static-artifacts/UpgradeableBeacon.json";
+
+async function main(): Promise<void> {
+  const deployOnL1 = process.env.TOKEN_BRIDGE_L1 === "true";
+  const securityCouncilAddress = getRequiredEnvVar(deployOnL1 ? "L1_SECURITY_COUNCIL" : "L2_SECURITY_COUNCIL");
+  const l2MessageServiceAddress = getRequiredEnvVar("L2_MESSAGE_SERVICE_ADDRESS");
+  const linethRollupAddress = getRequiredEnvVar("LINETH_ROLLUP_ADDRESS");
+  const remoteChainId = getRequiredEnvVar("REMOTE_CHAIN_ID");
+  const remoteSender = getRequiredEnvVar("REMOTE_TOKEN_BRIDGE_ADDRESS");
+  const pauseTypeRoles = getEnvVarOrDefault("TOKEN_BRIDGE_PAUSE_TYPES_ROLES", TOKEN_BRIDGE_PAUSE_TYPES_ROLES);
+  const unpauseTypeRoles = getEnvVarOrDefault("TOKEN_BRIDGE_UNPAUSE_TYPES_ROLES", TOKEN_BRIDGE_UNPAUSE_TYPES_ROLES);
+  const roleAddresses = getEnvVarOrDefault(
+    "TOKEN_BRIDGE_ROLE_ADDRESSES",
+    generateRoleAssignments(TOKEN_BRIDGE_ROLES, securityCouncilAddress, []),
+  );
+
+  const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
+  const wallet = new ethers.Wallet(getRequiredEnvVar("DEPLOYER_PRIVATE_KEY"), provider);
+  const startingNonce = await getDeployNonceFromEnv(wallet, deployOnL1 ? "L1_NONCE" : "L2_NONCE");
+  const fees: FeeOverrides = deployOnL1
+    ? await resolveOneModelFeeOverrides(provider, "L1_DEPLOY_GAS_PRICE_WEI")
+    : resolveL2DeployFeeOverrides();
+
+  const bridgedToken = await deployContractFromArtifacts(
+    BridgedTokenContractName,
+    BridgedTokenAbi,
+    BridgedTokenBytecode,
+    wallet,
+    { nonce: startingNonce, ...fees },
+  );
+  const tokenBridgeImplementation = await deployContractFromArtifacts(
+    "tokenBridgeContractImplementation",
+    TokenBridgeAbi,
+    TokenBridgeBytecode,
+    wallet,
+    { nonce: startingNonce + 1, ...fees },
+  );
+  const proxyAdmin = await deployContractFromArtifacts(
+    ProxyAdminContractName,
+    ProxyAdminAbi,
+    ProxyAdminBytecode,
+    wallet,
+    { nonce: startingNonce + 2, ...fees },
+  );
+  const [bridgedTokenAddress, tokenBridgeImplementationAddress, proxyAdminAddress] = await Promise.all([
+    bridgedToken.getAddress(),
+    tokenBridgeImplementation.getAddress(),
+    proxyAdmin.getAddress(),
+  ]);
+
+  const beacon = await deployContractFromArtifacts(
+    UpgradeableBeaconContractName,
+    UpgradeableBeaconAbi,
+    UpgradeableBeaconBytecode,
+    wallet,
+    bridgedTokenAddress,
+    { nonce: startingNonce + 3, ...fees },
+  );
+  const beaconAddress = await beacon.getAddress();
+  const reservedAddressesVariable = deployOnL1 ? "L1_RESERVED_TOKEN_ADDRESSES" : "L2_RESERVED_TOKEN_ADDRESSES";
+  const reservedAddresses = process.env[reservedAddressesVariable]
+    ? process.env[reservedAddressesVariable]!.split(",")
+    : [];
+  const chainId = (await provider.getNetwork()).chainId;
+  const initializer = getInitializerData(TokenBridgeAbi, "initialize", [
+    {
+      defaultAdmin: securityCouncilAddress,
+      messageService: deployOnL1 ? linethRollupAddress : l2MessageServiceAddress,
+      tokenBeacon: beaconAddress,
+      sourceChainId: chainId,
+      targetChainId: remoteChainId,
+      remoteSender,
+      reservedTokens: reservedAddresses,
+      roleAddresses,
+      pauseTypeRoles,
+      unpauseTypeRoles,
+    },
+  ]);
+
+  await deployContractFromArtifacts(
+    TokenBridgeContractName,
+    TransparentUpgradeableProxyAbi,
+    TransparentUpgradeableProxyBytecode,
+    wallet,
+    tokenBridgeImplementationAddress,
+    proxyAdminAddress,
+    initializer,
+    { nonce: startingNonce + 4, ...fees },
+  );
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/contracts/forge-deployer/src/store.ts
+++ b/contracts/forge-deployer/src/store.ts
@@ -1,0 +1,304 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import https from "node:https";
+import path from "node:path";
+
+import { DeploymentCheckpoint, parseCheckpoint, touchCheckpoint } from "./checkpoint";
+import { DeployerConfig } from "./config";
+
+export const DEFAULT_CONFIG_MAP_NAME = "lineth-contract-addresses";
+const CHECKPOINT_DATA_KEY = "checkpoint.json";
+const SERVICE_ACCOUNT_PATH = "/var/run/secrets/kubernetes.io/serviceaccount";
+const KUBERNETES_WRITE_ATTEMPTS = 5;
+const KUBERNETES_REQUEST_TIMEOUT_MS = 10_000;
+
+export interface CheckpointStore {
+  load(): Promise<DeploymentCheckpoint | undefined>;
+  save(checkpoint: DeploymentCheckpoint): Promise<void>;
+}
+
+function completedAddress(checkpoint: DeploymentCheckpoint, key: string): string | undefined {
+  return checkpoint.deployments[key]?.address;
+}
+
+export function checkpointToConfigMapData(checkpoint: DeploymentCheckpoint): Record<string, string> {
+  const expectedAddresses = Object.fromEntries(
+    Object.entries(checkpoint.expectedDeployments).map(([key, deployment]) => [key, deployment.expectedAddress]),
+  );
+  const serializedCheckpoint = JSON.stringify(checkpoint, null, 2);
+  const data: Record<string, string> = {
+    [CHECKPOINT_DATA_KEY]: serializedCheckpoint,
+    "addresses.json": serializedCheckpoint,
+    "expected-addresses.json": JSON.stringify(expectedAddresses, null, 2),
+  };
+
+  const publicAddresses: Array<[string, string | undefined]> = [
+    ["lineth-rollup", completedAddress(checkpoint, "l1-rollup.proxy")],
+    ["l2-message-service", completedAddress(checkpoint, "l2-message-service.proxy")],
+    ["l1-token-bridge", completedAddress(checkpoint, "l1-token-bridge.proxy")],
+    ["l2-token-bridge", completedAddress(checkpoint, "l2-token-bridge.proxy")],
+  ];
+  for (const [key, value] of publicAddresses) {
+    if (value !== undefined) data[key] = value;
+  }
+
+  return data;
+}
+
+export function configMapDataPatch(resourceVersion: string, data: Record<string, string>): unknown[] {
+  return [
+    { op: "test", path: "/metadata/resourceVersion", value: resourceVersion },
+    { op: "add", path: "/data", value: data },
+  ];
+}
+
+export function configMapContainsData(
+  configMap: { data?: Record<string, string> },
+  expectedData: Record<string, string>,
+): boolean {
+  const actualData = configMap.data ?? {};
+  const expectedEntries = Object.entries(expectedData);
+  return (
+    Object.keys(actualData).length === expectedEntries.length &&
+    expectedEntries.every(([key, value]) => actualData[key] === value)
+  );
+}
+
+export function isRetryableKubernetesStatus(statusCode: number): boolean {
+  return statusCode === 429 || [500, 502, 503, 504].includes(statusCode);
+}
+
+export function isKubernetesConflictStatus(statusCode: number): boolean {
+  return statusCode === 409 || statusCode === 422;
+}
+
+export class FileCheckpointStore implements CheckpointStore {
+  public constructor(private readonly filePath: string) {}
+
+  public async load(): Promise<DeploymentCheckpoint | undefined> {
+    try {
+      return parseCheckpoint(await readFile(this.filePath, "utf8"));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+      throw error;
+    }
+  }
+
+  public async save(checkpoint: DeploymentCheckpoint): Promise<void> {
+    touchCheckpoint(checkpoint);
+    await mkdir(path.dirname(this.filePath), { recursive: true });
+    const temporaryPath = `${this.filePath}.tmp`;
+    await writeFile(temporaryPath, JSON.stringify(checkpoint, null, 2), { mode: 0o600 });
+    await rename(temporaryPath, this.filePath);
+  }
+}
+
+interface KubernetesConfigMap {
+  metadata?: {
+    resourceVersion?: string;
+  };
+  data?: Record<string, string>;
+}
+
+interface KubernetesResponse {
+  statusCode: number;
+  body: string;
+}
+
+class KubernetesHttpError extends Error {
+  public constructor(
+    message: string,
+    public readonly statusCode: number,
+  ) {
+    super(message);
+  }
+}
+
+class KubernetesTransportError extends Error {}
+
+function wait(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+export class KubernetesCheckpointStore implements CheckpointStore {
+  private readonly host: string;
+  private readonly port: number;
+  private readonly namespace: string;
+  private readonly name: string;
+  private readonly token: string;
+  private readonly certificateAuthority: Buffer;
+  private resourceVersion: string | undefined;
+
+  private constructor(input: {
+    host: string;
+    port: number;
+    namespace: string;
+    name: string;
+    token: string;
+    certificateAuthority: Buffer;
+  }) {
+    this.host = input.host;
+    this.port = input.port;
+    this.namespace = input.namespace;
+    this.name = input.name;
+    this.token = input.token;
+    this.certificateAuthority = input.certificateAuthority;
+  }
+
+  public static async fromEnvironment(env: NodeJS.ProcessEnv = process.env): Promise<KubernetesCheckpointStore> {
+    const host = env.KUBERNETES_SERVICE_HOST;
+    if (!host) throw new Error("KUBERNETES_SERVICE_HOST is required unless CHECKPOINT_FILE is set");
+    const port = Number(env.KUBERNETES_SERVICE_PORT_HTTPS ?? "443");
+    if (!Number.isSafeInteger(port) || port <= 0) throw new Error("KUBERNETES_SERVICE_PORT_HTTPS is invalid");
+    const [token, namespace, certificateAuthority] = await Promise.all([
+      readFile(path.join(SERVICE_ACCOUNT_PATH, "token"), "utf8"),
+      env.POD_NAMESPACE
+        ? Promise.resolve(env.POD_NAMESPACE)
+        : readFile(path.join(SERVICE_ACCOUNT_PATH, "namespace"), "utf8"),
+      readFile(path.join(SERVICE_ACCOUNT_PATH, "ca.crt")),
+    ]);
+    return new KubernetesCheckpointStore({
+      host,
+      port,
+      namespace: namespace.trim(),
+      name: env.CHECKPOINT_CONFIG_MAP_NAME?.trim() || DEFAULT_CONFIG_MAP_NAME,
+      token: token.trim(),
+      certificateAuthority,
+    });
+  }
+
+  private resourcePath(): string {
+    return `/api/v1/namespaces/${encodeURIComponent(this.namespace)}/configmaps/${encodeURIComponent(this.name)}`;
+  }
+
+  private async request(method: string, requestPath: string, body?: unknown): Promise<KubernetesResponse> {
+    const payload = body === undefined ? undefined : JSON.stringify(body);
+    return await new Promise<KubernetesResponse>((resolve, reject) => {
+      const request = https.request(
+        {
+          hostname: this.host,
+          port: this.port,
+          path: requestPath,
+          method,
+          ca: this.certificateAuthority,
+          headers: {
+            authorization: `Bearer ${this.token}`,
+            accept: "application/json",
+            ...(payload === undefined
+              ? {}
+              : {
+                  "content-type": method === "PATCH" ? "application/json-patch+json" : "application/json",
+                  "content-length": Buffer.byteLength(payload).toString(),
+                }),
+          },
+        },
+        (response) => {
+          let responseBody = "";
+          response.setEncoding("utf8");
+          response.on("data", (chunk: string) => {
+            responseBody += chunk;
+          });
+          response.on("end", () => {
+            resolve({ statusCode: response.statusCode ?? 0, body: responseBody });
+          });
+        },
+      );
+      request.setTimeout(KUBERNETES_REQUEST_TIMEOUT_MS, () => {
+        request.destroy(
+          new KubernetesTransportError(`Kubernetes API request timed out after ${KUBERNETES_REQUEST_TIMEOUT_MS}ms`),
+        );
+      });
+      request.on("error", (error) => {
+        reject(
+          error instanceof KubernetesTransportError
+            ? error
+            : new KubernetesTransportError(`Kubernetes API request failed: ${error.message}`, { cause: error }),
+        );
+      });
+      if (payload !== undefined) request.write(payload);
+      request.end();
+    });
+  }
+
+  private async getConfigMap(): Promise<KubernetesConfigMap | undefined> {
+    const response = await this.request("GET", this.resourcePath());
+    if (response.statusCode === 404) return undefined;
+    if (response.statusCode !== 200) {
+      throw new KubernetesHttpError(
+        `Kubernetes ConfigMap read failed with HTTP ${response.statusCode}: ${response.body}`,
+        response.statusCode,
+      );
+    }
+    return JSON.parse(response.body) as KubernetesConfigMap;
+  }
+
+  public async load(): Promise<DeploymentCheckpoint | undefined> {
+    const configMap = await this.getConfigMap();
+    this.resourceVersion = configMap?.metadata?.resourceVersion;
+    const rawCheckpoint = configMap?.data?.[CHECKPOINT_DATA_KEY];
+    return rawCheckpoint === undefined ? undefined : parseCheckpoint(rawCheckpoint);
+  }
+
+  public async save(checkpoint: DeploymentCheckpoint): Promise<void> {
+    touchCheckpoint(checkpoint);
+    const desiredData = checkpointToConfigMapData(checkpoint);
+    for (let attempt = 1; attempt <= KUBERNETES_WRITE_ATTEMPTS; attempt += 1) {
+      try {
+        if (!this.resourceVersion) {
+          const existing = await this.getConfigMap();
+          if (!existing) {
+            throw new KubernetesHttpError(
+              `Kubernetes ConfigMap ${this.namespace}/${this.name} is missing; the chart must create its placeholder`,
+              404,
+            );
+          }
+          this.resourceVersion = existing.metadata?.resourceVersion;
+        }
+        if (!this.resourceVersion) {
+          throw new Error(`Kubernetes ConfigMap ${this.namespace}/${this.name} has no resourceVersion`);
+        }
+        const response = await this.request(
+          "PATCH",
+          this.resourcePath(),
+          configMapDataPatch(this.resourceVersion, desiredData),
+        );
+        if (response.statusCode === 200) {
+          const updated = JSON.parse(response.body) as KubernetesConfigMap;
+          if (!updated.metadata?.resourceVersion) {
+            throw new Error(`Kubernetes ConfigMap update response has no resourceVersion`);
+          }
+          this.resourceVersion = updated.metadata.resourceVersion;
+          return;
+        }
+        if (isKubernetesConflictStatus(response.statusCode)) {
+          const current = await this.getConfigMap();
+          if (current && configMapContainsData(current, desiredData) && current.metadata?.resourceVersion) {
+            this.resourceVersion = current.metadata.resourceVersion;
+            return;
+          }
+          throw new KubernetesHttpError(
+            `Kubernetes ConfigMap ${this.namespace}/${this.name} changed concurrently; refusing to overwrite it`,
+            response.statusCode,
+          );
+        }
+        throw new KubernetesHttpError(
+          `Kubernetes ConfigMap write failed with HTTP ${response.statusCode}: ${response.body}`,
+          response.statusCode,
+        );
+      } catch (error) {
+        const shouldRetry =
+          (error instanceof KubernetesTransportError ||
+            (error instanceof KubernetesHttpError && isRetryableKubernetesStatus(error.statusCode))) &&
+          attempt < KUBERNETES_WRITE_ATTEMPTS;
+        if (!shouldRetry) throw error;
+        await wait(100 * 2 ** (attempt - 1));
+      }
+    }
+    throw new Error("Kubernetes ConfigMap write attempts exhausted");
+  }
+}
+
+export async function createCheckpointStore(config: DeployerConfig): Promise<CheckpointStore> {
+  return config.checkpointFile
+    ? new FileCheckpointStore(config.checkpointFile)
+    : await KubernetesCheckpointStore.fromEnvironment();
+}

--- a/contracts/forge-deployer/test/address-plan.test.ts
+++ b/contracts/forge-deployer/test/address-plan.test.ts
@@ -1,0 +1,47 @@
+import { getCreateAddress } from "ethers";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildAddressPlan } from "../src/address-plan";
+
+const L1_SIGNER = "0x1000000000000000000000000000000000000001";
+const L2_SIGNER = "0x2000000000000000000000000000000000000002";
+
+test("builds the four-step deterministic deployment address plan", () => {
+  const plan = buildAddressPlan({
+    l1Signer: L1_SIGNER,
+    l2Signer: L2_SIGNER,
+    l1StartingNonce: 10,
+    l2StartingNonce: 20,
+  });
+
+  assert.deepEqual(
+    plan.map((step) => [step.id, step.deployments.length]),
+    [
+      ["l1-rollup", 5],
+      ["l2-message-service", 3],
+      ["l1-token-bridge", 5],
+      ["l2-token-bridge", 5],
+    ],
+  );
+  assert.equal(plan[0]?.deployments.at(-1)?.nonce, 14);
+  assert.equal(plan[1]?.deployments.at(-1)?.nonce, 22);
+  assert.equal(plan[2]?.deployments.at(-1)?.nonce, 19);
+  assert.equal(plan[3]?.deployments.at(-1)?.nonce, 27);
+  assert.equal(plan[0]?.deployments.at(-1)?.expectedAddress, getCreateAddress({ from: L1_SIGNER, nonce: 14 }));
+  assert.equal(plan[3]?.deployments.at(-1)?.expectedAddress, getCreateAddress({ from: L2_SIGNER, nonce: 27 }));
+});
+
+test("uses distinct stable keys for repeated infrastructure contracts", () => {
+  const plan = buildAddressPlan({
+    l1Signer: L1_SIGNER,
+    l2Signer: L2_SIGNER,
+    l1StartingNonce: 0,
+    l2StartingNonce: 0,
+  });
+  const keys = plan.flatMap((step) => step.deployments.map((deployment) => deployment.key));
+
+  assert.equal(new Set(keys).size, keys.length);
+  assert.ok(keys.includes("l1-token-bridge.proxy-admin"));
+  assert.ok(keys.includes("l2-token-bridge.proxy-admin"));
+});

--- a/contracts/forge-deployer/test/checkpoint.test.ts
+++ b/contracts/forge-deployer/test/checkpoint.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildAddressPlan } from "../src/address-plan";
+import {
+  assertCheckpointCompatible,
+  createCheckpoint,
+  DEPLOYMENT_PROFILE,
+  deploymentConfigurationHash,
+  parseCheckpoint,
+  SCHEMA_VERSION,
+} from "../src/checkpoint";
+import {
+  checkpointToConfigMapData,
+  configMapContainsData,
+  configMapDataPatch,
+  DEFAULT_CONFIG_MAP_NAME,
+  isKubernetesConflictStatus,
+  isRetryableKubernetesStatus,
+} from "../src/store";
+
+const STATE_ROOT = `0x${"ab".repeat(32)}`;
+const L1_SIGNER = "0x1000000000000000000000000000000000000001";
+const L2_SIGNER = "0x2000000000000000000000000000000000000002";
+
+function identity() {
+  return {
+    profile: DEPLOYMENT_PROFILE,
+    schemaVersion: SCHEMA_VERSION,
+    initialL2StateRootHash: STATE_ROOT,
+    l2GenesisTimestamp: 1_700_000_000,
+    chainIds: { l1: "1", l2: "1337" },
+    signers: { l1: L1_SIGNER, l2: L2_SIGNER },
+    configurationHash: `0x${"12".repeat(32)}`,
+  };
+}
+
+function checkpoint() {
+  const startingNonces = { l1: 3, l2: 7 };
+  return createCheckpoint({
+    ...identity(),
+    startingNonces,
+    plan: buildAddressPlan({
+      l1Signer: L1_SIGNER,
+      l2Signer: L2_SIGNER,
+      l1StartingNonce: startingNonces.l1,
+      l2StartingNonce: startingNonces.l2,
+    }),
+  });
+}
+
+test("creates a versioned checkpoint with every expected address and no secrets", () => {
+  const value = checkpoint();
+  const serialized = JSON.stringify(value);
+
+  assert.equal(value.profile, DEPLOYMENT_PROFILE);
+  assert.equal(value.schemaVersion, SCHEMA_VERSION);
+  assert.equal(Object.keys(value.expectedDeployments).length, 18);
+  assert.doesNotMatch(serialized, /private.?key|rpc.?url/i);
+});
+
+test("rejects incompatible chain, signer, state root, and profile", () => {
+  const value = checkpoint();
+
+  assert.throws(
+    () => assertCheckpointCompatible(value, { ...identity(), chainIds: { l1: "11155111", l2: "1337" } }),
+    /L1 chain ID/,
+  );
+  assert.throws(
+    () =>
+      assertCheckpointCompatible(value, {
+        ...identity(),
+        signers: { l1: "0x3000000000000000000000000000000000000003", l2: L2_SIGNER },
+      }),
+    /L1 signer/,
+  );
+  assert.throws(
+    () => assertCheckpointCompatible(value, { ...identity(), initialL2StateRootHash: `0x${"cd".repeat(32)}` }),
+    /initial L2 state root/,
+  );
+  assert.throws(
+    () => assertCheckpointCompatible(value, { ...identity(), profile: "another-profile" }),
+    /deployment profile/,
+  );
+  assert.throws(
+    () => assertCheckpointCompatible(value, { ...identity(), configurationHash: `0x${"34".repeat(32)}` }),
+    /deployment configuration/,
+  );
+});
+
+test("serializes sufficient ConfigMap state and public addresses", () => {
+  const value = checkpoint();
+  const data = checkpointToConfigMapData(value);
+  const restored = JSON.parse(data["checkpoint.json"] ?? "");
+
+  assert.equal(DEFAULT_CONFIG_MAP_NAME, "lineth-contract-addresses");
+  assert.deepEqual(restored, value);
+  assert.equal(restored.expectedDeployments["l1-rollup.proxy"].expectedAddress.length, 42);
+  assert.ok(data["addresses.json"]);
+});
+
+test("replaces ConfigMap data with a resource-version guard", () => {
+  assert.deepEqual(configMapDataPatch("42", { "addresses.json": '{"schemaVersion":1}' }), [
+    { op: "test", path: "/metadata/resourceVersion", value: "42" },
+    { op: "add", path: "/data", value: { "addresses.json": '{"schemaVersion":1}' } },
+  ]);
+});
+
+test("retries only transient Kubernetes write responses", () => {
+  for (const status of [429, 500, 502, 503, 504]) {
+    assert.equal(isRetryableKubernetesStatus(status), true);
+  }
+  for (const status of [400, 401, 403, 404, 409, 422]) {
+    assert.equal(isRetryableKubernetesStatus(status), false);
+  }
+  assert.equal(isKubernetesConflictStatus(409), true);
+  assert.equal(isKubernetesConflictStatus(422), true);
+});
+
+test("recognizes only an exact checkpoint write after an ambiguous response", () => {
+  const expected = { "checkpoint.json": '{"version":2}', "addresses.json": '{"version":2}' };
+
+  assert.equal(configMapContainsData({ data: expected }, expected), true);
+  assert.equal(
+    configMapContainsData(
+      { data: { "checkpoint.json": '{"version":1}', "addresses.json": '{"version":1}' } },
+      expected,
+    ),
+    false,
+  );
+});
+
+test("hashes normalized public deployment settings", () => {
+  const first = deploymentConfigurationHash({
+    rateLimitPeriod: "086400",
+    rateLimitAmount: "01000",
+    roles: {
+      l1SecurityCouncil: L1_SIGNER.toLowerCase(),
+      l1RollupOperators: [L1_SIGNER.toLowerCase()],
+      l2SecurityCouncil: L2_SIGNER.toLowerCase(),
+      l1L2MessageSetter: L2_SIGNER.toLowerCase(),
+    },
+  });
+  const second = deploymentConfigurationHash({
+    rateLimitPeriod: "86400",
+    rateLimitAmount: "1000",
+    roles: {
+      l1SecurityCouncil: L1_SIGNER,
+      l1RollupOperators: [L1_SIGNER],
+      l2SecurityCouncil: L2_SIGNER,
+      l1L2MessageSetter: L2_SIGNER,
+    },
+  });
+
+  assert.equal(first, second);
+});
+
+test("rejects incomplete or malformed persisted deployment records", () => {
+  const value = checkpoint();
+  const deployment = value.expectedDeployments["l1-rollup.verifier"]!;
+  value.deployments["l1-rollup.verifier"] = {
+    address: deployment.expectedAddress,
+    transactionHash: "not-a-transaction-hash",
+    blockNumber: -1,
+    chainId: "not-a-chain-id",
+    recovered: false,
+  };
+
+  assert.throws(() => parseCheckpoint(JSON.stringify(value)), /invalid deployment record/);
+});

--- a/contracts/forge-deployer/test/config.test.ts
+++ b/contracts/forge-deployer/test/config.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { loadConfig, resolveRoleConfig, sanitizeText } from "../src/config";
+import { assertDistinctChainIds } from "../src/runner";
+
+const STATE_ROOT = `0x${"ab".repeat(32)}`;
+const L1_ADDRESS = "0x1000000000000000000000000000000000000001";
+const L2_ADDRESS = "0x2000000000000000000000000000000000000002";
+
+function requiredEnvironment(): NodeJS.ProcessEnv {
+  return {
+    L1_RPC_URL: "https://user:password@l1.example/rpc",
+    L2_RPC_URL: "http://l2.example:8545",
+    L1_DEPLOYER_PRIVATE_KEY: "__test_l1_private_key__",
+    L2_DEPLOYER_PRIVATE_KEY: "__test_l2_private_key__",
+    INITIAL_L2_STATE_ROOT_HASH: STATE_ROOT,
+  };
+}
+
+test("requires a 32-byte initial L2 state root", () => {
+  const env = requiredEnvironment();
+  env.INITIAL_L2_STATE_ROOT_HASH = "0x1234";
+
+  assert.throws(() => loadConfig(env), /INITIAL_L2_STATE_ROOT_HASH must be a 32-byte hex value/);
+});
+
+test("validates uint256 bounds, positive rate limits, and nonzero role addresses", () => {
+  const zeroPeriod = requiredEnvironment();
+  zeroPeriod.CONTRACT_RATE_LIMIT_PERIOD = "0";
+  assert.throws(() => loadConfig(zeroPeriod), /CONTRACT_RATE_LIMIT_PERIOD must be greater than zero/);
+
+  const overflowAmount = requiredEnvironment();
+  overflowAmount.CONTRACT_RATE_LIMIT_AMOUNT = (1n << 256n).toString();
+  assert.throws(() => loadConfig(overflowAmount), /CONTRACT_RATE_LIMIT_AMOUNT must fit uint256/);
+
+  const zeroRole = requiredEnvironment();
+  zeroRole.L1_SECURITY_COUNCIL = "0x0000000000000000000000000000000000000000";
+  assert.throws(() => loadConfig(zeroRole), /L1_SECURITY_COUNCIL must not be the zero address/);
+});
+
+test("rejects non-HTTP RPC endpoints", () => {
+  const env = requiredEnvironment();
+  env.L1_RPC_URL = "file:///tmp/not-an-rpc";
+
+  assert.throws(() => loadConfig(env), /L1_RPC_URL must be an HTTP\(S\) URL/);
+});
+
+test("rejects identical L1 and L2 chain IDs", () => {
+  assert.throws(() => assertDistinctChainIds("1337", "1337"), /L1 and L2 chain IDs must differ/);
+  assert.doesNotThrow(() => assertDistinctChainIds("1", "1337"));
+});
+
+test("uses documented defaults and derives dev roles from deployers", () => {
+  const config = loadConfig(requiredEnvironment());
+  const roles = resolveRoleConfig(config, L1_ADDRESS, L2_ADDRESS);
+
+  assert.equal(config.rateLimitPeriod, "86400");
+  assert.equal(config.rateLimitAmount, "1000000000000000000000");
+  assert.equal(roles.l1SecurityCouncil, L1_ADDRESS);
+  assert.deepEqual(roles.l1RollupOperators, [L1_ADDRESS]);
+  assert.equal(roles.l2SecurityCouncil, L2_ADDRESS);
+  assert.equal(roles.l1L2MessageSetter, L2_ADDRESS);
+});
+
+test("redacts private keys and credential-bearing RPC URLs", () => {
+  const config = loadConfig(requiredEnvironment());
+  const text = `failed key=${config.l1PrivateKey} endpoint=${config.l1RpcUrl}`;
+
+  assert.equal(sanitizeText(text, config.sensitiveValues), "failed key=[REDACTED] endpoint=[REDACTED]");
+});

--- a/contracts/forge-deployer/test/decision.test.ts
+++ b/contracts/forge-deployer/test/decision.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildAddressPlan } from "../src/address-plan";
+import { createCheckpoint, DEPLOYMENT_PROFILE, SCHEMA_VERSION } from "../src/checkpoint";
+import { decideStepAction } from "../src/decision";
+
+const STATE_ROOT = `0x${"ab".repeat(32)}`;
+const TX_HASH = `0x${"cd".repeat(32)}`;
+const L1_SIGNER = "0x1000000000000000000000000000000000000001";
+const L2_SIGNER = "0x2000000000000000000000000000000000000002";
+
+function fixture() {
+  const plan = buildAddressPlan({
+    l1Signer: L1_SIGNER,
+    l2Signer: L2_SIGNER,
+    l1StartingNonce: 5,
+    l2StartingNonce: 9,
+  });
+  const checkpoint = createCheckpoint({
+    profile: DEPLOYMENT_PROFILE,
+    schemaVersion: SCHEMA_VERSION,
+    initialL2StateRootHash: STATE_ROOT,
+    l2GenesisTimestamp: 1_700_000_000,
+    chainIds: { l1: "1", l2: "1337" },
+    signers: { l1: L1_SIGNER, l2: L2_SIGNER },
+    configurationHash: `0x${"12".repeat(32)}`,
+    startingNonces: { l1: 5, l2: 9 },
+    plan,
+  });
+  return { checkpoint, step: plan[0]! };
+}
+
+test("skips only when all records and bytecode verify", () => {
+  const { checkpoint, step } = fixture();
+  const codeByKey: Record<string, boolean> = {};
+  for (const deployment of step.deployments) {
+    codeByKey[deployment.key] = true;
+    checkpoint.deployments[deployment.key] = {
+      address: deployment.expectedAddress,
+      transactionHash: TX_HASH,
+      blockNumber: 100,
+      chainId: "1",
+      recovered: false,
+    };
+  }
+  checkpoint.completedSteps.push(step.id);
+
+  assert.deepEqual(decideStepAction({ step, checkpoint, codeByKey, currentNonce: 10 }), { action: "skip" });
+});
+
+test("recovers a fully checkpointed step when only its completion marker is missing", () => {
+  const { checkpoint, step } = fixture();
+  const codeByKey = Object.fromEntries(step.deployments.map((deployment) => [deployment.key, true]));
+  for (const deployment of step.deployments) {
+    checkpoint.deployments[deployment.key] = {
+      address: deployment.expectedAddress,
+      transactionHash: TX_HASH,
+      blockNumber: 100,
+      chainId: "1",
+      recovered: false,
+    };
+  }
+
+  assert.deepEqual(decideStepAction({ step, checkpoint, codeByKey, currentNonce: 10 }), { action: "recover" });
+});
+
+test("fails closed when addresses contain code without durable deployment records", () => {
+  const { checkpoint, step } = fixture();
+  const codeByKey = Object.fromEntries(step.deployments.map((deployment) => [deployment.key, true]));
+
+  assert.throws(() => decideStepAction({ step, checkpoint, codeByKey, currentNonce: 10 }), /uncheckpointed code/);
+});
+
+test("deploys only when the range is empty and nonce has not drifted", () => {
+  const { checkpoint, step } = fixture();
+  const codeByKey = Object.fromEntries(step.deployments.map((deployment) => [deployment.key, false]));
+
+  assert.deepEqual(decideStepAction({ step, checkpoint, codeByKey, currentNonce: 5 }), { action: "deploy" });
+});
+
+test("fails closed on partial deployment, nonce drift, or lost bytecode", () => {
+  const { checkpoint, step } = fixture();
+  const partialCode = Object.fromEntries(step.deployments.map((deployment, index) => [deployment.key, index === 0]));
+  const noCode = Object.fromEntries(step.deployments.map((deployment) => [deployment.key, false]));
+
+  assert.throws(
+    () => decideStepAction({ step, checkpoint, codeByKey: partialCode, currentNonce: 6 }),
+    /partial deployment/,
+  );
+  assert.throws(() => decideStepAction({ step, checkpoint, codeByKey: noCode, currentNonce: 6 }), /nonce drift/);
+
+  const first = step.deployments[0]!;
+  checkpoint.deployments[first.key] = {
+    address: first.expectedAddress,
+    transactionHash: TX_HASH,
+    blockNumber: 100,
+    chainId: "1",
+    recovered: false,
+  };
+  assert.throws(
+    () => decideStepAction({ step, checkpoint, codeByKey: noCode, currentNonce: 5 }),
+    /checkpointed deployment.*has no bytecode/,
+  );
+});

--- a/contracts/forge-deployer/test/deployment-record.test.ts
+++ b/contracts/forge-deployer/test/deployment-record.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { formatDeploymentRecord, parseDeploymentRecord } from "../../common/helpers/deploymentRecord";
+
+const ADDRESS = "0x1000000000000000000000000000000000000001";
+const TX_HASH = `0x${"ab".repeat(32)}`;
+
+test("formats and parses a durable deployment record", () => {
+  const line = formatDeploymentRecord({
+    contractName: "LinethRollupV8",
+    address: ADDRESS,
+    transactionHash: TX_HASH,
+    blockNumber: 42,
+    chainId: 1337n,
+  });
+
+  assert.equal(
+    line,
+    `contract=LinethRollupV8 deployed: address=${ADDRESS} blockNumber=42 chainId=1337 txHash=${TX_HASH}`,
+  );
+  assert.deepEqual(parseDeploymentRecord(line), {
+    contractName: "LinethRollupV8",
+    address: ADDRESS,
+    transactionHash: TX_HASH,
+    blockNumber: 42,
+    chainId: "1337",
+  });
+});
+
+test("ignores ordinary logs and legacy records without transaction hashes", () => {
+  assert.equal(parseDeploymentRecord("Deploying LinethRollupV8..."), undefined);
+  assert.equal(
+    parseDeploymentRecord(`contract=LinethRollupV8 deployed: address=${ADDRESS} blockNumber=42 chainId=1337`),
+    undefined,
+  );
+});

--- a/contracts/forge-deployer/test/fees.test.ts
+++ b/contracts/forge-deployer/test/fees.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveL2DeployFeeOverrides } from "../../common/helpers/feeOverrides";
+import { assertDeployerCanPay, formatInsufficientFundsError } from "../src/funds";
+
+const DEPLOYER = "0x2000000000000000000000000000000000000002";
+
+test("honors an explicit zero L2 deployment gas price", () => {
+  const previous = process.env.L2_DEPLOY_GAS_PRICE_WEI;
+  process.env.L2_DEPLOY_GAS_PRICE_WEI = "0";
+  try {
+    assert.deepEqual(resolveL2DeployFeeOverrides(), { gasPrice: 0n });
+  } finally {
+    if (previous === undefined) delete process.env.L2_DEPLOY_GAS_PRICE_WEI;
+    else process.env.L2_DEPLOY_GAS_PRICE_WEI = previous;
+  }
+});
+
+test("does not require a positive balance when the selected fee is zero", () => {
+  assert.doesNotThrow(() => assertDeployerCanPay("L2", DEPLOYER, 0n, { gasPrice: 0n }));
+});
+
+test("reports actionable insufficient funds on a fee-paying chain", () => {
+  assert.throws(
+    () => assertDeployerCanPay("L2", DEPLOYER, 0n, { gasPrice: 1n }),
+    /Fund L2 deployer 0x2000.*or set L2_DEPLOY_GAS_PRICE_WEI=0/,
+  );
+  assert.match(
+    formatInsufficientFundsError("L1", DEPLOYER, new Error("insufficient funds for gas * price + value")).message,
+    /Fund L1 deployer/,
+  );
+});
+
+test("requires the full configured deployment gas budget", () => {
+  assert.throws(() => assertDeployerCanPay("L1", DEPLOYER, 99n, { gasPrice: 10n }, 10n), /requires at least 100 wei/);
+  assert.doesNotThrow(() => assertDeployerCanPay("L1", DEPLOYER, 100n, { gasPrice: 10n }, 10n));
+});

--- a/contracts/forge-deployer/test/fixtures/checkpoint-ack-child.cjs
+++ b/contracts/forge-deployer/test/fixtures/checkpoint-ack-child.cjs
@@ -1,0 +1,33 @@
+const { writeFileSync } = require("node:fs");
+
+const records = JSON.parse(process.env.TEST_DEPLOYMENT_RECORDS);
+const markerFile = process.env.TEST_SECOND_TRANSACTION_MARKER;
+
+async function sendRecord(record, index) {
+  if (!process.send) throw new Error("checkpoint acknowledgement IPC is unavailable");
+
+  const id = `record-${index}`;
+  const acknowledgement = new Promise((resolve, reject) => {
+    const onMessage = (message) => {
+      if (!message || message.type !== "lineth-deployment-record-ack" || message.id !== id) return;
+      process.off("message", onMessage);
+      if (message.error) reject(new Error(message.error));
+      else resolve();
+    };
+    process.on("message", onMessage);
+  });
+
+  process.send({ type: "lineth-deployment-record", id, record });
+  await acknowledgement;
+}
+
+async function main() {
+  await sendRecord(records[0], 0);
+  writeFileSync(markerFile, "second transaction submitted");
+  await sendRecord(records[1], 1);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/contracts/forge-deployer/test/genesis.test.ts
+++ b/contracts/forge-deployer/test/genesis.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveGenesisTimestamp } from "../src/genesis";
+
+test("derives the genesis timestamp from L2 block zero", async () => {
+  const provider = {
+    getBlock: async (blockNumber: number) => {
+      assert.equal(blockNumber, 0);
+      return { timestamp: 1_700_000_000 };
+    },
+  };
+
+  assert.equal(await resolveGenesisTimestamp(provider, undefined), 1_700_000_000);
+});
+
+test("accepts a valid override without querying block zero", async () => {
+  const provider = {
+    getBlock: async () => {
+      throw new Error("block zero must not be queried");
+    },
+  };
+
+  assert.equal(await resolveGenesisTimestamp(provider, "1700000001"), 1_700_000_001);
+});
+
+test("rejects an invalid genesis timestamp override", async () => {
+  await assert.rejects(() => resolveGenesisTimestamp({ getBlock: async () => null }, "-1"), /non-negative integer/);
+});

--- a/contracts/forge-deployer/test/integration/two-chain.sh
+++ b/contracts/forge-deployer/test/integration/two-chain.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FOUNDRY_IMAGE="${FOUNDRY_IMAGE:-ghcr.io/foundry-rs/foundry@sha256:2dbf3d0fc58593ad9d01ef57677f93f83f4987acd295d17f303448d82e3a3ae7}"
+DEPLOYER_IMAGE="${DEPLOYER_IMAGE:-consensys/lineth-contract-deployer:local}"
+REPOSITORY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+NETWORK="forge-deployer-test-$$"
+CHECKPOINT_DIR="$(mktemp -d)"
+L1_CONTAINER="forge-deployer-l1-$$"
+L2_CONTAINER="forge-deployer-l2-$$"
+L1_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+# Deliberately not one of Anvil's funded accounts. A zero-fee L2 must accept
+# deployments from this zero-balance signer.
+L2_KEY="0x0000000000000000000000000000000000000000000000000000000000000001"
+STATE_ROOT="0xabababababababababababababababababababababababababababababababab"
+
+cleanup() {
+  docker rm -f "$L1_CONTAINER" "$L2_CONTAINER" >/dev/null 2>&1 || true
+  docker network rm "$NETWORK" >/dev/null 2>&1 || true
+  rm -rf "$CHECKPOINT_DIR"
+}
+trap cleanup EXIT
+
+if ! docker image inspect "$DEPLOYER_IMAGE" >/dev/null 2>&1; then
+  make -C "$REPOSITORY_ROOT" docker-build-contract-deployer
+fi
+
+docker network create "$NETWORK" >/dev/null
+docker run -d --name "$L1_CONTAINER" --network "$NETWORK" --entrypoint anvil "$FOUNDRY_IMAGE" \
+  --host 0.0.0.0 --chain-id 31337 --base-fee 0 --gas-price 0 >/dev/null
+docker run -d --name "$L2_CONTAINER" --network "$NETWORK" --entrypoint anvil "$FOUNDRY_IMAGE" \
+  --host 0.0.0.0 --chain-id 1337 --base-fee 0 --gas-price 0 >/dev/null
+
+wait_for_rpc() {
+  local container="$1"
+  for _ in $(seq 1 30); do
+    if docker run --rm --network "$NETWORK" --entrypoint cast "$FOUNDRY_IMAGE" \
+      block-number --rpc-url "http://${container}:8545" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "${container} RPC did not become ready" >&2
+  return 1
+}
+
+wait_for_rpc "$L1_CONTAINER"
+wait_for_rpc "$L2_CONTAINER"
+L1_ADDRESS="$(docker run --rm --entrypoint cast "$FOUNDRY_IMAGE" wallet address "$L1_KEY")"
+L2_ADDRESS="$(docker run --rm --entrypoint cast "$FOUNDRY_IMAGE" wallet address "$L2_KEY")"
+
+chmod 0777 "$CHECKPOINT_DIR"
+run_deployer() {
+  docker run --rm --network "$NETWORK" \
+    -v "$CHECKPOINT_DIR:/checkpoint" \
+    -e "L1_RPC_URL=http://${L1_CONTAINER}:8545" \
+    -e "L2_RPC_URL=http://${L2_CONTAINER}:8545" \
+    -e "L1_DEPLOYER_PRIVATE_KEY=$L1_KEY" \
+    -e "L2_DEPLOYER_PRIVATE_KEY=$L2_KEY" \
+    -e "INITIAL_L2_STATE_ROOT_HASH=$STATE_ROOT" \
+    -e "L1_DEPLOY_GAS_PRICE_WEI=0" \
+    -e "L2_DEPLOY_GAS_PRICE_WEI=0" \
+    -e "CHECKPOINT_FILE=/checkpoint/checkpoint.json" \
+    "$DEPLOYER_IMAGE"
+}
+
+run_deployer
+L1_NONCE_BEFORE="$(docker run --rm --network "$NETWORK" --entrypoint cast "$FOUNDRY_IMAGE" \
+  nonce --rpc-url "http://${L1_CONTAINER}:8545" "$L1_ADDRESS")"
+L2_NONCE_BEFORE="$(docker run --rm --network "$NETWORK" --entrypoint cast "$FOUNDRY_IMAGE" \
+  nonce --rpc-url "http://${L2_CONTAINER}:8545" "$L2_ADDRESS")"
+
+run_deployer
+L1_NONCE_AFTER="$(docker run --rm --network "$NETWORK" --entrypoint cast "$FOUNDRY_IMAGE" \
+  nonce --rpc-url "http://${L1_CONTAINER}:8545" "$L1_ADDRESS")"
+L2_NONCE_AFTER="$(docker run --rm --network "$NETWORK" --entrypoint cast "$FOUNDRY_IMAGE" \
+  nonce --rpc-url "http://${L2_CONTAINER}:8545" "$L2_ADDRESS")"
+
+test "$L1_NONCE_BEFORE" = "$L1_NONCE_AFTER"
+test "$L2_NONCE_BEFORE" = "$L2_NONCE_AFTER"
+echo "two-chain deployment and zero-transaction rerun verified"

--- a/contracts/forge-deployer/test/process-runner.test.ts
+++ b/contracts/forge-deployer/test/process-runner.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { DeploymentStep } from "../src/address-plan";
+import { DeploymentCheckpoint } from "../src/checkpoint";
+import { childEnvironment, runStepScript } from "../src/process-runner";
+import { CheckpointStore } from "../src/store";
+
+const FIRST_ADDRESS = "0x1000000000000000000000000000000000000001";
+const SECOND_ADDRESS = "0x2000000000000000000000000000000000000002";
+const FIRST_HASH = `0x${"11".repeat(32)}`;
+const SECOND_HASH = `0x${"22".repeat(32)}`;
+
+test("does not inherit unvalidated deployment overrides", () => {
+  const environment = childEnvironment(
+    { RPC_URL: "http://l1.example" },
+    {
+      PATH: "/usr/bin",
+      NODE_EXTRA_CA_CERTS: "/etc/private-ca.pem",
+      LINETH_ROLLUP_ROLE_ADDRESSES: "malicious-unvalidated-value",
+      NODE_OPTIONS: "--require=/tmp/untrusted.js",
+    },
+  );
+
+  assert.deepEqual(environment, {
+    NODE_EXTRA_CA_CERTS: "/etc/private-ca.pem",
+    PATH: "/usr/bin",
+    RPC_URL: "http://l1.example",
+  });
+});
+
+test("acknowledges a deployment only after its checkpoint is durable", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "forge-deployer-process-runner-"));
+  const markerFile = path.join(directory, "second-transaction");
+  const scriptPath = path.join(__dirname, "fixtures/checkpoint-ack-child.cjs");
+  let releaseFirstSave!: () => void;
+  let markFirstSaveStarted!: () => void;
+  const firstSaveStarted = new Promise<void>((resolve) => {
+    markFirstSaveStarted = resolve;
+  });
+  const firstSaveReleased = new Promise<void>((resolve) => {
+    releaseFirstSave = resolve;
+  });
+  let saveCount = 0;
+
+  const store: CheckpointStore = {
+    async load() {
+      return undefined;
+    },
+    async save() {
+      saveCount += 1;
+      if (saveCount === 1) {
+        markFirstSaveStarted();
+        await firstSaveReleased;
+      }
+    },
+  };
+  const step: DeploymentStep = {
+    id: "l1-rollup",
+    chain: "l1",
+    startingNonce: 0,
+    script: "l1-rollup",
+    deployments: [
+      { key: "l1-rollup.first", contractName: "First", nonce: 0, expectedAddress: FIRST_ADDRESS },
+      { key: "l1-rollup.second", contractName: "Second", nonce: 1, expectedAddress: SECOND_ADDRESS },
+    ],
+  };
+  const checkpoint = {
+    chainIds: { l1: "31337", l2: "1337" },
+    deployments: {},
+  } as DeploymentCheckpoint;
+  const records = [
+    {
+      contractName: "First",
+      address: FIRST_ADDRESS,
+      transactionHash: FIRST_HASH,
+      blockNumber: 1,
+      chainId: "31337",
+    },
+    {
+      contractName: "Second",
+      address: SECOND_ADDRESS,
+      transactionHash: SECOND_HASH,
+      blockNumber: 2,
+      chainId: "31337",
+    },
+  ];
+
+  try {
+    const run = runStepScript({
+      scriptPath,
+      environment: {
+        TEST_DEPLOYMENT_RECORDS: JSON.stringify(records),
+        TEST_SECOND_TRANSACTION_MARKER: markerFile,
+      },
+      step,
+      checkpoint,
+      store,
+      sensitiveValues: [],
+    });
+
+    await Promise.race([
+      firstSaveStarted,
+      run.then(() => {
+        throw new Error("child exited before the first checkpoint save started");
+      }),
+    ]);
+    await assert.rejects(access(markerFile), /ENOENT/);
+
+    releaseFirstSave();
+    await run;
+
+    assert.equal(await readFile(markerFile, "utf8"), "second transaction submitted");
+    assert.equal(saveCount, 2);
+  } finally {
+    releaseFirstSave();
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/contracts/forge-deployer/tsconfig.json
+++ b/contracts/forge-deployer/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "dotenv": ["node_modules/dotenv"],
+      "ethers": ["node_modules/ethers"]
+    },
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "../common/helpers/deploymentRecord.ts", "../common/helpers/feeOverrides.ts"]
+}

--- a/contracts/forge-deployer/tsup.config.ts
+++ b/contracts/forge-deployer/tsup.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    cli: "src/cli.ts",
+    "steps/l1-rollup": "src/steps/l1-rollup.ts",
+    "steps/l2-message-service": "src/steps/l2-message-service.ts",
+    "steps/token-bridge": "src/steps/token-bridge.ts",
+  },
+  format: ["cjs"],
+  platform: "node",
+  target: "node24",
+  outDir: "dist",
+  clean: true,
+  sourcemap: true,
+  noExternal: ["dotenv", "ethers"],
+});

--- a/contracts/local-deployments-artifacts/deployL2MessageServiceV1.ts
+++ b/contracts/local-deployments-artifacts/deployL2MessageServiceV1.ts
@@ -23,7 +23,7 @@ import {
 } from "../common/constants";
 import { deployContractFromArtifacts, getDeployNonceFromEnv, getInitializerData } from "../common/helpers/deployments";
 import { getEnvVarOrDefault, getRequiredEnvVar } from "../common/helpers/environment";
-import { LOCAL_L2_DEPLOY_FEE_OVERRIDES } from "../common/helpers/feeOverrides";
+import { resolveL2DeployFeeOverrides } from "../common/helpers/feeOverrides";
 import { getDeploymentNetworkName, requireAddressFromRegistryOrEnv } from "../common/helpers/readAddress";
 import { generateRoleAssignments } from "../common/helpers/roles";
 
@@ -40,25 +40,24 @@ async function main() {
   const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
   const wallet = new ethers.Wallet(process.env.DEPLOYER_PRIVATE_KEY!, provider);
   const walletNonce = await getDeployNonceFromEnv(wallet, "L2_NONCE");
+  const feeOverrides = resolveL2DeployFeeOverrides();
 
   const l2MessageServiceContractImplementationName = "L2MessageServiceImplementation";
 
-  const [l2MessageServiceImplementation, proxyAdmin] = await Promise.all([
-    deployContractFromArtifacts(
-      l2MessageServiceContractImplementationName,
-      L2MessageServiceAbi,
-      L2MessageServiceBytecode,
-      wallet,
-      {
-        nonce: walletNonce,
-        ...LOCAL_L2_DEPLOY_FEE_OVERRIDES,
-      },
-    ),
-    deployContractFromArtifacts(ProxyAdminContractName, ProxyAdminAbi, ProxyAdminBytecode, wallet, {
-      nonce: walletNonce + 1,
-      ...LOCAL_L2_DEPLOY_FEE_OVERRIDES,
-    }),
-  ]);
+  const l2MessageServiceImplementation = await deployContractFromArtifacts(
+    l2MessageServiceContractImplementationName,
+    L2MessageServiceAbi,
+    L2MessageServiceBytecode,
+    wallet,
+    { nonce: walletNonce, ...feeOverrides },
+  );
+  const proxyAdmin = await deployContractFromArtifacts(
+    ProxyAdminContractName,
+    ProxyAdminAbi,
+    ProxyAdminBytecode,
+    wallet,
+    { nonce: walletNonce + 1, ...feeOverrides },
+  );
 
   const proxyAdminAddress = await proxyAdmin.getAddress();
   const l2MessageServiceImplementationAddress = await l2MessageServiceImplementation.getAddress();
@@ -107,7 +106,8 @@ async function main() {
     proxyAdminAddress,
     initializer,
     {
-      ...LOCAL_L2_DEPLOY_FEE_OVERRIDES,
+      nonce: walletNonce + 2,
+      ...feeOverrides,
     },
   );
 }

--- a/contracts/local-deployments-artifacts/deployPlonkVerifierAndLinethRollupV8.ts
+++ b/contracts/local-deployments-artifacts/deployPlonkVerifierAndLinethRollupV8.ts
@@ -96,45 +96,53 @@ async function main() {
   ];
   const roleAddresses = getEnvVarOrDefault("LINETH_ROLLUP_ROLE_ADDRESSES", defaultRoleAddresses);
 
-  const verifierArtifacts = loadArtifactFromDirectory(path.join(__dirname, "./dynamic-artifacts"), verifierName);
+  const verifierArtifacts = loadArtifactFromDirectory(
+    process.env.CONTRACT_DEPLOY_ARTIFACTS_DIR ?? path.join(__dirname, "./dynamic-artifacts"),
+    verifierName,
+  );
 
   const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
 
   const wallet = new ethers.Wallet(process.env.DEPLOYER_PRIVATE_KEY!, provider);
+  const walletNonce = await getDeployNonceFromEnv(wallet, "L1_NONCE");
 
   // The public quickstart can pin local L1 deploy gas for deterministic boot
   // behavior via L1_DEPLOY_GAS_PRICE_WEI; otherwise the provider's fee data is
   // used. resolveOneModelFeeOverrides guarantees a single, complete fee model.
   const feeOverrides = await resolveOneModelFeeOverrides(provider, "L1_DEPLOY_GAS_PRICE_WEI");
 
-  const walletNonce = await getDeployNonceFromEnv(wallet, "L1_NONCE");
-
-  const [verifier, linethRollupImplementation, proxyAdmin, addressFilter] = await Promise.all([
-    deployContractFromArtifacts(verifierName, verifierArtifacts.abi, verifierArtifacts.bytecode, wallet, {
-      nonce: walletNonce,
-      ...feeOverrides,
-    }),
-    deployContractFromArtifacts(linethRollupImplementationName, LinethRollupV8Abi, LinethRollupV8Bytecode, wallet, {
-      nonce: walletNonce + 1,
-      ...feeOverrides,
-    }),
-    deployContractFromArtifacts(ProxyAdminContractName, ProxyAdminAbi, ProxyAdminBytecode, wallet, {
-      nonce: walletNonce + 2,
-      ...feeOverrides,
-    }),
-    deployContractFromArtifacts(
-      AddressFilterContractName,
-      AddressFilterAbi,
-      AddressFilterBytecode,
-      wallet,
-      linethRollupSecurityCouncil,
-      PRECOMPILES_ADDRESSES,
-      {
-        nonce: walletNonce + 3,
-        ...feeOverrides,
-      },
-    ),
-  ]);
+  // Serialize deployments before using the next planned nonce so RPCs never
+  // estimate a transaction with a future nonce.
+  const verifier = await deployContractFromArtifacts(
+    verifierName,
+    verifierArtifacts.abi,
+    verifierArtifacts.bytecode,
+    wallet,
+    { nonce: walletNonce, ...feeOverrides },
+  );
+  const linethRollupImplementation = await deployContractFromArtifacts(
+    linethRollupImplementationName,
+    LinethRollupV8Abi,
+    LinethRollupV8Bytecode,
+    wallet,
+    { nonce: walletNonce + 1, ...feeOverrides },
+  );
+  const proxyAdmin = await deployContractFromArtifacts(
+    ProxyAdminContractName,
+    ProxyAdminAbi,
+    ProxyAdminBytecode,
+    wallet,
+    { nonce: walletNonce + 2, ...feeOverrides },
+  );
+  const addressFilter = await deployContractFromArtifacts(
+    AddressFilterContractName,
+    AddressFilterAbi,
+    AddressFilterBytecode,
+    wallet,
+    linethRollupSecurityCouncil,
+    PRECOMPILES_ADDRESSES,
+    { nonce: walletNonce + 3, ...feeOverrides },
+  );
 
   const [proxyAdminAddress, verifierAddress, linethRollupImplementationAddress, addressFilterAddress] =
     await Promise.all([
@@ -173,10 +181,7 @@ async function main() {
     linethRollupImplementationAddress,
     proxyAdminAddress,
     initializer,
-    {
-      nonce: walletNonce + 4,
-      ...feeOverrides,
-    },
+    { nonce: walletNonce + 4, ...feeOverrides },
   );
 
   const linethRollupAddress = await linethRollupContract.getAddress();
@@ -195,10 +200,7 @@ async function main() {
       MimcAddressAbi,
       MimcAddressFilterBytecode,
       wallet,
-      {
-        nonce: walletNonce + 5,
-        ...feeOverrides,
-      },
+      { nonce: walletNonce + 5, ...feeOverrides },
     );
     const mimcAddress = await mimc.getAddress();
 
@@ -221,10 +223,7 @@ async function main() {
       wallet,
       { libraries: { "src/libraries/Mimc.sol:Mimc": mimcAddress } },
       ...args,
-      {
-        nonce: walletNonce + 6,
-        ...feeOverrides,
-      },
+      { nonce: walletNonce + 6, ...feeOverrides },
     );
 
     const forcedTransactionGatewayAddress = await forcedTransactionGateway.getAddress();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -284,6 +284,34 @@ importers:
         specifier: 'catalog:'
         version: 18.0.0
 
+  contracts/forge-deployer:
+    dependencies:
+      dotenv:
+        specifier: 'catalog:'
+        version: 17.4.2
+      ethers:
+        specifier: 'catalog:'
+        version: 6.17.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    devDependencies:
+      '@lfdt-lineth/eslint-config':
+        specifier: workspace:*
+        version: link:../../ts-libs/eslint-config
+      '@types/node':
+        specifier: 24.13.2
+        version: 24.13.2
+      eslint:
+        specifier: 9.39.4
+        version: 9.39.4(jiti@2.6.1)(supports-color@8.1.1)
+      tsup:
+        specifier: 'catalog:'
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(supports-color@8.1.1)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.4
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
   contracts/integrity-verifier/verifier-core:
     devDependencies:
       '@lfdt-lineth/eslint-config':

--- a/scripts/docker/images.mk
+++ b/scripts/docker/images.mk
@@ -48,6 +48,7 @@ endef
 DOCKER_IMAGE_TARGETS := \
 	docker-build-linea-besu-package \
 	docker-build-coordinator \
+	docker-build-contract-deployer \
 	docker-build-transaction-exclusion-api \
 	docker-build-maru \
 	docker-build-postman \
@@ -99,6 +100,14 @@ docker-build-postman:
 		--dockerfile ./postman/Dockerfile \
 		--context . \
 		--build-arg NATIVE_LIBS_RELEASE_TAG=$(POSTMAN_NATIVE_LIBS_RELEASE_TAG) \
+		--build-arg NODE_VERSION=$(NODE_VERSION)
+
+# .github/workflows/contracts-forge-deployer-build-and-publish.yml
+docker-build-contract-deployer:
+	$(DOCKER_BUILD) \
+		--image-name consensys/lineth-contract-deployer \
+		--dockerfile ./contracts/forge-deployer/Dockerfile \
+		--context . \
 		--build-arg NODE_VERSION=$(NODE_VERSION)
 
 # .github/workflows/prover-build-and-publish.yml


### PR DESCRIPTION
## Summary
- package the four-step dev/test contract deployment flow as `consensys/lineth-contract-deployer`
- persist resource-version-guarded deployment checkpoints and fail closed on chain, nonce, configuration, or bytecode drift
- add immutable-image build, two-chain rerun testing, and high/critical vulnerability scanning

This profile intentionally uses `IntegrationTestTrueVerifier`; production finalization components remain out of scope.

## Test plan
- [x] 32 deployer unit tests
- [x] TypeScript typecheck, package lint, and build
- [x] contracts TypeScript lint
- [x] GitHub Actions validation
- [x] two-chain Docker integration test with zero-balance gas-free L2 signer
- [x] transaction-free rerun with unchanged addresses and nonces
- [x] Trivy HIGH/CRITICAL image scan

Made with [Cursor](https://cursor.com)