### PR TITLE
chore(contracts): add yield manager audit revision

### DIFF
--- a/docs/audits.md
+++ b/docs/audits.md
@@ -34,6 +34,8 @@ Linea Mainnet contracts, and relevant dependencies.
 
 | Round | Component or change | Auditor | Report |
 | --- | --- | --- | --- |
+| Nineth | Yield Manager Revision August 20th 2026 | Consensys Diligence | [Report](https://diligence.security/audits/2025/12/linea-yield-manager/) |
+| Nineth | Yield Manager Revision August 20th 2026 | Cyfrin | [Report](https://github.com/Cyfrin/cyfrin-audit-reports/blob/9293d45a74271fa53213331ecaabda29bf966923/reports/2026-08-20-cyfrin-linea-yield-manager-v2.1.pdf) |
 | Eighth | Forced transactions | Consensys Diligence | [Report](https://diligence.security/audits/2026/02/linea-forced-transactions/) |
 | Eighth | Forced transactions | Cyfrin | [Report](https://github.com/Cyfrin/cyfrin-audit-reports/blob/9397aab67a15854b08eb302722cdebf5ddb3ac3f/reports/2026-06-18-cyfrin-linea-forced-txns-v2.0.pdf) |
 | Seventh | Modularization, pause cooldown, and dynamic chain configuration | Consensys Diligence | [Report](https://diligence.security/audits/2026/02/linea-rollup-update/) |


### PR DESCRIPTION
Adds links to the revised audit reports for the Yield Manager extension on the LineaRollup containing the fix for the synthetic yield report message address.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only inventory of audit report links; no code, contract, or security-logic changes.
> 
> **Overview**
> Adds a ninth audit round to `docs/audits.md` for the Yield Manager revision (August 20th 2026), with Consensys Diligence and Cyfrin report links.
> 
> The Diligence link reuses the existing Yield Manager report URL; Cyfrin points to a new v2.1 PDF.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b27efe1216f7ce80171b293225226f3e1d3206a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->