### PR TITLE
refactor(coordinator): restructure chain params in L2 execution proof request

### DIFF
--- a/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/L2ExecutionProverClient.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/L2ExecutionProverClient.kt
@@ -20,6 +20,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture
 internal class L2ExecutionProofRequestDtoMapper(
   private val programVk: String,
   private val l2MessageServiceAddress: String,
+  private val forkName: String,
 ) : (L2ExecutionProofRequestV1) -> SafeFuture<L2ExecutionProofRequestDto> {
   override fun invoke(request: L2ExecutionProofRequestV1): SafeFuture<L2ExecutionProofRequestDto> {
     val payloads = request.executions.map { executionInfo ->
@@ -48,8 +49,8 @@ internal class L2ExecutionProofRequestDtoMapper(
         chainConfig = ChainConfigDto(
           l2MessageServiceAddress = l2MessageServiceAddress,
           coinbase = request.coinbase,
-          chainId = request.chainConfig.chainId.toLong(),
-          forkName = request.chainConfig.forkName,
+          chainId = request.chainId.toLong(),
+          forkName = forkName,
         ),
         payloads = payloads,
       ),
@@ -99,8 +100,9 @@ class L2ExecutionProverClient(
   private val transport: L2ExecutionProofTransport,
   programVk: String,
   l2MessageServiceAddress: String,
+  forkName: String,
   proofRequestDtoMapper: (L2ExecutionProofRequestV1) -> SafeFuture<L2ExecutionProofRequestDto> =
-    L2ExecutionProofRequestDtoMapper(programVk, l2MessageServiceAddress),
+    L2ExecutionProofRequestDtoMapper(programVk, l2MessageServiceAddress, forkName),
   proofResponseDtoMapper: (L2ExecutionProofResponseDto) -> L2ExecutionProofResponseV1 =
     L2ExecutionProofResponseDtoMapper,
   hashFunction: HashFunction = Sha256HashFunction(),

--- a/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/L2ExecutionProverClient.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/L2ExecutionProverClient.kt
@@ -20,7 +20,6 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture
 internal class L2ExecutionProofRequestDtoMapper(
   private val programVk: String,
   private val l2MessageServiceAddress: String,
-  private val coinbase: String,
 ) : (L2ExecutionProofRequestV1) -> SafeFuture<L2ExecutionProofRequestDto> {
   override fun invoke(request: L2ExecutionProofRequestV1): SafeFuture<L2ExecutionProofRequestDto> {
     val payloads = request.executions.map { executionInfo ->
@@ -48,7 +47,7 @@ internal class L2ExecutionProofRequestDtoMapper(
         parentFtxNumber = request.parentFtxNumber.toLong(),
         chainConfig = ChainConfigDto(
           l2MessageServiceAddress = l2MessageServiceAddress,
-          coinbase = coinbase,
+          coinbase = request.coinbase,
           chainId = request.chainConfig.chainId.toLong(),
           forkName = request.chainConfig.forkName,
         ),
@@ -100,9 +99,8 @@ class L2ExecutionProverClient(
   private val transport: L2ExecutionProofTransport,
   programVk: String,
   l2MessageServiceAddress: String,
-  coinbase: String,
   proofRequestDtoMapper: (L2ExecutionProofRequestV1) -> SafeFuture<L2ExecutionProofRequestDto> =
-    L2ExecutionProofRequestDtoMapper(programVk, l2MessageServiceAddress, coinbase),
+    L2ExecutionProofRequestDtoMapper(programVk, l2MessageServiceAddress),
   proofResponseDtoMapper: (L2ExecutionProofResponseDto) -> L2ExecutionProofResponseV1 =
     L2ExecutionProofResponseDtoMapper,
   hashFunction: HashFunction = Sha256HashFunction(),

--- a/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/RiscvProverClientFactory.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/RiscvProverClientFactory.kt
@@ -17,7 +17,6 @@ class RiscvProverClientFactory(
   private val vertx: Vertx,
   private val config: ProversConfig,
   private val l2MessageServiceAddress: String,
-  private val coinbase: String,
   metricsFacade: MetricsFacade,
 ) {
   private val executionWaitingResponsesMetric = GaugeAggregator()
@@ -66,7 +65,6 @@ class RiscvProverClientFactory(
         "programVk must be configured for the RISC-V execution prover"
       },
       l2MessageServiceAddress = l2MessageServiceAddress,
-      coinbase = coinbase,
     )
   }
 }

--- a/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/RiscvProverClientFactory.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/main/kotlin/lineth/coordinator/clients/prover/riscv/RiscvProverClientFactory.kt
@@ -65,6 +65,9 @@ class RiscvProverClientFactory(
         "programVk must be configured for the RISC-V execution prover"
       },
       l2MessageServiceAddress = l2MessageServiceAddress,
+      forkName = requireNotNull(proverConfig.forkName) {
+        "forkName must be configured for the RISC-V execution prover"
+      },
     )
   }
 }

--- a/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/FileBasedL2ExecutionProverClientTest.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/FileBasedL2ExecutionProverClientTest.kt
@@ -4,6 +4,7 @@ import io.vertx.core.Vertx
 import io.vertx.junit5.VertxExtension
 import linea.domain.BlockIntervalProofIndex
 import lineth.coordinator.clients.prover.FileBasedProverConfig
+import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.FORK_NAME
 import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.L2_EXECUTION_PROGRAM_VK
 import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.L2_MESSAGE_SERVICE_ADDRESS
 import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.fileBasedProverConfig
@@ -50,6 +51,7 @@ class FileBasedL2ExecutionProverClientTest {
       transport = transport,
       programVk = L2_EXECUTION_PROGRAM_VK,
       l2MessageServiceAddress = L2_MESSAGE_SERVICE_ADDRESS,
+      forkName = FORK_NAME,
     )
   }
 
@@ -66,6 +68,7 @@ class FileBasedL2ExecutionProverClientTest {
     val expectedDto = L2ExecutionProofRequestDtoMapper(
       L2_EXECUTION_PROGRAM_VK,
       L2_MESSAGE_SERVICE_ADDRESS,
+      FORK_NAME,
     ).invoke(request).get()
     assertThat(writtenDto).isEqualTo(expectedDto)
   }

--- a/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/FileBasedL2ExecutionProverClientTest.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/FileBasedL2ExecutionProverClientTest.kt
@@ -4,7 +4,6 @@ import io.vertx.core.Vertx
 import io.vertx.junit5.VertxExtension
 import linea.domain.BlockIntervalProofIndex
 import lineth.coordinator.clients.prover.FileBasedProverConfig
-import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.COINBASE
 import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.L2_EXECUTION_PROGRAM_VK
 import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.L2_MESSAGE_SERVICE_ADDRESS
 import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.fileBasedProverConfig
@@ -51,7 +50,6 @@ class FileBasedL2ExecutionProverClientTest {
       transport = transport,
       programVk = L2_EXECUTION_PROGRAM_VK,
       l2MessageServiceAddress = L2_MESSAGE_SERVICE_ADDRESS,
-      coinbase = COINBASE,
     )
   }
 
@@ -68,7 +66,6 @@ class FileBasedL2ExecutionProverClientTest {
     val expectedDto = L2ExecutionProofRequestDtoMapper(
       L2_EXECUTION_PROGRAM_VK,
       L2_MESSAGE_SERVICE_ADDRESS,
-      COINBASE,
     ).invoke(request).get()
     assertThat(writtenDto).isEqualTo(expectedDto)
   }

--- a/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/RestfulL2ExecutionProverClientTest.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/RestfulL2ExecutionProverClientTest.kt
@@ -7,6 +7,7 @@ import io.vertx.core.Vertx
 import io.vertx.junit5.VertxExtension
 import linea.domain.BlockIntervalProofIndex
 import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.CHAIN_ID
+import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.FORK_NAME
 import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.L2_EXECUTION_PROGRAM_VK
 import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.L2_MESSAGE_SERVICE_ADDRESS
 import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.jsonMapper
@@ -59,6 +60,7 @@ class RestfulL2ExecutionProverClientTest {
       transport = transport,
       programVk = L2_EXECUTION_PROGRAM_VK,
       l2MessageServiceAddress = L2_MESSAGE_SERVICE_ADDRESS,
+      forkName = FORK_NAME,
     )
   }
 
@@ -84,6 +86,7 @@ class RestfulL2ExecutionProverClientTest {
     val expectedDto = L2ExecutionProofRequestDtoMapper(
       L2_EXECUTION_PROGRAM_VK,
       L2_MESSAGE_SERVICE_ADDRESS,
+      FORK_NAME,
     ).invoke(request).get()
     assertThat(postedDto).isEqualTo(expectedDto)
   }

--- a/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/RestfulL2ExecutionProverClientTest.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/RestfulL2ExecutionProverClientTest.kt
@@ -7,7 +7,6 @@ import io.vertx.core.Vertx
 import io.vertx.junit5.VertxExtension
 import linea.domain.BlockIntervalProofIndex
 import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.CHAIN_ID
-import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.COINBASE
 import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.L2_EXECUTION_PROGRAM_VK
 import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.L2_MESSAGE_SERVICE_ADDRESS
 import lineth.coordinator.clients.prover.riscv.RiscVProverClientTestFixtures.jsonMapper
@@ -60,7 +59,6 @@ class RestfulL2ExecutionProverClientTest {
       transport = transport,
       programVk = L2_EXECUTION_PROGRAM_VK,
       l2MessageServiceAddress = L2_MESSAGE_SERVICE_ADDRESS,
-      coinbase = COINBASE,
     )
   }
 
@@ -86,7 +84,6 @@ class RestfulL2ExecutionProverClientTest {
     val expectedDto = L2ExecutionProofRequestDtoMapper(
       L2_EXECUTION_PROGRAM_VK,
       L2_MESSAGE_SERVICE_ADDRESS,
-      COINBASE,
     ).invoke(request).get()
     assertThat(postedDto).isEqualTo(expectedDto)
   }

--- a/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProofRequestDtoMapperTest.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProofRequestDtoMapperTest.kt
@@ -1,6 +1,5 @@
 package lineth.coordinator.clients.prover.riscv
 
-import linea.clients.ChainConfig
 import linea.clients.ConflationWitness
 import linea.clients.ExecutionInfo
 import linea.clients.ForcedTransaction
@@ -42,6 +41,7 @@ class RiscVProofRequestDtoMapperTest {
     val dto = L2ExecutionProofRequestDtoMapper(
       programVk,
       l2MessageServiceAddress,
+      forkName,
     ).invoke(request).get()
 
     assertThat(dto).isEqualTo(
@@ -97,6 +97,7 @@ class RiscVProofRequestDtoMapperTest {
       L2ExecutionProofRequestDtoMapper(
         programVk,
         l2MessageServiceAddress,
+        forkName,
       ).invoke(badRequest)
     }
       .isInstanceOf(IllegalArgumentException::class.java)
@@ -297,10 +298,7 @@ class RiscVProofRequestDtoMapperTest {
         ),
       ),
     ),
-    chainConfig = ChainConfig(
-      chainId = chainId.toULong(),
-      forkName = forkName,
-    ),
+    chainId = chainId.toULong(),
     coinbase = coinbase,
     parentFtxRollingHash = ByteArray(32) { 0x1a },
     parentFtxNumber = 8UL,

--- a/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProofRequestDtoMapperTest.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/test/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProofRequestDtoMapperTest.kt
@@ -32,7 +32,7 @@ class RiscVProofRequestDtoMapperTest {
   private val chainId = 59144L
   private val forkName = "Amsterdam"
   private val l2MessageServiceAddress = "0x508ca82df566dcd1b0019d2dedf7e3d6f7ad6dde"
-  private val coinbase = "0x0000000000000000000000000000000000000000"
+  private val coinbase = RiscVProverClientTestFixtures.COINBASE
 
   @Test
   fun `L2ExecutionProofRequestDtoMapper encodes every field`() {
@@ -42,7 +42,6 @@ class RiscVProofRequestDtoMapperTest {
     val dto = L2ExecutionProofRequestDtoMapper(
       programVk,
       l2MessageServiceAddress,
-      coinbase,
     ).invoke(request).get()
 
     assertThat(dto).isEqualTo(
@@ -98,7 +97,6 @@ class RiscVProofRequestDtoMapperTest {
       L2ExecutionProofRequestDtoMapper(
         programVk,
         l2MessageServiceAddress,
-        coinbase,
       ).invoke(badRequest)
     }
       .isInstanceOf(IllegalArgumentException::class.java)
@@ -303,6 +301,7 @@ class RiscVProofRequestDtoMapperTest {
       chainId = chainId.toULong(),
       forkName = forkName,
     ),
+    coinbase = coinbase,
     parentFtxRollingHash = ByteArray(32) { 0x1a },
     parentFtxNumber = 8UL,
   )

--- a/coordinator/clients/prover-client/riscv-client/src/testFixtures/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProverClientTestFixtures.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/testFixtures/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProverClientTestFixtures.kt
@@ -146,6 +146,7 @@ object RiscVProverClientTestFixtures {
 
   fun l2ExecutionProofRequestV1(
     executions: List<ExecutionInfo> = listOf(executionInfo(1000501UL), executionInfo(1000502UL)),
+    coinbase: String = COINBASE,
     parentFtxRollingHash: ByteArray = ByteArray(32) { 1 },
     parentFtxNumber: ULong = 100UL,
   ): L2ExecutionProofRequestV1 = L2ExecutionProofRequestV1(
@@ -153,8 +154,8 @@ object RiscVProverClientTestFixtures {
     chainConfig = ChainConfig(
       chainId = CHAIN_ID.toULong(),
       forkName = FORK_NAME,
-
     ),
+    coinbase = coinbase,
     parentFtxRollingHash = parentFtxRollingHash,
     parentFtxNumber = parentFtxNumber,
   )

--- a/coordinator/clients/prover-client/riscv-client/src/testFixtures/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProverClientTestFixtures.kt
+++ b/coordinator/clients/prover-client/riscv-client/src/testFixtures/kotlin/lineth/coordinator/clients/prover/riscv/RiscVProverClientTestFixtures.kt
@@ -6,7 +6,6 @@ import io.vertx.core.Vertx
 import io.vertx.core.http.HttpVersion
 import io.vertx.core.http.PoolOptions
 import io.vertx.ext.web.client.WebClientOptions
-import linea.clients.ChainConfig
 import linea.clients.ConflationWitness
 import linea.clients.ExecutionInfo
 import linea.clients.ForcedTransaction
@@ -151,10 +150,7 @@ object RiscVProverClientTestFixtures {
     parentFtxNumber: ULong = 100UL,
   ): L2ExecutionProofRequestV1 = L2ExecutionProofRequestV1(
     executions = executions,
-    chainConfig = ChainConfig(
-      chainId = CHAIN_ID.toULong(),
-      forkName = FORK_NAME,
-    ),
+    chainId = CHAIN_ID.toULong(),
     coinbase = coinbase,
     parentFtxRollingHash = parentFtxRollingHash,
     parentFtxNumber = parentFtxNumber,

--- a/coordinator/core-interfaces/src/main/kotlin/linea/clients/L2ExecutionProverRequestResponse.kt
+++ b/coordinator/core-interfaces/src/main/kotlin/linea/clients/L2ExecutionProverRequestResponse.kt
@@ -44,6 +44,7 @@ data class ExecutionInfo(
 data class L2ExecutionProofRequestV1(
   val executions: List<ExecutionInfo>,
   val chainConfig: ChainConfig,
+  val coinbase: String,
   val parentFtxRollingHash: ByteArray,
   val parentFtxNumber: ULong,
 ) : BlockInterval, StartBlockTimestampProvider {
@@ -73,6 +74,7 @@ data class L2ExecutionProofRequestV1(
 
     if (executions != other.executions) return false
     if (chainConfig != other.chainConfig) return false
+    if (coinbase != other.coinbase) return false
     if (!parentFtxRollingHash.contentEquals(other.parentFtxRollingHash)) return false
     if (parentFtxNumber != other.parentFtxNumber) return false
 
@@ -82,6 +84,7 @@ data class L2ExecutionProofRequestV1(
   override fun hashCode(): Int {
     var result = executions.hashCode()
     result = 31 * result + chainConfig.hashCode()
+    result = 31 * result + coinbase.hashCode()
     result = 31 * result + parentFtxRollingHash.contentHashCode()
     result = 31 * result + parentFtxNumber.hashCode()
     return result

--- a/coordinator/core-interfaces/src/main/kotlin/linea/clients/L2ExecutionProverRequestResponse.kt
+++ b/coordinator/core-interfaces/src/main/kotlin/linea/clients/L2ExecutionProverRequestResponse.kt
@@ -43,7 +43,7 @@ data class ExecutionInfo(
 
 data class L2ExecutionProofRequestV1(
   val executions: List<ExecutionInfo>,
-  val chainConfig: ChainConfig,
+  val chainId: ULong,
   val coinbase: String,
   val parentFtxRollingHash: ByteArray,
   val parentFtxNumber: ULong,
@@ -73,7 +73,7 @@ data class L2ExecutionProofRequestV1(
     other as L2ExecutionProofRequestV1
 
     if (executions != other.executions) return false
-    if (chainConfig != other.chainConfig) return false
+    if (chainId != other.chainId) return false
     if (coinbase != other.coinbase) return false
     if (!parentFtxRollingHash.contentEquals(other.parentFtxRollingHash)) return false
     if (parentFtxNumber != other.parentFtxNumber) return false
@@ -83,7 +83,7 @@ data class L2ExecutionProofRequestV1(
 
   override fun hashCode(): Int {
     var result = executions.hashCode()
-    result = 31 * result + chainConfig.hashCode()
+    result = 31 * result + chainId.hashCode()
     result = 31 * result + coinbase.hashCode()
     result = 31 * result + parentFtxRollingHash.contentHashCode()
     result = 31 * result + parentFtxNumber.hashCode()
@@ -116,30 +116,6 @@ data class ForcedTransaction(
     result = 31 * result + deadlineBlockNumber.hashCode()
     result = 31 * result + signedTxRlp.contentHashCode()
     result = 31 * result + acceptance.hashCode()
-    return result
-  }
-}
-
-// References StatelessChainConfig in rollup_spec/src/rollup_spec/block.py
-data class ChainConfig(
-  val chainId: ULong,
-  val forkName: String,
-) {
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (javaClass != other?.javaClass) return false
-
-    other as ChainConfig
-
-    if (chainId != other.chainId) return false
-    if (forkName != other.forkName) return false
-
-    return true
-  }
-
-  override fun hashCode(): Int {
-    var result = chainId.hashCode()
-    result = 31 * result + forkName.hashCode()
     return result
   }
 }

--- a/coordinator/core/src/main/kotlin/lineth/coordination/riscv/execution/L2ExecutionRequestBuilderImpl.kt
+++ b/coordinator/core/src/main/kotlin/lineth/coordination/riscv/execution/L2ExecutionRequestBuilderImpl.kt
@@ -10,6 +10,7 @@ import linea.domain.toBlockParameter
 import linea.domain.toExecutionPayload
 import linea.ethapi.ExecutionWitness
 import linea.ethapi.ExecutionWitnessClient
+import linea.kotlin.encodeHex
 import linea.kotlin.minusCoercingUnderflow
 import lineth.coordination.FtxRollingInfoProvider
 import lineth.coordination.FtxRollingInfoProviderImpl
@@ -54,6 +55,7 @@ class L2ExecutionRequestBuilderImpl(
             )
           },
           chainConfig = chainConfig,
+          coinbase = conflation.blocks.first().miner.encodeHex(),
           parentFtxRollingHash = ftxState.ftxRollingHash,
           parentFtxNumber = ftxState.ftxNumber,
         )

--- a/coordinator/core/src/main/kotlin/lineth/coordination/riscv/execution/L2ExecutionRequestBuilderImpl.kt
+++ b/coordinator/core/src/main/kotlin/lineth/coordination/riscv/execution/L2ExecutionRequestBuilderImpl.kt
@@ -1,6 +1,5 @@
 package lineth.coordination.riscv.execution
 
-import linea.clients.ChainConfig
 import linea.clients.ExecutionInfo
 import linea.clients.ForcedTransaction
 import linea.clients.L2ExecutionProofRequestV1
@@ -22,7 +21,7 @@ class L2ExecutionRequestBuilderImpl(
   private val executionWitnessClient: ExecutionWitnessClient,
   private val forcedTransactionsDao: ForcedTransactionsDao,
   private val ftxRollingInfoProvider: FtxRollingInfoProvider = FtxRollingInfoProviderImpl(forcedTransactionsDao),
-  private val chainConfig: ChainConfig,
+  private val chainId: ULong,
 ) : L2ExecutionRequestBuilder {
 
   override fun build(conflation: BlocksConflation): SafeFuture<L2ExecutionProofRequestV1> {
@@ -54,7 +53,7 @@ class L2ExecutionRequestBuilderImpl(
               forcedTransactions = ftxsByBlock[block.number] ?: emptyList(),
             )
           },
-          chainConfig = chainConfig,
+          chainId = chainId,
           coinbase = conflation.blocks.first().miner.encodeHex(),
           parentFtxRollingHash = ftxState.ftxRollingHash,
           parentFtxNumber = ftxState.ftxNumber,


### PR DESCRIPTION
## Summary

- **Commit 1**: Move `coinbase` from `L2ExecutionProverClient` constructor to `L2ExecutionProofRequestV1`. Coinbase can differ per block, so it belongs on the per-request object rather than being fixed at client construction time. `L2ExecutionRequestBuilderImpl` now derives it from `conflation.blocks.first().miner`.
- **Commit 2**: Remove `ChainConfig` entirely. `chainId` is promoted to a direct field on `L2ExecutionProofRequestV1` (set per conflation by `L2ExecutionRequestBuilderImpl`). `forkName` moves to `L2ExecutionProverClient` / `L2ExecutionProofRequestDtoMapper` constructors, read from `FileBasedProverConfig.forkName` in `RiscvProverClientFactory`.

## Motivation

Coinbase must be per-conflation (not per-client) to support cutting off conflation when the coinbase changes between blocks. Flattening `ChainConfig` removes an unnecessary wrapper — `chainId` is a static property and `forkName` is a per-client/prover property, so grouping them into one object was misleading.

## Test plan

- [ ] `RiscVProofRequestDtoMapperTest` — verifies mapper encodes all fields correctly
- [ ] `FileBasedL2ExecutionProverClientTest` — end-to-end file-based transport
- [ ] `RestfulL2ExecutionProverClientTest` — end-to-end REST transport

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which fields are per-request vs per-prover for proof payloads; incorrect wiring could produce wrong chain config sent to the prover, though the external DTO shape is largely unchanged.
> 
> **Overview**
> **Restructures how chain parameters flow into L2 execution proof requests** so coinbase can vary per conflation and static vs prover-scoped settings are not bundled together.
> 
> `L2ExecutionProofRequestV1` drops nested `ChainConfig` in favor of top-level `chainId` and `coinbase`. The domain `ChainConfig` type is removed. `L2ExecutionRequestBuilderImpl` now takes only `chainId` and sets `coinbase` from the first conflation block’s miner (hex-encoded).
> 
> On the RISC-V prover client side, **coinbase is no longer fixed at client construction**: `RiscvProverClientFactory` no longer accepts `coinbase`, and `L2ExecutionProverClient` / `L2ExecutionProofRequestDtoMapper` take **`forkName`** instead. The mapper still fills `ChainConfigDto` for the prover schema, but **`coinbase` and `chainId` come from the domain request** while **`forkName` comes from prover config** (`FileBasedProverConfig.forkName`, required at factory build time). Tests and fixtures are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60b958e1973a52a587c3394b3e31b343ac7b0533. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->