### PR TITLE
fix: address coordinator review findings (backtesting service & AsyncRetryer)

### DIFF
--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflationbacktesting/ConflationBacktestingService.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflationbacktesting/ConflationBacktestingService.kt
@@ -31,38 +31,90 @@ class ConflationBacktestingService(
   enum class ConflationBacktestingJobStatus {
     IN_PROGRESS,
     COMPLETED,
+    FAILED,
   }
 
   private val jobLifecycleLock = Any()
 
+  // jobIds that have been accepted but whose app is still being constructed. Guarded by [jobLifecycleLock].
+  private val reservedJobIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
   private val completedJobs: MutableSet<String> = ConcurrentHashMap.newKeySet()
+  private val failedJobs: MutableSet<String> = ConcurrentHashMap.newKeySet()
   private val conflationBackTestingApps: MutableMap<String, ConflationBacktestingApp> = ConcurrentHashMap()
 
   fun submitConflationBacktestingJob(conflationBacktestingConfig: ConflationBacktestingConfig): String {
     val jobId = conflationBacktestingConfig.jobId()
-    val app = ConflationBacktestingApp(
-      vertx = vertx,
-      conflationBacktestingAppConfig = conflationBacktestingConfig,
-      mainCoordinatorConfig = configs,
-      httpJsonRpcClientFactory = httpJsonRpcClientFactory,
-      metricsFacade = metricsFacade,
-    )
+    // Accept (or reject) the job id before doing any of the expensive app setup, so a duplicate or
+    // already-completed submission is rejected without running the full construction path for work that
+    // will never be scheduled.
     synchronized(jobLifecycleLock) {
       if (completedJobs.contains(jobId)) {
         throw IllegalArgumentException("Given Conflation backtesting Request with jobId=$jobId is already completed")
       }
-      if (conflationBackTestingApps.putIfAbsent(jobId, app) != null) {
+      if (conflationBackTestingApps.containsKey(jobId) || !reservedJobIds.add(jobId)) {
         throw IllegalArgumentException(
           "Given Conflation backtesting Request with jobId=$jobId is already being processed",
         )
       }
+      // A previously failed job may be resubmitted; clear the terminal state now that it is accepted again.
+      failedJobs.remove(jobId)
     }
+
+    val app = try {
+      ConflationBacktestingApp(
+        vertx = vertx,
+        conflationBacktestingAppConfig = conflationBacktestingConfig,
+        mainCoordinatorConfig = configs,
+        httpJsonRpcClientFactory = httpJsonRpcClientFactory,
+        metricsFacade = metricsFacade,
+      )
+    } catch (error: Throwable) {
+      // Construction failed: release the reservation so the id can be retried.
+      synchronized(jobLifecycleLock) {
+        reservedJobIds.remove(jobId)
+      }
+      throw error
+    }
+
+    synchronized(jobLifecycleLock) {
+      conflationBackTestingApps[jobId] = app
+      reservedJobIds.remove(jobId)
+    }
+
     app.start().thenPeek {
       log.info("Conflation backtesting job started: jobId={}", jobId)
     }.exceptionally { error ->
       log.error("Conflation backtesting job failed: jobId={}, errorMessage={}", jobId, error.message, error)
+      handleFailedJobStart(jobId, app)
     }
     return jobId
+  }
+
+  /**
+   * Handles a failure of [ConflationBacktestingApp.start] by moving the job to a terminal [FAILED] state
+   * and stopping the partially started app, so status checks no longer report it as [IN_PROGRESS] and its
+   * resources are released. Does nothing if the app is no longer the active one for [jobId] (e.g. it was
+   * concurrently stopped), which already removed it and ran [ConflationBacktestingApp.stop].
+   */
+  private fun handleFailedJobStart(jobId: String, app: ConflationBacktestingApp) {
+    val shouldStop = synchronized(jobLifecycleLock) {
+      if (conflationBackTestingApps.remove(jobId, app)) {
+        failedJobs.add(jobId)
+        true
+      } else {
+        false
+      }
+    }
+    if (shouldStop) {
+      app.stop().whenException { error ->
+        log.error(
+          "Error while stopping failed conflation backtesting job: jobId={}, errorMessage={}",
+          jobId,
+          error.message,
+          error,
+        )
+      }
+    }
   }
 
   fun getConflationBacktestingJobStatus(jobId: String): ConflationBacktestingJobStatus {
@@ -70,7 +122,10 @@ class ConflationBacktestingService(
       if (completedJobs.contains(jobId)) {
         return ConflationBacktestingJobStatus.COMPLETED
       }
-      if (conflationBackTestingApps.containsKey(jobId)) {
+      if (failedJobs.contains(jobId)) {
+        return ConflationBacktestingJobStatus.FAILED
+      }
+      if (conflationBackTestingApps.containsKey(jobId) || reservedJobIds.contains(jobId)) {
         return ConflationBacktestingJobStatus.IN_PROGRESS
       }
     }
@@ -129,7 +184,9 @@ class ConflationBacktestingService(
       val appsToShutdown = synchronized(jobLifecycleLock) {
         val apps = conflationBackTestingApps.values.toList()
         conflationBackTestingApps.clear()
+        reservedJobIds.clear()
         completedJobs.clear()
+        failedJobs.clear()
         apps
       }
       SafeFuture.allOf(*appsToShutdown.map { app -> app.stop() }.toTypedArray())

--- a/jvm-libs/generic/extensions/futures/src/main/kotlin/net/consensys/linea/async/AsyncRetryer.kt
+++ b/jvm-libs/generic/extensions/futures/src/main/kotlin/net/consensys/linea/async/AsyncRetryer.kt
@@ -133,15 +133,18 @@ internal class SequentialAsyncActionRetryer<T>(
       remainingTime =
         timeout?.let { it.inWholeMilliseconds - timeElapsedSinceStarted }
       val stopRetrying =
-        if (errorThrowable != null) {
-          stopRetriesOnErrorPredicate(throwable)
-        } else {
-          try {
+        try {
+          if (errorThrowable != null) {
+            stopRetriesOnErrorPredicate(throwable)
+          } else {
             stopRetriesPredicate(result)
-          } catch (predicateError: Throwable) {
-            errorThrowable = predicateError
-            false
           }
+        } catch (predicateError: Throwable) {
+          // A throwing predicate (either success or error variant) must not abort the handle callback
+          // before resultFuture is completed, otherwise the retry operation would hang forever. Record
+          // the failure so the retry logic can eventually complete the outer future exceptionally.
+          errorThrowable = predicateError
+          false
         }
 
       if (errorThrowable != null && timeElapsedSinceStarted >

--- a/jvm-libs/generic/extensions/futures/src/test/kotlin/net/consensys/linea/async/AsyncRetryerTest.kt
+++ b/jvm-libs/generic/extensions/futures/src/test/kotlin/net/consensys/linea/async/AsyncRetryerTest.kt
@@ -112,6 +112,31 @@ class AsyncRetryerTest {
   }
 
   @Test
+  fun `retry should complete exceptionally instead of hanging when stopRetriesOnErrorPredicate throws`(vertx: Vertx) {
+    val callCount = AtomicInteger(0)
+    val future =
+      AsyncRetryer.retry<String>(
+        vertx,
+        backoffDelay = 20.milliseconds,
+        maxRetries = 3,
+        stopRetriesOnErrorPredicate = { throw IllegalStateException("predicate boom") },
+      ) {
+        SafeFuture.failedFuture(RuntimeException("action failure ${callCount.incrementAndGet()}"))
+      }
+
+    runCatching { future.get() }
+
+    assertThat(callCount.get()).isEqualTo(4)
+    assertThat(future)
+      .isCompletedExceptionally
+      .isNotCancelled
+      .failsWithin(2.seconds.toJavaDuration())
+      .withThrowableOfType(ExecutionException::class.java)
+      .withCauseInstanceOf(IllegalStateException::class.java)
+      .withMessageContaining("predicate boom")
+  }
+
+  @Test
   fun `Retryer should retry endlessly if predicate is never met when both timeout and maxRetries are null`(
     vertx: Vertx,
     testContext: VertxTestContext,


### PR DESCRIPTION
Addresses the findings from the coordinator review in #3838.

### Changes
- `ConflationBacktestingService`: reserve the job id before constructing `ConflationBacktestingApp`, so duplicate/completed submissions are rejected without running the expensive setup path.
- `ConflationBacktestingService`: on `start()` failure, move the job to a new terminal `FAILED` status and stop the partially started app instead of leaving it reporting `IN_PROGRESS`.
- `AsyncRetryer`: guard `stopRetriesOnErrorPredicate` with the same try/catch used for `stopRetriesPredicate` so a throwing predicate no longer hangs the retry future. Adds a regression test.

Resolves #3838

Generated with [Claude Code](https://claude.ai/code)