### PR TITLE
fix(misc): adjust CI conditions fixing bugs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -275,7 +275,7 @@ jobs:
         manual-docker-build-and-e2e-tests,
       ]
     # Make this execute for has-changes-requiring-e2e-testing == 'false' so that we can get to the required job @ which is in reusable-run-e2e-tests.yml
-    if: ${{ always() && needs.get-has-changes-requiring-e2e-testing.outputs.has-changes-requiring-e2e-testing == 'false' || needs.docker-build.result == 'success' }}
+    if: ${{ always() && (needs.get-has-changes-requiring-e2e-testing.outputs.has-changes-requiring-e2e-testing == 'false' || needs.docker-build.result == 'success') }}
     concurrency:
       group: run-e2e-tests-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -305,7 +305,7 @@ jobs:
 
   cleanup-deployments:
     needs: [run-e2e-tests]
-    if: ${{ always() && github.event.pull_request.head.repo.fork == false }}
+    if: ${{ always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     permissions:
       contents: read

--- a/.github/workflows/run-smc-tests.yml
+++ b/.github/workflows/run-smc-tests.yml
@@ -59,7 +59,7 @@ jobs:
 
       # Required for hardhat commands due to @nomicfoundation/hardhat-foundry package
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d #v1.8.0
+        uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 #v1.9.1
 
       - name: Compile kzg.node
         run: pnpm -F contracts exec node-gyp --directory=node_modules/c-kzg rebuild # explicitly running rebuild to get the .node file


### PR DESCRIPTION
Guard cleanup-deployments to PR events only and fix run-e2e-tests operator precedence
  - cleanup-deployments: added github.event_name == 'pull_request' guard so the job no longer runs on push to main
  - run-e2e-tests: added explicit parentheses around the || clause to fix operator precedence with always()

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow condition and toolchain pin changes only; no application runtime or security logic is modified.
> 
> **Overview**
> Fixes two GitHub Actions **if** expressions in `main.yml` and bumps the Foundry toolchain used for smart-contract CI.
> 
> **run-e2e-tests** now groups the skip/run logic with explicit parentheses so the job runs only when `always()` is satisfied *and* either e2e is not required or `docker-build` succeeded—avoiding the previous precedence where a successful docker build alone could satisfy the condition.
> 
> **cleanup-deployments** is limited to **pull_request** events (still non-fork), so deployment cleanup no longer runs on pushes to `main` where PR-only fields like `head_ref` are unavailable.
> 
> **run-smc-tests** pins **foundry-toolchain** from v1.8.0 to **v1.9.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40af949ba54d5b36225bce36834d66a1c0e90a1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->