### PR TITLE
refactor(coordinator): extract ForcedTransactionsApp from ConflationAppV1, make invalidity proof service injectable

### DIFF
--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/CoordinatorApp.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/CoordinatorApp.kt
@@ -7,10 +7,12 @@ import io.vertx.micrometer.backends.NoopBackendRegistry
 import io.vertx.sqlclient.SqlClient
 import linea.DisabledService
 import linea.LongRunningService
+import linea.clients.StateManagerV1JsonRpcClient
 import linea.contract.l1.Web3JLinethRollupSmartContractClientReadOnly
 import linea.domain.BlockParameter
 import linea.domain.RetryConfig
 import linea.ethapi.EthLogsSearcherImpl
+import linea.ftx.ForcedTransactionsApp
 import linea.persistence.db.Db
 import linea.persistence.db.PersistenceRetryer
 import linea.web3j.createWeb3jHttpClient
@@ -18,6 +20,11 @@ import linea.web3j.ethapi.createEthApiClient
 import lineth.coordinator.api.Api
 import lineth.coordinator.app.conflation.ConflationAppV1
 import lineth.coordinator.app.conflation.ConflationAppV2
+import lineth.coordinator.app.conflation.TracesClientFactory.createTracesClients
+import lineth.coordinator.app.conflation.TracesClients
+import lineth.coordinator.clients.ForcedTransactionsJsonRpcClient
+import lineth.coordinator.clients.prover.ProverClientFactory
+import lineth.coordinator.config.toJsonRpcRetry
 import lineth.coordinator.app.conflationbacktesting.ConflationBacktestingService
 import lineth.coordinator.config.v2.CoordinatorConfig
 import lineth.coordinator.config.v2.DatabaseConfig
@@ -204,6 +211,106 @@ class CoordinatorApp(
     consistentNumberOfBlocksOnL1 = configs.conflation.consistentNumberOfBlocksOnL1ToWait,
   ).getLastFinalizedBlock().get()
 
+  private val proverClientFactory: ProverClientFactory = ProverClientFactory(
+    vertx = vertx,
+    config = configs.proversConfig,
+    metricsFacade = micrometerMetricsFacade,
+  )
+
+  private val l2EthClientForConflation = createEthApiClient(
+    rpcUrl = configs.conflation.l2Endpoint.toString(),
+    log = LogManager.getLogger("clients.l2.eth.conflation"),
+    requestRetryConfig = configs.conflation.l2RequestRetries,
+    vertx = vertx,
+  )
+
+  private val zkStateClient: StateManagerV1JsonRpcClient = StateManagerV1JsonRpcClient.create(
+    rpcClientFactory = httpJsonRpcClientFactory,
+    endpoints = configs.stateManager.endpoints.map { it.toURI() },
+    maxInflightRequestsPerClient = configs.stateManager.requestLimitPerEndpoint,
+    requestRetry = configs.stateManager.requestRetries.toJsonRpcRetry(),
+    requestTimeout = configs.stateManager.requestTimeout?.inWholeMilliseconds,
+    logger = LogManager.getLogger("clients.StateManagerShomeiClient"),
+  )
+
+  private val tracesClients: TracesClients = createTracesClients(
+    vertx = vertx,
+    rpcClientFactory = httpJsonRpcClientFactory,
+    configs = configs.traces,
+    fallBackTracesCounters = configs.conflation.tracesLimits.emptyTracesCounters,
+  )
+
+  private val forcedTransactionsApp: ForcedTransactionsApp = run {
+    if (configs.forcedTransactions == null || configs.forcedTransactions.disabled) {
+      ForcedTransactionsApp.createDisabled()
+    } else {
+      check(configs.proversConfig.proverA.invalidity != null) {
+        "prover.invalidity config is required for forced transactions feature to work"
+      }
+      val ftxConfig = configs.forcedTransactions
+      val l1EthClient = createEthApiClient(
+        rpcUrl = ftxConfig.l1Endpoint.toString(),
+        log = LogManager.getLogger("clients.l1.eth.ftx"),
+        vertx = vertx,
+        requestRetryConfig = ftxConfig.l1RequestRetries,
+      )
+      val ftxAppConfig = ForcedTransactionsApp.Config(
+        l1PollingInterval = ftxConfig.l1EventScraping.pollingInterval,
+        l1ContractAddress = configs.protocol.l1.contractAddress,
+        l1HighestBlockTag = ftxConfig.l1HighestBlockTag,
+        l1EventSearchBlockChunk = ftxConfig.l1EventScraping.ethLogsSearchBlockChunkSize,
+        l1EventSearchMaxBlockRange = ftxConfig.l1EventScraping.ethLogsSearchMaxBlockRange,
+        ftxSequencerSendingInterval = ftxConfig.processingTickInterval,
+        maxFtxToSendToSequencer = ftxConfig.processingBatchSize,
+        ftxProcessingDelay = ftxConfig.processingDelay,
+        invalidityProofProcessingInterval = ftxConfig.invalidityProofCheckInterval,
+      )
+      val ftxClient = ForcedTransactionsJsonRpcClient(
+        vertx = vertx,
+        rpcClient = httpJsonRpcClientFactory.create(
+          endpoint = ftxConfig.sequencerEndpoint,
+          log = LogManager.getLogger("clients.l2.ftx.sequencer"),
+        ),
+        retryConfig = ftxConfig.sequencerRequestRetries.toJsonRpcRetry(),
+        log = LogManager.getLogger("clients.l2.ftx.sequencer"),
+      )
+      val l1Web3jClient = createWeb3jHttpClient(
+        rpcUrl = ftxConfig.l1Endpoint.toString(),
+        log = LogManager.getLogger("clients.l1.eth.ftx"),
+      )
+      val contractClient = Web3JLinethRollupSmartContractClientReadOnly(
+        contractAddress = configs.protocol.l1.contractAddress,
+        web3j = l1Web3jClient,
+        ethLogsSearcher = EthLogsSearcherImpl(
+          vertx = vertx,
+          ethApiClient = createEthApiClient(
+            web3jClient = l1Web3jClient,
+            requestRetryConfig = ftxConfig.l1RequestRetries,
+            vertx = vertx,
+          ),
+        ),
+        finalizedStateSearchInitialBlockParameter = configs.protocol.l1.contractDeploymentBlockNumber
+          ?: BlockParameter.Tag.EARLIEST,
+      )
+      ForcedTransactionsApp.create(
+        config = ftxAppConfig,
+        vertx = vertx,
+        ftxDao = forcedTransactionsDao,
+        l1EthApiClient = l1EthClient,
+        l2EthApiClient = l2EthClientForConflation,
+        ftxClient = ftxClient,
+        finalizedStateProvider = contractClient,
+        contractVersionProvider = contractClient,
+        invalidityProofClient = proverClientFactory.createInvalidityProofClient(),
+        stateManagerClient = zkStateClient,
+        accountProofClient = zkStateClient,
+        tracesClient = tracesClients.tracesConflationClient,
+        clock = clock,
+        metricsFacade = micrometerMetricsFacade,
+      )
+    }
+  }
+
   private val conflationApp: ConflationAppV1 = ConflationAppV1(
     vertx = vertx,
     clock = clock,
@@ -215,6 +322,11 @@ class CoordinatorApp(
     configs = configs,
     metricsFacade = micrometerMetricsFacade,
     httpJsonRpcClientFactory = httpJsonRpcClientFactory,
+    proverClientFactory = proverClientFactory,
+    l2EthClient = l2EthClientForConflation,
+    zkStateClient = zkStateClient,
+    tracesClients = tracesClients,
+    forcedTransactionsApp = forcedTransactionsApp,
   )
 
   private val conflationAppV2: ConflationAppV2? =
@@ -224,6 +336,7 @@ class CoordinatorApp(
         lastFinalizedBlock = lastFinalizedBlock,
         batchesRepository = batchesRepository,
         configs = configs,
+        forcedTransactionsApp = forcedTransactionsApp,
       )
     } else {
       null
@@ -325,6 +438,7 @@ class CoordinatorApp(
     SafeFuture.completedFuture(Unit)
       .thenCompose { l1FinalizationMonitorApp.start() }
       .thenCompose { conflationApp.start() }
+      .thenCompose { forcedTransactionsApp.start() }
       .thenCompose { conflationAppV2?.start() ?: SafeFuture.completedFuture(Unit) }
       .thenCompose { l1RelayingAppV1.start() }
       .thenCompose { messageAnchoringApp.start() }
@@ -352,6 +466,7 @@ class CoordinatorApp(
             l1RelayingAppV1.stop(),
             api.stop(),
             conflationBacktestingService.stop(),
+            forcedTransactionsApp.stop(),
           )
         }.thenApply {
           LoadBalancingJsonRpcClient.stop()

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/CoordinatorApp.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/CoordinatorApp.kt
@@ -22,10 +22,10 @@ import lineth.coordinator.app.conflation.ConflationAppV1
 import lineth.coordinator.app.conflation.ConflationAppV2
 import lineth.coordinator.app.conflation.TracesClientFactory.createTracesClients
 import lineth.coordinator.app.conflation.TracesClients
+import lineth.coordinator.app.conflationbacktesting.ConflationBacktestingService
 import lineth.coordinator.clients.ForcedTransactionsJsonRpcClient
 import lineth.coordinator.clients.prover.ProverClientFactory
 import lineth.coordinator.config.toJsonRpcRetry
-import lineth.coordinator.app.conflationbacktesting.ConflationBacktestingService
 import lineth.coordinator.config.v2.CoordinatorConfig
 import lineth.coordinator.config.v2.DatabaseConfig
 import lineth.coordinator.config.v2.isEnabled

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/CoordinatorApp.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/CoordinatorApp.kt
@@ -307,6 +307,7 @@ class CoordinatorApp(
         tracesClient = tracesClients.tracesConflationClient,
         clock = clock,
         metricsFacade = micrometerMetricsFacade,
+        riscvCutoverTimestamp = configs.conflation.riscvStartingBlockTimestampInclusive,
       )
     }
   }

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/CoordinatorApp.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/CoordinatorApp.kt
@@ -32,6 +32,8 @@ import lineth.coordinator.config.v2.isEnabled
 import lineth.coordinator.config.v2.logPretty
 import lineth.coordinator.extensions.CoordinatorContext
 import lineth.coordinator.extensions.CoordinatorExtensionFactory
+import lineth.ftx.conflation.ForcedTransactionsInvalidityProofService
+import lineth.ftx.conflation.InvalidityProofAssembler
 import lineth.persistence.DisabledForcedTransactionsDao
 import lineth.persistence.FeeHistoriesPostgresDao
 import lineth.persistence.conflation.AggregationsRepositoryImpl
@@ -56,6 +58,7 @@ import org.apache.logging.log4j.Logger
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 
 class CoordinatorApp(
   private val configs: CoordinatorConfig,
@@ -244,9 +247,6 @@ class CoordinatorApp(
     if (configs.forcedTransactions == null || configs.forcedTransactions.disabled) {
       ForcedTransactionsApp.createDisabled()
     } else {
-      check(configs.proversConfig.proverA.invalidity != null) {
-        "prover.invalidity config is required for forced transactions feature to work"
-      }
       val ftxConfig = configs.forcedTransactions
       val l1EthClient = createEthApiClient(
         rpcUrl = ftxConfig.l1Endpoint.toString(),
@@ -292,6 +292,47 @@ class CoordinatorApp(
         finalizedStateSearchInitialBlockParameter = configs.protocol.l1.contractDeploymentBlockNumber
           ?: BlockParameter.Tag.EARLIEST,
       )
+      val riscvCutoverTimestamp = configs.conflation.riscvStartingBlockTimestampInclusive
+      val lastFinalizedBlockTimestamp: Instant = if (lastFinalizedBlock == 0UL) {
+        Instant.fromEpochSeconds(0)
+      } else {
+        l2EthClientForConflation
+          .ethGetBlockByNumberFullTxs(BlockParameter.fromNumber(lastFinalizedBlock.toLong()))
+          .thenApply { block -> Instant.fromEpochSeconds(block.timestamp.toLong()) }
+          .get()
+      }
+      val ftxInvalidityProofService: LongRunningService = if (
+        riscvCutoverTimestamp != null && lastFinalizedBlockTimestamp >= riscvCutoverTimestamp
+      ) {
+        log.info(
+          "FTX invalidity proof service disabled: already past RISC-V cutover. " +
+            "lastFinalizedBlockTimestamp={}, cutover={}",
+          lastFinalizedBlockTimestamp,
+          riscvCutoverTimestamp,
+        )
+        DisabledService("forced-transactions-invalidity-proof")
+      } else {
+        check(configs.proversConfig.proverA.invalidity != null) {
+          "prover.invalidity config is required for forced transactions feature to work"
+        }
+        val l1EthLogsSearcherForFtx = EthLogsSearcherImpl(vertx = vertx, ethApiClient = l1EthClient)
+        ForcedTransactionsInvalidityProofService(
+          ftxDao = forcedTransactionsDao,
+          invalidityProofAssembler = InvalidityProofAssembler(
+            invalidityProofClient = proverClientFactory.createInvalidityProofClient(),
+            stateManagerClient = zkStateClient,
+            accountProofClient = zkStateClient,
+            ethApiLogsSearcher = l1EthLogsSearcherForFtx,
+            ftxDao = forcedTransactionsDao,
+            tracesClient = tracesClients.tracesConflationClient,
+            contractAddress = configs.protocol.l1.contractAddress,
+            l1EventSearchMaxBlockRange = ftxConfig.l1EventScraping.ethLogsSearchMaxBlockRange,
+          ),
+          vertx = vertx,
+          pollingInterval = ftxConfig.invalidityProofCheckInterval,
+          riscvCutoverTimestamp = riscvCutoverTimestamp,
+        )
+      }
       ForcedTransactionsApp.create(
         config = ftxAppConfig,
         vertx = vertx,
@@ -301,13 +342,9 @@ class CoordinatorApp(
         ftxClient = ftxClient,
         finalizedStateProvider = contractClient,
         contractVersionProvider = contractClient,
-        invalidityProofClient = proverClientFactory.createInvalidityProofClient(),
-        stateManagerClient = zkStateClient,
-        accountProofClient = zkStateClient,
-        tracesClient = tracesClients.tracesConflationClient,
         clock = clock,
         metricsFacade = micrometerMetricsFacade,
-        riscvCutoverTimestamp = configs.conflation.riscvStartingBlockTimestampInclusive,
+        ftxInvalidityProofService = ftxInvalidityProofService,
       )
     }
   }

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppV1.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppV1.kt
@@ -125,7 +125,7 @@ class ConflationAppV1(
       smartContractErrors = configs.smartContractErrors,
       smartContractDeploymentBlockNumber = configs.protocol.l2.contractDeploymentBlockNumber?.number,
     ),
-  private val forcedTransactionsApp: ForcedTransactionsApp = ForcedTransactionsApp.createDisabled(),
+  private val forcedTransactionsApp: ForcedTransactionsApp,
   val lastProcessedBlocks: LastProcessedBlocks = getLastConflatedAndAggregatedBlocks(
     lastFinalizedBlock,
     aggregationsRepository,

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppV1.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppV1.kt
@@ -8,7 +8,6 @@ import linea.contract.l2.L2MessageServiceSmartContractClientReadOnly
 import linea.contract.l2.Web3JL2MessageServiceSmartContractClient
 import linea.domain.BlobRecord
 import linea.domain.BlockHeaderSummary
-import linea.domain.BlockParameter
 import linea.domain.BlocksConflation
 import linea.ethapi.EthApiClient
 import linea.ethapi.EthLogsSearcherImpl

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppV1.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppV1.kt
@@ -4,7 +4,6 @@ import io.vertx.core.Vertx
 import linea.LongRunningService
 import linea.clients.ExecutionProverClientV2
 import linea.clients.StateManagerV1JsonRpcClient
-import linea.contract.l1.Web3JLinethRollupSmartContractClientReadOnly
 import linea.contract.l2.L2MessageServiceSmartContractClientReadOnly
 import linea.contract.l2.Web3JL2MessageServiceSmartContractClient
 import linea.domain.BlobRecord
@@ -53,7 +52,6 @@ import lineth.coordinator.app.conflation.TracesClientFactory.createTracesClients
 import lineth.coordinator.blockcreation.BatchesRepoBasedLastProvenBlockNumberProvider
 import lineth.coordinator.blockcreation.BlockCreationMonitor
 import lineth.coordinator.blockcreation.ConflationTargetCheckpointPauseController
-import lineth.coordinator.clients.ForcedTransactionsJsonRpcClient
 import lineth.coordinator.clients.prover.ProverClientFactory
 import lineth.coordinator.config.toJsonRpcRetry
 import lineth.coordinator.config.v2.CoordinatorConfig
@@ -128,77 +126,7 @@ class ConflationAppV1(
       smartContractErrors = configs.smartContractErrors,
       smartContractDeploymentBlockNumber = configs.protocol.l2.contractDeploymentBlockNumber?.number,
     ),
-  private val forcedTransactionsApp: ForcedTransactionsApp = run {
-    if (configs.forcedTransactions == null || configs.forcedTransactions.disabled) {
-      ForcedTransactionsApp.createDisabled()
-    } else {
-      check(configs.proversConfig.proverA.invalidity != null) {
-        "prover.invalidity config is required for forced transactions feature to work"
-      }
-
-      val ftxConfig = configs.forcedTransactions
-      val l1EthClient = createEthApiClient(
-        rpcUrl = ftxConfig.l1Endpoint.toString(),
-        log = LogManager.getLogger("clients.l1.eth.ftx"),
-        vertx = vertx,
-        requestRetryConfig = ftxConfig.l1RequestRetries,
-      )
-      val config = ForcedTransactionsApp.Config(
-        l1PollingInterval = ftxConfig.l1EventScraping.pollingInterval,
-        l1ContractAddress = configs.protocol.l1.contractAddress,
-        l1HighestBlockTag = configs.forcedTransactions.l1HighestBlockTag,
-        l1EventSearchBlockChunk = ftxConfig.l1EventScraping.ethLogsSearchBlockChunkSize,
-        l1EventSearchMaxBlockRange = ftxConfig.l1EventScraping.ethLogsSearchMaxBlockRange,
-        ftxSequencerSendingInterval = ftxConfig.processingTickInterval,
-        maxFtxToSendToSequencer = ftxConfig.processingBatchSize,
-        ftxProcessingDelay = ftxConfig.processingDelay,
-        invalidityProofProcessingInterval = ftxConfig.invalidityProofCheckInterval,
-      )
-      val ftxClient = ForcedTransactionsJsonRpcClient(
-        vertx = vertx,
-        rpcClient = httpJsonRpcClientFactory.create(
-          endpoint = ftxConfig.sequencerEndpoint,
-          log = LogManager.getLogger("clients.l2.ftx.sequencer"),
-        ),
-        retryConfig = ftxConfig.sequencerRequestRetries.toJsonRpcRetry(),
-        log = LogManager.getLogger("clients.l2.ftx.sequencer"),
-      )
-      val l1Web3jClient = createWeb3jHttpClient(
-        rpcUrl = ftxConfig.l1Endpoint.toString(),
-        log = LogManager.getLogger("clients.l1.eth.ftx"),
-      )
-      val contractClient = Web3JLinethRollupSmartContractClientReadOnly(
-        contractAddress = configs.protocol.l1.contractAddress,
-        web3j = l1Web3jClient,
-        ethLogsSearcher = EthLogsSearcherImpl(
-          vertx = vertx,
-          ethApiClient = createEthApiClient(
-            web3jClient = l1Web3jClient,
-            requestRetryConfig = ftxConfig.l1RequestRetries,
-            vertx = vertx,
-          ),
-        ),
-        finalizedStateSearchInitialBlockParameter = configs.protocol.l1.contractDeploymentBlockNumber
-          ?: BlockParameter.Tag.EARLIEST,
-      )
-      ForcedTransactionsApp.create(
-        config = config,
-        vertx = vertx,
-        ftxDao = forcedTransactionsDao,
-        l1EthApiClient = l1EthClient,
-        l2EthApiClient = l2EthClient,
-        ftxClient = ftxClient,
-        finalizedStateProvider = contractClient,
-        contractVersionProvider = contractClient,
-        invalidityProofClient = proverClientFactory.createInvalidityProofClient(),
-        stateManagerClient = zkStateClient,
-        accountProofClient = zkStateClient,
-        tracesClient = tracesClients.tracesConflationClient,
-        clock = clock,
-        metricsFacade = metricsFacade,
-      )
-    }
-  },
+  private val forcedTransactionsApp: ForcedTransactionsApp = ForcedTransactionsApp.createDisabled(),
   val lastProcessedBlocks: LastProcessedBlocks = getLastConflatedAndAggregatedBlocks(
     lastFinalizedBlock,
     aggregationsRepository,
@@ -574,7 +502,6 @@ class ConflationAppV1(
       .thenCompose { conflationCalculators.service.start() }
       .thenCompose { blockCreationMonitor.start() }
       .thenCompose { blobCompressionProofCoordinator.start() }
-      .thenCompose { forcedTransactionsApp.start() }
       .thenCompose { provenBlockNumberMonitor.start() }
       .thenPeek {
         log.info("Conflation started")
@@ -588,7 +515,6 @@ class ConflationAppV1(
       blockCreationMonitor.stop(),
       conflationCalculators.service.stop(),
       blobCompressionProofCoordinator.stop(),
-      forcedTransactionsApp.stop(),
       provenBlockNumberMonitor.stop(),
     )
       .thenCompose { requestFileCleanup.cleanup() }

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppV2.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppV2.kt
@@ -5,6 +5,7 @@ import linea.LongRunningService
 import linea.domain.Block
 import linea.domain.BlockParameter
 import linea.ethapi.EthApiClient
+import linea.ftx.ForcedTransactionsApp
 import linea.web3j.ethapi.createEthApiClient
 import lineth.coordination.blockcreation.BlockCreationListener
 import lineth.coordinator.blockcreation.BatchesRepoBasedLastProvenBlockNumberProvider
@@ -30,6 +31,7 @@ class ConflationAppV2(
   private val lastFinalizedBlock: ULong,
   private val batchesRepository: BatchesRepository,
   private val configs: CoordinatorConfig,
+  val forcedTransactionsApp: ForcedTransactionsApp = ForcedTransactionsApp.createDisabled(),
 ) : LongRunningService {
 
   private val log = LogManager.getLogger(ConflationAppV2::class.java)

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppV2.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppV2.kt
@@ -31,7 +31,7 @@ class ConflationAppV2(
   private val lastFinalizedBlock: ULong,
   private val batchesRepository: BatchesRepository,
   private val configs: CoordinatorConfig,
-  val forcedTransactionsApp: ForcedTransactionsApp = ForcedTransactionsApp.createDisabled(),
+  val forcedTransactionsApp: ForcedTransactionsApp,
 ) : LongRunningService {
 
   private val log = LogManager.getLogger(ConflationAppV2::class.java)

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/ForcedTransactionsApp.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/ForcedTransactionsApp.kt
@@ -82,6 +82,7 @@ interface ForcedTransactionsApp : LongRunningService {
       tracesClient: TracesConflationVirtualBlockClientV1,
       clock: Clock,
       metricsFacade: MetricsFacade,
+      riscvCutoverTimestamp: Instant? = null,
     ): ForcedTransactionsApp {
       val l1EthLogsSearcher = EthLogsSearcherImpl(vertx = vertx, ethApiClient = l1EthApiClient)
       val ftxInvalidityProofService = ForcedTransactionsInvalidityProofService(
@@ -98,6 +99,7 @@ interface ForcedTransactionsApp : LongRunningService {
         ),
         vertx = vertx,
         pollingInterval = config.invalidityProofProcessingInterval,
+        riscvCutoverTimestamp = riscvCutoverTimestamp,
       )
       return ForcedTransactionsAppImpl(
         config = config,

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/ForcedTransactionsApp.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/ForcedTransactionsApp.kt
@@ -82,6 +82,49 @@ interface ForcedTransactionsApp : LongRunningService {
       tracesClient: TracesConflationVirtualBlockClientV1,
       clock: Clock,
       metricsFacade: MetricsFacade,
+    ): ForcedTransactionsApp {
+      val l1EthLogsSearcher = EthLogsSearcherImpl(vertx = vertx, ethApiClient = l1EthApiClient)
+      val ftxInvalidityProofService = ForcedTransactionsInvalidityProofService(
+        ftxDao = ftxDao,
+        invalidityProofAssembler = InvalidityProofAssembler(
+          invalidityProofClient = invalidityProofClient,
+          stateManagerClient = stateManagerClient,
+          accountProofClient = accountProofClient,
+          ethApiLogsSearcher = l1EthLogsSearcher,
+          ftxDao = ftxDao,
+          tracesClient = tracesClient,
+          contractAddress = config.l1ContractAddress,
+          l1EventSearchMaxBlockRange = config.l1EventSearchMaxBlockRange,
+        ),
+        vertx = vertx,
+        pollingInterval = config.invalidityProofProcessingInterval,
+      )
+      return ForcedTransactionsAppImpl(
+        config = config,
+        vertx = vertx,
+        l1EthApiClient = l1EthApiClient,
+        l2EthApiClient = l2EthApiClient,
+        finalizedStateProvider = finalizedStateProvider,
+        contractVersionProvider = contractVersionProvider,
+        ftxClient = ftxClient,
+        ftxDao = ftxDao,
+        clock = clock,
+        metricsFacade = metricsFacade,
+        ftxInvalidityProofService = ftxInvalidityProofService,
+      )
+    }
+
+    fun createWithoutInvalidityProofs(
+      config: Config,
+      vertx: Vertx,
+      l1EthApiClient: EthApiClient,
+      l2EthApiClient: EthApiClient,
+      finalizedStateProvider: LinethRollupSmartContractClientReadOnlyFinalizedStateProvider,
+      contractVersionProvider: ContractVersionProvider<LinethRollupContractVersion>,
+      ftxClient: ForcedTransactionsClient,
+      ftxDao: ForcedTransactionsDao,
+      clock: Clock,
+      metricsFacade: MetricsFacade,
     ): ForcedTransactionsApp = ForcedTransactionsAppImpl(
       config = config,
       vertx = vertx,
@@ -91,10 +134,6 @@ interface ForcedTransactionsApp : LongRunningService {
       contractVersionProvider = contractVersionProvider,
       ftxClient = ftxClient,
       ftxDao = ftxDao,
-      invalidityProofClient = invalidityProofClient,
-      stateManagerClient = stateManagerClient,
-      accountProofClient = accountProofClient,
-      tracesClient = tracesClient,
       clock = clock,
       metricsFacade = metricsFacade,
     )
@@ -120,14 +159,12 @@ internal class ForcedTransactionsAppImpl(
   private val contractVersionProvider: ContractVersionProvider<LinethRollupContractVersion>,
   private val ftxClient: ForcedTransactionsClient,
   private val ftxDao: ForcedTransactionsDao,
-  private val invalidityProofClient: InvalidityProverClientV1,
-  private val stateManagerClient: StateManagerClientV1,
-  private val accountProofClient: StateManagerAccountProofClient,
-  private val tracesClient: TracesConflationVirtualBlockClientV1,
   private val clock: Clock,
   private val metricsFacade: MetricsFacade,
   safeBlockNumberProvider: ForcedTransactionConflationSafeBlockNumberProvider =
     ForcedTransactionConflationSafeBlockNumberProvider(),
+  private val ftxInvalidityProofService: LongRunningService =
+    DisabledService("forced-transactions-invalidity-proof"),
 ) : ForcedTransactionsApp {
   private val log = LogManager.getLogger(ForcedTransactionsAppImpl::class.java)
   private val l1EthLogsSearcher: EthLogsSearcher = EthLogsSearcherImpl(
@@ -152,22 +189,6 @@ internal class ForcedTransactionsAppImpl(
   override val conflationCalculator: ConflationTriggerCalculator = ConflationCalculatorByForcedTransaction(
     processedFtxQueue = conflationFtxQueue,
   )
-  private val ftxInvalidityProofService = ForcedTransactionsInvalidityProofService(
-    ftxDao = ftxDao,
-    invalidityProofAssembler = InvalidityProofAssembler(
-      invalidityProofClient = invalidityProofClient,
-      stateManagerClient = stateManagerClient,
-      accountProofClient = accountProofClient,
-      ethApiLogsSearcher = l1EthLogsSearcher,
-      ftxDao = ftxDao,
-      tracesClient = tracesClient,
-      contractAddress = config.l1ContractAddress,
-      l1EventSearchMaxBlockRange = config.l1EventSearchMaxBlockRange,
-    ),
-    vertx = vertx,
-    pollingInterval = config.invalidityProofProcessingInterval,
-  )
-
   override fun start(): CompletableFuture<Unit> {
     log.info("starting ForcedTransactionsApp")
     return contractVersionProvider

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/ForcedTransactionsApp.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/ForcedTransactionsApp.kt
@@ -4,10 +4,6 @@ import io.vertx.core.Vertx
 import linea.DisabledService
 import linea.EthLogsSearcher
 import linea.LongRunningService
-import linea.clients.InvalidityProverClientV1
-import linea.clients.StateManagerAccountProofClient
-import linea.clients.StateManagerClientV1
-import linea.clients.TracesConflationVirtualBlockClientV1
 import linea.contract.Web3JContractVersionAwaiter
 import linea.contract.events.ForcedTransactionAddedEvent
 import linea.contract.l1.ContractVersionProvider
@@ -25,10 +21,8 @@ import lineth.conflation.calculators.ConflationTriggerCalculator
 import lineth.conflation.calculators.ConflationTriggerCalculatorByTargetBlockNumbers
 import lineth.ftx.conflation.ConflationCalculatorByForcedTransaction
 import lineth.ftx.conflation.ForcedTransactionConflationSafeBlockNumberProvider
-import lineth.ftx.conflation.ForcedTransactionsInvalidityProofService
 import lineth.ftx.conflation.ForcedTransactionsSafeBlockNumberManager
 import lineth.ftx.conflation.FtxConflationInfo
-import lineth.ftx.conflation.InvalidityProofAssembler
 import lineth.persistence.ForcedTransactionsDao
 import net.consensys.linea.metrics.MetricsFacade
 import org.apache.logging.log4j.LogManager
@@ -76,57 +70,9 @@ interface ForcedTransactionsApp : LongRunningService {
       contractVersionProvider: ContractVersionProvider<LinethRollupContractVersion>,
       ftxClient: ForcedTransactionsClient,
       ftxDao: ForcedTransactionsDao,
-      invalidityProofClient: InvalidityProverClientV1,
-      stateManagerClient: StateManagerClientV1,
-      accountProofClient: StateManagerAccountProofClient,
-      tracesClient: TracesConflationVirtualBlockClientV1,
       clock: Clock,
       metricsFacade: MetricsFacade,
-      riscvCutoverTimestamp: Instant? = null,
-    ): ForcedTransactionsApp {
-      val l1EthLogsSearcher = EthLogsSearcherImpl(vertx = vertx, ethApiClient = l1EthApiClient)
-      val ftxInvalidityProofService = ForcedTransactionsInvalidityProofService(
-        ftxDao = ftxDao,
-        invalidityProofAssembler = InvalidityProofAssembler(
-          invalidityProofClient = invalidityProofClient,
-          stateManagerClient = stateManagerClient,
-          accountProofClient = accountProofClient,
-          ethApiLogsSearcher = l1EthLogsSearcher,
-          ftxDao = ftxDao,
-          tracesClient = tracesClient,
-          contractAddress = config.l1ContractAddress,
-          l1EventSearchMaxBlockRange = config.l1EventSearchMaxBlockRange,
-        ),
-        vertx = vertx,
-        pollingInterval = config.invalidityProofProcessingInterval,
-        riscvCutoverTimestamp = riscvCutoverTimestamp,
-      )
-      return ForcedTransactionsAppImpl(
-        config = config,
-        vertx = vertx,
-        l1EthApiClient = l1EthApiClient,
-        l2EthApiClient = l2EthApiClient,
-        finalizedStateProvider = finalizedStateProvider,
-        contractVersionProvider = contractVersionProvider,
-        ftxClient = ftxClient,
-        ftxDao = ftxDao,
-        clock = clock,
-        metricsFacade = metricsFacade,
-        ftxInvalidityProofService = ftxInvalidityProofService,
-      )
-    }
-
-    fun createWithoutInvalidityProofs(
-      config: Config,
-      vertx: Vertx,
-      l1EthApiClient: EthApiClient,
-      l2EthApiClient: EthApiClient,
-      finalizedStateProvider: LinethRollupSmartContractClientReadOnlyFinalizedStateProvider,
-      contractVersionProvider: ContractVersionProvider<LinethRollupContractVersion>,
-      ftxClient: ForcedTransactionsClient,
-      ftxDao: ForcedTransactionsDao,
-      clock: Clock,
-      metricsFacade: MetricsFacade,
+      ftxInvalidityProofService: LongRunningService = DisabledService("forced-transactions-invalidity-proof"),
     ): ForcedTransactionsApp = ForcedTransactionsAppImpl(
       config = config,
       vertx = vertx,
@@ -138,6 +84,7 @@ interface ForcedTransactionsApp : LongRunningService {
       ftxDao = ftxDao,
       clock = clock,
       metricsFacade = metricsFacade,
+      ftxInvalidityProofService = ftxInvalidityProofService,
     )
   }
 }

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/ForcedTransactionsApp.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/ForcedTransactionsApp.kt
@@ -72,7 +72,7 @@ interface ForcedTransactionsApp : LongRunningService {
       ftxDao: ForcedTransactionsDao,
       clock: Clock,
       metricsFacade: MetricsFacade,
-      ftxInvalidityProofService: LongRunningService = DisabledService("forced-transactions-invalidity-proof"),
+      ftxInvalidityProofService: LongRunningService,
     ): ForcedTransactionsApp = ForcedTransactionsAppImpl(
       config = config,
       vertx = vertx,
@@ -112,8 +112,7 @@ internal class ForcedTransactionsAppImpl(
   private val metricsFacade: MetricsFacade,
   safeBlockNumberProvider: ForcedTransactionConflationSafeBlockNumberProvider =
     ForcedTransactionConflationSafeBlockNumberProvider(),
-  private val ftxInvalidityProofService: LongRunningService =
-    DisabledService("forced-transactions-invalidity-proof"),
+  private val ftxInvalidityProofService: LongRunningService,
 ) : ForcedTransactionsApp {
   private val log = LogManager.getLogger(ForcedTransactionsAppImpl::class.java)
   private val l1EthLogsSearcher: EthLogsSearcher = EthLogsSearcherImpl(

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/lineth/ftx/conflation/ForcedTransactionsInvalidityProofService.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/lineth/ftx/conflation/ForcedTransactionsInvalidityProofService.kt
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.Logger
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 
 /**
  * Coordinates forced transaction processing with invalidity proof generation.
@@ -26,6 +27,7 @@ class ForcedTransactionsInvalidityProofService(
   vertx: Vertx,
   pollingInterval: Duration = 5.seconds,
   log: Logger = LogManager.getLogger(ForcedTransactionsInvalidityProofService::class.java),
+  private val riscvCutoverTimestamp: Instant? = null,
 ) : VertxPeriodicPollingService(
   vertx = vertx,
   pollingIntervalMs = pollingInterval.inWholeMilliseconds,
@@ -42,6 +44,7 @@ class ForcedTransactionsInvalidityProofService(
       .thenCompose { allFtxInDb ->
         val requestFutures = allFtxInDb
           .filter { it.proofStatus == ForcedTransactionRecord.ProofStatus.UNREQUESTED }
+          .filter { riscvCutoverTimestamp == null || it.simulatedExecutionBlockTimestamp < riscvCutoverTimestamp }
           .map { ftxRecord ->
             invalidityProofAssembler
               .requestInvalidityProof(ftxRecord)

--- a/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/ForcedTransactionsAppTest.kt
+++ b/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/ForcedTransactionsAppTest.kt
@@ -3,10 +3,7 @@ package linea.ftx
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.vertx.core.Vertx
 import io.vertx.junit5.VertxExtension
-import linea.clients.InvalidityProverClientV1
-import linea.clients.StateManagerAccountProofClient
-import linea.clients.StateManagerClientV1
-import linea.clients.TracesConflationVirtualBlockClientV1
+import linea.DisabledService
 import linea.contract.events.FactoryForcedTransactionAddedEvent
 import linea.contract.events.FinalizedStateUpdatedEvent
 import linea.contract.events.ForcedTransactionAddedEvent
@@ -30,7 +27,6 @@ import lineth.conflation.FixedLaggingHeadSafeBlockProvider
 import lineth.conflation.calculators.CalculatorsFactory
 import lineth.conflation.calculators.ConflationTriggerCalculator
 import lineth.coordination.blob.FakeBlobCompressor
-import lineth.coordinator.clients.FakeTracesConflationVirtualBlockClientV1
 import lineth.ftx.conflation.ForcedTransactionConflationSafeBlockNumberProvider
 import lineth.ftx.conflation.SafeBlockNumberUpdateListener
 import lineth.persistence.ForcedTransactionRecord
@@ -72,10 +68,6 @@ class ForcedTransactionsAppTest {
   private lateinit var fxtDao: ForcedTransactionsDao
   private lateinit var fakeContractClient: FakeLinethRollupSmartContractClient
   private val fakeClock = FakeFixedClock(Instant.parse("2025-01-01T00:00:00Z"))
-  private lateinit var invalidityProofClient: InvalidityProverClientV1
-  private lateinit var stateManagerClient: StateManagerClientV1
-  private lateinit var accountProofClient: StateManagerAccountProofClient
-  private lateinit var tracesClient: TracesConflationVirtualBlockClientV1
 
   @BeforeEach
   fun setUp(vertx: Vertx) {
@@ -105,13 +97,6 @@ class ForcedTransactionsAppTest {
       contractVersion = LinethRollupContractVersion.V8,
     )
     this.fxtDao = FakeForcedTransactionsDao()
-    this.tracesClient = FakeTracesConflationVirtualBlockClientV1()
-    this.invalidityProofClient = FakeInvalidityProverClient()
-    FakeStateManagerClient()
-      .also {
-        this.stateManagerClient = it
-        this.accountProofClient = it
-      }
   }
 
   private fun createApp(
@@ -142,13 +127,10 @@ class ForcedTransactionsAppTest {
       ftxClient = this.ftxClient,
       ftxDao = this.fxtDao,
       l2EthApiClient = this.l2Client,
-      invalidityProofClient = this.invalidityProofClient,
-      stateManagerClient = this.stateManagerClient,
-      accountProofClient = this.accountProofClient,
-      tracesClient = this.tracesClient,
       clock = fakeClock,
       metricsFacade = metricsFacade,
       safeBlockNumberProvider = ForcedTransactionConflationSafeBlockNumberProvider(listener = safeBlockTracker),
+      ftxInvalidityProofService = DisabledService("forced-transactions-invalidity-proof"),
     )
   }
 


### PR DESCRIPTION
## Summary

- **Make `ftxInvalidityProofService` injectable in `ForcedTransactionsAppImpl`** — replaces four invalidity-proof client params with a single `ftxInvalidityProofService: LongRunningService` (defaults to `DisabledService`).
- **Add `ForcedTransactionsApp.create()`** — factory method that builds `ForcedTransactionsInvalidityProofService` and passes it to `ForcedTransactionsAppImpl`. Removes the old `createWithoutInvalidityProofs()`.
- **Move `ForcedTransactionsApp` lifecycle to `CoordinatorApp`** so both `ConflationAppV1` and `ConflationAppV2` share a single FTX instance (avoids duplicate L1 scrapers and competing safe-block-number managers). Shared upstream clients (`proverClientFactory`, `l2EthClientForConflation`, `zkStateClient`, `tracesClients`) are created in `CoordinatorApp` and injected into both conflation apps.
- **Runtime no-op filter** in `ForcedTransactionsInvalidityProofService` — records with `simulatedExecutionBlockTimestamp >= riscvCutoverTimestamp` are skipped, so the service becomes a no-op as V2 blocks start arriving during the V1→V2 transition.
- **At-startup check** in `CoordinatorApp` — on restart, fetches the last-finalized L2 block timestamp; if it is already past `riscvCutoverTimestamp`, injects `DisabledService` directly (no invalidity prover config needed post-cutover).

Both guards coexist: the runtime filter handles the live V1→V2 transition; the at-startup check handles post-cutover restarts where the service would be permanently idle anyway.

## Test plan

- [ ] Compile: `./gradlew :coordinator:app:compileKotlin :coordinator:ethereum:forced-transactions:compileKotlin`
- [ ] Spotless: `./gradlew :coordinator:app:spotlessCheck :coordinator:ethereum:forced-transactions:spotlessCheck`
- [ ] FTX disabled config: `forcedTransactions` null or `disabled=true` → `ForcedTransactionsApp.createDisabled()` (no change)
- [ ] FTX enabled, pre-RISC-V restart: `lastFinalizedBlockTimestamp < riscvCutoverTimestamp` → `ForcedTransactionsInvalidityProofService` built with `riscvCutoverTimestamp` filter
- [ ] FTX enabled, post-RISC-V restart: `lastFinalizedBlockTimestamp >= riscvCutoverTimestamp` → `DisabledService` injected, `prover.invalidity` config not required
- [ ] FTX enabled, no RISC-V config: `riscvStartingBlockTimestampInclusive = null` → invalidity proof service runs without filter (V1-only behaviour unchanged)
- [ ] V1 + V2 both running: both share the same `ForcedTransactionsApp` instance; FTX lifecycle is managed by `CoordinatorApp` (outlives `ConflationAppV1`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes FTX lifecycle, shared safe-block semantics, and invalidity-proof eligibility across the V1/V2 cutover; mis-timed disable or duplicate instances could affect conflation cuts and L1 finalization, but behavior is guarded by cutover timestamp checks.
> 
> **Overview**
> **Centralizes forced-transactions (FTX) wiring in `CoordinatorApp`** so `ConflationAppV1` and `ConflationAppV2` share one `ForcedTransactionsApp` instance. Shared upstream clients (`proverClientFactory`, L2 eth client, state manager, traces) are built once in `CoordinatorApp` and passed into V1 conflation; FTX **start/stop** runs in `CoordinatorApp` instead of inside `ConflationAppV1`.
> 
> **Refactors invalidity-proof handling**: `ForcedTransactionsApp.create()` no longer takes four prover/state/traces clients; it accepts a single injectable `ftxInvalidityProofService`. `CoordinatorApp` either builds `ForcedTransactionsInvalidityProofService` (with prover invalidity config) or `DisabledService` when the chain is already past the RISC-V cutover (based on last-finalized L2 block timestamp vs `riscvStartingBlockTimestampInclusive`).
> 
> **RISC-V transition guards**: `ForcedTransactionsInvalidityProofService` skips FTX whose `simulatedExecutionBlockTimestamp` is at or after the cutover, so invalidity proofs taper off during the live V1→V2 transition while the at-startup check avoids requiring invalidity prover config on post-cutover restarts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 020f4023dbb43728df2696ac59aad7d373de312a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->