### PR TITLE
fix(verifier-ray): bug fixes

### DIFF
--- a/.github/workflows/verifier-ray.yml
+++ b/.github/workflows/verifier-ray.yml
@@ -37,7 +37,7 @@ permissions:
 
 env:
   GO_VERSION: '1.25.7'
-  ZKC_VERSION: 'v1.2.27'
+  ZKC_VERSION: 'v1.2.30'
   ZIG_VERSION: '0.16.0'
 
 concurrency:

--- a/verifier-ray/codegen/go.mod
+++ b/verifier-ray/codegen/go.mod
@@ -2,13 +2,13 @@ module github.com/consensys/linea-monorepo/verifier-ray/codegen
 
 go 1.25.7
 
-require github.com/LFDT-Lineth/lineth-monorepo/prover-ray v0.0.0-20260811123635-a88dfd54fad0
+require github.com/LFDT-Lineth/lineth-monorepo/prover-ray v0.0.0-20260827095445-9c51af6cc3b1
 
 require (
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/consensys/gnark v0.14.1-0.20260219004710-bbfb2f70a565 // indirect
-	github.com/consensys/gnark-crypto v0.20.2-0.20260806172022-e2a02f711389 // indirect
+	github.com/consensys/gnark-crypto v0.20.2-0.20260807171631-a71790dd0fe3 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect

--- a/verifier-ray/codegen/go.sum
+++ b/verifier-ray/codegen/go.sum
@@ -1,13 +1,13 @@
-github.com/LFDT-Lineth/lineth-monorepo/prover-ray v0.0.0-20260811123635-a88dfd54fad0 h1:yNY/K9xaiVEh33G8O+A8VaZqN5Ac7b2YdC8y9V74FNQ=
-github.com/LFDT-Lineth/lineth-monorepo/prover-ray v0.0.0-20260811123635-a88dfd54fad0/go.mod h1:68nFvO0Fy0oBJM/ssYjlExChHkM1aJWt3UiK66Z3Mzs=
+github.com/LFDT-Lineth/lineth-monorepo/prover-ray v0.0.0-20260827095445-9c51af6cc3b1 h1:7jkMwDOucHpfrvdBJQq5+HU8TLJe4EGHb1K3v0OJ8Ns=
+github.com/LFDT-Lineth/lineth-monorepo/prover-ray v0.0.0-20260827095445-9c51af6cc3b1/go.mod h1:+ZCrSWb2pdQMZgYTRvbiYBY8kXxSSdSsUAk0jpj5x78=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/consensys/gnark v0.14.1-0.20260219004710-bbfb2f70a565 h1:NlOAmbLYsVb/hcuOBxza6CAA+233tB0eFiunGVEMyv4=
 github.com/consensys/gnark v0.14.1-0.20260219004710-bbfb2f70a565/go.mod h1:EoWWbEboQRydCqJDSA7zrFxucIeoy/5R+MDx04oFpF4=
-github.com/consensys/gnark-crypto v0.20.2-0.20260806172022-e2a02f711389 h1:Tv/RvAXh6IhI9wNipgUTdY1KFDgsDA/hb+6sucFEbjw=
-github.com/consensys/gnark-crypto v0.20.2-0.20260806172022-e2a02f711389/go.mod h1:aODe15M1eN2z4gLryLOSZ0rx6DgrahcIw8TuzPurR1c=
+github.com/consensys/gnark-crypto v0.20.2-0.20260807171631-a71790dd0fe3 h1:+3Q/7HTCH/PCQknIIOGUbwbowgCPWd2JZFIiiy9+eeM=
+github.com/consensys/gnark-crypto v0.20.2-0.20260807171631-a71790dd0fe3/go.mod h1:aODe15M1eN2z4gLryLOSZ0rx6DgrahcIw8TuzPurR1c=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fxamacker/cbor/v2 v2.9.1 h1:2rWm8B193Ll4VdjsJY28jxs70IdDsHRWgQYAI80+rMQ=

--- a/verifier-ray/codegen/vanishing_test.go
+++ b/verifier-ray/codegen/vanishing_test.go
@@ -196,7 +196,7 @@ func TestExprNodeLiteralRendersLagrangeSelector(t *testing.T) {
 
 func TestExprNodeLiteralRendersZeroConstant(t *testing.T) {
 	got := exprNodeLiteral(ExprNode{Kind: ExprConstant})
-	want := ".{ .constant = field.Element.init(0) },"
+	want := ".{ .constant = .{ .value = 0 } },"
 	if got != want {
 		t.Fatalf("exprNodeLiteral(zero constant) = %q, want %q", got, want)
 	}

--- a/verifier-ray/codegen/vanishing_zig.go
+++ b/verifier-ray/codegen/vanishing_zig.go
@@ -174,7 +174,7 @@ func exprNodeLiteral(expr ExprNode) string {
 	case ExprCoinValue:
 		return fmt.Sprintf(".{ .coin_value = %d }, // coin: \"%s\"", expr.Coin.FlatIndex, ZigString(expr.Coin.SourceName))
 	case ExprConstant:
-		return fmt.Sprintf(".{ .constant = field.Element.init(%d) },", expr.Constant.Uint64())
+		return fmt.Sprintf(".{ .constant = .{ .value = %d } },", expr.Constant.Uint64())
 	case ExprOp:
 		return fmt.Sprintf(".{ .op = .{ .operator = .%s, .operands = &%s } },", expr.Operator, IntSlice(expr.Operands))
 	case ExprLagrangeSelector:

--- a/verifier-ray/src/query/logderivativesum.zig
+++ b/verifier-ray/src/query/logderivativesum.zig
@@ -36,6 +36,9 @@ pub const System = struct {
 };
 
 pub fn verify(comptime system: System, ctx: protocol.Context) (Error || protocol.CellError)!void {
+    comptime {
+        @setEvalBranchQuota(20_000_000);
+    }
     inline for (system.queries) |query| {
         // Σ_i Z_i[n-1], reading each Z endpoint from the transcript. `cell` is
         // bounds-checked: the refs are trusted (comptime System) but the proof's

--- a/verifier-ray/src/query/pcs.zig
+++ b/verifier-ray/src/query/pcs.zig
@@ -31,6 +31,7 @@ pub const Error = merkle.Error || fri.Error || error{
     RowShapeMismatch,
     ConjugateRowShapeMismatch,
     ClaimPointOnQueryPoint,
+    InconsistentAliasedClaim,
     MissingTopLevelAux,
     BoundaryFinalSelfMismatch,
     BoundaryFinalSiblingMismatch,
@@ -771,39 +772,67 @@ fn reconstructQueryValueAt(
         const entry_value: ext.Ext = if (recon.entry_is_ext[i]) row.ext[row_idx] else ext.Ext.lift(row.base[row_idx]);
 
         const shifts = system.columns[recon.entry_col_decl_idx[i]].shifts;
-        var term = ext.Ext.zero();
-        for (shifts, 0..) |shift, k| {
-            const point = shiftedPoint(size_log2, shift, zeta);
-            // Distinct RAW shifts baked at codegen time can alias to the SAME
-            // domain point at a smaller runtime module size (e.g. offsets 0
-            // and -1 both normalize to row 0 when the runtime size is 1).
-            // prover-ray's own RecoverBatchClaims dedupes by the
-            // runtime-normalized shift before ever building the FRI batch, so
-            // an aliasing pair contributes exactly ONE term to the DEEP
-            // quotient sum there. The two (or more) claim cells baked here for
-            // aliasing raw shifts are guaranteed equal by construction (see
-            // wiop.LagrangeEval.evalPolynomials: the shift is applied via
-            // omega_n^k with n the RUNTIME size, so aliasing shifts multiply
-            // the evaluation point by the same root of unity and every prover
-            // computes byte-identical claims for them). Skipping repeats of an
-            // already-seen point here reproduces that same single-term
-            // contribution instead of double-counting it.
-            var already_seen = false;
-            for (shifts[0..k]) |prior_shift| {
-                if (shiftedPoint(size_log2, prior_shift, zeta).eql(point)) {
-                    already_seen = true;
-                    break;
-                }
-            }
-            if (already_seen) continue;
-            const denom = x.sub(point);
-            if (denom.isZero()) return Error.ClaimPointOnQueryPoint;
-            const numerator = entry_value.sub(entry_claims[i][k]);
-            term = term.add(numerator.mul(denom.inverse()));
-        }
+        const term = try entryDeepTerm(shifts, entry_claims[i], entry_value, size_log2, zeta, x);
         value = value.mul(alpha_deep).add(term);
     }
     return value;
+}
+
+/// Sums one entry's DEEP-quotient contribution over its shift schedule:
+/// sum over distinct claim points of (entry_value - claim) / (x - point).
+///
+/// Distinct RAW shifts baked at codegen time can alias to the SAME domain
+/// point at a smaller runtime module size (e.g. offsets 0 and -1 both
+/// normalize to row 0 when the runtime size is 1). prover-ray's own
+/// RecoverBatchClaims dedupes by the runtime-normalized shift before ever
+/// building the FRI batch, so an aliasing group contributes exactly ONE term
+/// to the DEEP quotient sum there. Skipping repeats of an already-seen point
+/// here reproduces that same single-term contribution instead of
+/// double-counting it.
+///
+/// The claims of an aliasing group come from DISTINCT transcript cells, so
+/// before a repeat is skipped it must be equality-bound to the claim that was
+/// kept: only the kept claim is authenticated against the commitment by the
+/// quotient reconstruction, while every cell independently reaches later
+/// consumers (routeClaims routes each raw-shift slot on its own). Skipping an
+/// unequal duplicate would let a malicious prover keep the first claim
+/// consistent with the commitment and route a second, different value into
+/// vanishing. An honest prover always produces equal claims for an aliasing
+/// group (wiop.LagrangeEval.evalPolynomials applies the shift via omega_n^k
+/// with n the RUNTIME size, so aliasing shifts evaluate at the same point);
+/// prover-ray's RecoverBatchClaims enforces the same equality on its side.
+/// Each repeat is compared against the group's first (kept) claim, which
+/// transitively binds the whole group.
+///
+/// pub rather than file-private: the aliasing path needs a module to run at an
+/// aliasing size, which no golden vector currently does, so the adversarial
+/// regression in test/pcs_test.zig drives this function directly.
+pub fn entryDeepTerm(
+    shifts: []const isize,
+    claims: []const ext.Ext,
+    entry_value: ext.Ext,
+    size_log2: u8,
+    zeta: ext.Ext,
+    x: ext.Ext,
+) Error!ext.Ext {
+    var term = ext.Ext.zero();
+    for (shifts, 0..) |shift, k| {
+        const point = shiftedPoint(size_log2, shift, zeta);
+        var already_seen = false;
+        for (shifts[0..k], 0..) |prior_shift, prior_k| {
+            if (shiftedPoint(size_log2, prior_shift, zeta).eql(point)) {
+                if (!claims[prior_k].eql(claims[k])) return Error.InconsistentAliasedClaim;
+                already_seen = true;
+                break;
+            }
+        }
+        if (already_seen) continue;
+        const denom = x.sub(point);
+        if (denom.isZero()) return Error.ClaimPointOnQueryPoint;
+        const numerator = entry_value.sub(claims[k]);
+        term = term.add(numerator.mul(denom.inverse()));
+    }
+    return term;
 }
 
 /// zeta * omega_N^(offset mod N), omega_N the generator of the size-2^size_log2

--- a/verifier-ray/src/query/pcs.zig
+++ b/verifier-ray/src/query/pcs.zig
@@ -268,7 +268,19 @@ pub fn reconstruct(comptime system: System, module_sizes: []const usize) Error!R
                 const n = module_sizes[dyn.index];
                 if (!field.isPowerOfTwo(n)) return Error.NonPowerOfTwoModuleSize;
                 const sz: u8 = @intCast(field.log2PowerOfTwo(n));
-                if (sz < dyn.min_size_log2) return Error.DynamicModuleSizeBelowMinimum;
+                // dyn.min_size_log2 used to reject runtime sizes where two
+                // distinct RAW shifts of this column alias to the same domain
+                // point (e.g. offsets 0 and -1 both normalize to row 0 at
+                // runtime size 1). That rejection was overly conservative: an
+                // honest prover CAN legitimately run a module at an aliasing
+                // size (prover-ray's own RecoverBatchClaims dedupes such
+                // openings into a single FRI claim before batching, and
+                // reconstructQueryValueAt below dedupes the same way when
+                // summing the DEEP quotient), so aliasing sizes are safe to
+                // accept, not just aliasing-completeness gaps to reject. Kept
+                // as a documented field (still emitted by codegen) but no
+                // longer enforced here.
+                _ = dyn.min_size_log2;
                 break :blk sz;
             },
         };
@@ -327,6 +339,7 @@ pub fn reconstruct(comptime system: System, module_sizes: []const usize) Error!R
 /// `shifts.len` (and hence `claim_cells.len`) is fixed at codegen time.
 fn totalClaimSlots(comptime system: System) usize {
     comptime {
+        @setEvalBranchQuota(20_000_000);
         var total: usize = 0;
         for (system.columns) |col| total += col.shifts.len;
         return total;
@@ -761,6 +774,28 @@ fn reconstructQueryValueAt(
         var term = ext.Ext.zero();
         for (shifts, 0..) |shift, k| {
             const point = shiftedPoint(size_log2, shift, zeta);
+            // Distinct RAW shifts baked at codegen time can alias to the SAME
+            // domain point at a smaller runtime module size (e.g. offsets 0
+            // and -1 both normalize to row 0 when the runtime size is 1).
+            // prover-ray's own RecoverBatchClaims dedupes by the
+            // runtime-normalized shift before ever building the FRI batch, so
+            // an aliasing pair contributes exactly ONE term to the DEEP
+            // quotient sum there. The two (or more) claim cells baked here for
+            // aliasing raw shifts are guaranteed equal by construction (see
+            // wiop.LagrangeEval.evalPolynomials: the shift is applied via
+            // omega_n^k with n the RUNTIME size, so aliasing shifts multiply
+            // the evaluation point by the same root of unity and every prover
+            // computes byte-identical claims for them). Skipping repeats of an
+            // already-seen point here reproduces that same single-term
+            // contribution instead of double-counting it.
+            var already_seen = false;
+            for (shifts[0..k]) |prior_shift| {
+                if (shiftedPoint(size_log2, prior_shift, zeta).eql(point)) {
+                    already_seen = true;
+                    break;
+                }
+            }
+            if (already_seen) continue;
             const denom = x.sub(point);
             if (denom.isZero()) return Error.ClaimPointOnQueryPoint;
             const numerator = entry_value.sub(entry_claims[i][k]);

--- a/verifier-ray/src/query/vanishing.zig
+++ b/verifier-ray/src/query/vanishing.zig
@@ -43,7 +43,15 @@ pub const ExprNode = union(enum) {
     coin_value: usize,
     constant: field.Element,
     op: ExprOp,
-    lagrange_selector: usize,
+    // i32, not usize (matching Vanishing.cancelled_positions' own type): a
+    // LagrangeSelector position may be end-relative (negative — -1 is the
+    // module's last row, mirroring prover-ray wiop.LagrangeSelector's own
+    // convention). Codegen resolves a STATIC module's negative position into
+    // [0, size) at codegen time (the size is already known there); a DYNAMIC
+    // module's position is left negative and resolved here at verify time
+    // against the runtime size, since the size isn't known until then. See
+    // evalLagrangeSelector / normalizePosition.
+    lagrange_selector: i32,
 };
 
 pub const Vanishing = struct {
@@ -153,6 +161,15 @@ fn verifyBucket(
     merge_coin: ext.Ext,
     ctx: EvalCtx,
 ) Error!void {
+    // A real (non-synthetic) arithmetization module's bucket can carry many
+    // thousands of vanishing constraints (e.g. a wide opcode-decode module),
+    // comfortably exceeding Zig's default 1000-backwards-branch comptime
+    // budget for the `inline for` below. Mirrors the same raised quota already
+    // used by `query/pcs.zig`'s comptime-heavy loops.
+    comptime {
+        @setEvalBranchQuota(2_000_000);
+    }
+
     // r^n = Z_H(r) + 1, recovered from the annihilator carried in ctx.
     const r_pow_n = ctx.annihilator.add(ext.Ext.one());
     var quotient = ext.Ext.zero();
@@ -194,9 +211,33 @@ const EvalCtx = struct {
     dynamic_n: usize,
 };
 
+// evalExpr/evalOp evaluate a single node of a module's expression tree,
+// identified by a RUNTIME expr_index/op rather than a comptime one.
+//
+// module.expressions is built by codegen (see codegen/vanishing.go's
+// appendExpr) as a post-order flattening of each vanishing constraint's
+// expression tree: every operand is appended, and therefore assigned its
+// index, strictly before the node that references it. So op.operands[i] is
+// always < the node's own index, and recursion here always makes progress
+// toward index 0 (the array's leaves) — there is no cycle.
+//
+// expr_index/op used to be `comptime` parameters. That made Zig monomorphize
+// a distinct evalExpr/evalOp instantiation per unique node ever evaluated —
+// for a real (non-synthetic) RISC-V arithmetization module with thousands of
+// expression nodes, that blew up into a stack overflow (observed as a SIGSEGV
+// inside verifyModule) well before any actual recursion depth problem: the
+// per-tree depth is shallow in practice (a few dozen levels for real modules),
+// but the sheer number of monomorphized node-specific function bodies bloated
+// the generated code and its stack frames. Keeping module/static_n comptime
+// (there are only ~100 modules total, and static_n legitimately folds
+// static-size exponentiation/root-of-unity work at compile time) while making
+// expr_index/op ordinary runtime values gives exactly one evalExpr/evalOp
+// instantiation per module, with recursion depth bounded by that module's
+// actual (shallow) expression-tree depth — eliminating the blowup without
+// changing any evaluation semantics or error behavior.
 fn evalExpr(
     comptime module: Module,
-    comptime expr_index: usize,
+    expr_index: usize,
     comptime static_n: usize,
     ctx: EvalCtx,
     input: CheckInput,
@@ -214,7 +255,7 @@ fn evalExpr(
 
 fn evalOp(
     comptime module: Module,
-    comptime op: ExprOp,
+    op: ExprOp,
     comptime static_n: usize,
     ctx: EvalCtx,
     input: CheckInput,
@@ -242,19 +283,28 @@ fn evalOp(
 // mirrors prover-ray wiop.LagrangeSelector.EvaluateOutOfDomain, the reference
 // used by global.Verifier.
 //
-// position is comptime-known (it lives in the comptime expression DAG), so for
-// static modules (static_n != 0) omega^position folds to a comptime field
-// constant via staticRootPower — no runtime exponentiation. Dynamic modules
-// (static_n == 0) derive the n-th root of unity from ctx.dynamic_n and take the
-// runtime pow. Everything else (the annihilator, the r - omega^position
-// denominator, the division) depends on the runtime eval coin r and stays
-// runtime in both cases.
-fn evalLagrangeSelector(comptime position: usize, comptime static_n: usize, ctx: EvalCtx) Error!ext.Ext {
+// position comes from the node's runtime expression payload (module.expressions
+// is looked up by a runtime expr_index — see evalExpr) and may be end-relative
+// (negative — -1 is the module's last row, mirroring prover-ray
+// wiop.LagrangeSelector's own convention), the same shape cancellationAtPoint's
+// `positions` already handles via normalizePosition. For a STATIC module
+// (static_n != 0), codegen has already resolved a negative position into
+// [0, static_n) (the module size is known at codegen time), so
+// normalizePosition is a no-op there in practice, but is still used for
+// consistency with cancellationAtPoint. static_n itself stays comptime (it's
+// part of the comptime System), so staticRootPower's root-of-unity lookup
+// still folds at compile time; only the exponent (position-derived) is
+// runtime now, same cost as the already-runtime dynamic-module path below. A
+// DYNAMIC module's size is only known at verify time, so its position is
+// normalized into [0, ctx.dynamic_n) here at runtime before the runtime pow.
+// Everything else (the annihilator, the r - omega^position denominator, the
+// division) depends on the runtime eval coin r and stays runtime in both cases.
+fn evalLagrangeSelector(position: i32, comptime static_n: usize, ctx: EvalCtx) Error!ext.Ext {
     const omega_pos = if (static_n != 0)
-        comptime staticRootPower(static_n, position)
+        staticRootPower(static_n, normalizePosition(position, static_n, 0))
     else blk: {
         const omega = field.rootOfUnityBy(ctx.dynamic_n) catch return error.InvalidModuleSize;
-        break :blk omega.powComptime(position);
+        break :blk omega.pow(@as(u64, normalizePosition(position, 0, ctx.dynamic_n)));
     };
 
     // numerator = omega^position * (r^n - 1).
@@ -297,12 +347,12 @@ fn cancellationAtPoint(
     return result;
 }
 
-fn staticRootPower(comptime n: usize, comptime k: usize) field.Element {
+fn staticRootPower(comptime n: usize, k: usize) field.Element {
     const omega = field.rootOfUnityBy(n) catch unreachable;
-    return omega.powComptime(k);
+    return omega.pow(@as(u64, k));
 }
 
-fn normalizePosition(comptime position: i32, comptime static_n: usize, dynamic_n: usize) usize {
+fn normalizePosition(position: i32, comptime static_n: usize, dynamic_n: usize) usize {
     const n = if (static_n != 0) static_n else dynamic_n;
     if (position < 0) return n - @as(usize, @intCast(-position));
     return @as(usize, @intCast(position));

--- a/verifier-ray/src/query/vanishing.zig
+++ b/verifier-ray/src/query/vanishing.zig
@@ -8,6 +8,7 @@ pub const Error = error{
     InvalidClaimCount,
     QuotientIdentityMismatch,
     LagrangeSelectorInDomain,
+    LagrangeSelectorPositionOutOfRange,
     CellRefOutOfRange,
 };
 
@@ -300,6 +301,17 @@ fn evalOp(
 // Everything else (the annihilator, the r - omega^position denominator, the
 // division) depends on the runtime eval coin r and stays runtime in both cases.
 fn evalLagrangeSelector(position: i32, comptime static_n: usize, ctx: EvalCtx) Error!ext.Ext {
+    // Bounds-check before normalizing. For a DYNAMIC module n comes from the
+    // proof-supplied module_sizes, so a hostile size can push a codegen-baked
+    // position out of [-n, n): a position < -n would underflow
+    // normalizePosition's usize subtraction, and a position >= n would be
+    // silently reduced mod n by the root-of-unity exponentiation, evaluating a
+    // DIFFERENT selector than the constraint declares. Mirrors the Go
+    // reference (wiop.LagrangeSelector.resolvedRow), which rejects positions
+    // outside [-n, n).
+    const n = if (static_n != 0) static_n else ctx.dynamic_n;
+    if (!validPosition(position, n)) return error.LagrangeSelectorPositionOutOfRange;
+
     const omega_pos = if (static_n != 0)
         staticRootPower(static_n, normalizePosition(position, static_n, 0))
     else blk: {
@@ -317,7 +329,6 @@ fn evalLagrangeSelector(position: i32, comptime static_n: usize, ctx: EvalCtx) E
     // out-of-domain contract.
     const r_minus_omega = ctx.coin.sub(ext.Ext.lift(omega_pos));
     if (r_minus_omega.isZero()) return error.LagrangeSelectorInDomain;
-    const n = if (static_n != 0) static_n else ctx.dynamic_n;
     const denominator = r_minus_omega.mulByBase(field.Element.init(@as(u64, n)));
 
     return numerator.div(denominator);
@@ -334,6 +345,16 @@ fn cancellationAtPoint(
     var result = ext.Ext.one();
 
     inline for (positions) |position| {
+        // Same runtime bounds check as evalLagrangeSelector, for the same
+        // reason: on the dynamic path n is proof-supplied, so a hostile size
+        // can push a codegen-baked position out of [-n, n) (usize underflow
+        // when position < -n, silent mod-n reduction when position >= n). The
+        // static path normalizes at comptime against the trusted static_n, so
+        // an out-of-range position there is a codegen bug caught at compile
+        // time, not a proof-dependent condition.
+        if (static_n == 0 and !validPosition(position, ctx.dynamic_n)) {
+            return error.LagrangeSelectorPositionOutOfRange;
+        }
         // Cancellation polynomial for openings already enforced elsewhere:
         // C(r) = product_{k in cancelled} (r - omega_n^norm(k)).
         const root = if (static_n != 0)
@@ -352,6 +373,21 @@ fn staticRootPower(comptime n: usize, k: usize) field.Element {
     return omega.pow(@as(u64, k));
 }
 
+// Whether an (end-relative) selector position is addressable in a module of
+// size n, i.e. lands in [-n, n). Callers must check this before
+// normalizePosition, whose negative branch underflows for position < -n.
+// The magnitude is widened through i64 so that position == minInt(i32) cannot
+// overflow the negation.
+fn validPosition(position: i32, n: usize) bool {
+    if (position >= 0) {
+        return @as(usize, @intCast(position)) < n;
+    }
+    const magnitude: usize = @intCast(-@as(i64, position));
+    return magnitude <= n;
+}
+
+// Resolves an end-relative position into [0, n). Precondition: position is in
+// [-n, n) — see validPosition; the subtraction below underflows otherwise.
 fn normalizePosition(position: i32, comptime static_n: usize, dynamic_n: usize) usize {
     const n = if (static_n != 0) static_n else dynamic_n;
     if (position < 0) return n - @as(usize, @intCast(-position));

--- a/verifier-ray/test/pcs_test.zig
+++ b/verifier-ray/test/pcs_test.zig
@@ -366,6 +366,75 @@ test "reconstruct: accepts a dynamic size below the column's declared min_size_l
     try std.testing.expectEqual(@as(u8, 1), recon.entry_size_log2[recon.col_to_entry[0]]);
 }
 
+// ── Aliased-claim equality binding ────────────────────────────────────────────
+//
+// At an aliasing runtime size, distinct raw shifts open the SAME domain point
+// but carry DISTINCT transcript claim cells. Only the first cell of an aliasing
+// group is authenticated through the DEEP quotient (the repeats are deduped),
+// while routeClaims later routes every raw-shift slot independently — so the
+// dedup must equality-bind the skipped cells to the kept one, or a malicious
+// prover could keep the first claim commitment-consistent and smuggle a
+// different value through a skipped slot. No golden vector runs at an aliasing
+// size, so these drive pcs.entryDeepTerm directly.
+
+test "entryDeepTerm: rejects inconsistent aliased claims" {
+    // size_log2 = 1 (n = 2): raw shifts 1 and -1 both normalize to row 1, so
+    // both open zeta * omega. An honest prover writes the same value into both
+    // claim cells; this adversarial pair differs in the second cell.
+    const shifts = [_]isize{ 1, -1 };
+    const claims = [_]ext.Ext{
+        ext.Ext.fromUints(.{ 5, 0, 0, 0, 0, 0 }),
+        ext.Ext.fromUints(.{ 6, 0, 0, 0, 0, 0 }), // tampered duplicate
+    };
+    const zeta = ext.Ext.fromUints(.{ 3, 1, 4, 1, 5, 9 });
+    const x = ext.Ext.fromUints(.{ 2, 7, 1, 8, 2, 8 });
+    try std.testing.expectError(
+        error.InconsistentAliasedClaim,
+        pcs.entryDeepTerm(&shifts, &claims, ext.Ext.fromUints(.{ 9, 0, 0, 0, 0, 0 }), 1, zeta, x),
+    );
+}
+
+test "entryDeepTerm: equal aliased claims contribute exactly one term" {
+    // Same aliasing pair, honest (equal) claims: the contribution must be the
+    // single term (entry_value - claim) / (x - zeta * omega), not twice it.
+    const shifts = [_]isize{ 1, -1 };
+    const claim = ext.Ext.fromUints(.{ 5, 0, 0, 0, 0, 0 });
+    const claims = [_]ext.Ext{ claim, claim };
+    const entry_value = ext.Ext.fromUints(.{ 9, 0, 0, 0, 0, 0 });
+    const zeta = ext.Ext.fromUints(.{ 3, 1, 4, 1, 5, 9 });
+    const x = ext.Ext.fromUints(.{ 2, 7, 1, 8, 2, 8 });
+
+    const got = try pcs.entryDeepTerm(&shifts, &claims, entry_value, 1, zeta, x);
+
+    const omega = try field.rootOfUnityBy(2);
+    const point = zeta.mulByBase(omega); // shift 1 and -1 both land here at n = 2
+    const expected = entry_value.sub(claim).mul(x.sub(point).inverse());
+    try std.testing.expect(got.eql(expected));
+}
+
+test "entryDeepTerm: non-aliasing shifts still sum one term per point" {
+    // Control at a non-aliasing size (n = 4): shifts 1 and -1 open different
+    // points and both terms must be counted — pinning that the dedup only
+    // fires on genuine aliasing.
+    const shifts = [_]isize{ 1, -1 };
+    const claims = [_]ext.Ext{
+        ext.Ext.fromUints(.{ 5, 0, 0, 0, 0, 0 }),
+        ext.Ext.fromUints(.{ 6, 0, 0, 0, 0, 0 }),
+    };
+    const entry_value = ext.Ext.fromUints(.{ 9, 0, 0, 0, 0, 0 });
+    const zeta = ext.Ext.fromUints(.{ 3, 1, 4, 1, 5, 9 });
+    const x = ext.Ext.fromUints(.{ 2, 7, 1, 8, 2, 8 });
+
+    const got = try pcs.entryDeepTerm(&shifts, &claims, entry_value, 2, zeta, x);
+
+    const omega = try field.rootOfUnityBy(4);
+    const p1 = zeta.mulByBase(omega.pow(1));
+    const p2 = zeta.mulByBase(omega.pow(3)); // -1 mod 4
+    const expected = entry_value.sub(claims[0]).mul(x.sub(p1).inverse())
+        .add(entry_value.sub(claims[1]).mul(x.sub(p2).inverse()));
+    try std.testing.expect(got.eql(expected));
+}
+
 test "routeInputRoots follows input-opening order as dynamic sizes change" {
     const roots = [_]poseidon2.Digest{
         challengeDigest(100),

--- a/verifier-ray/test/pcs_test.zig
+++ b/verifier-ray/test/pcs_test.zig
@@ -347,7 +347,23 @@ test "reconstruct: same System, LARGER dynamic size changes bundle + top_size" {
 test "reconstruct: rejects non-power-of-two and missing dynamic sizes" {
     try std.testing.expectError(error.NonPowerOfTwoModuleSize, pcs.reconstruct(recon_system, &[_]usize{6}));
     try std.testing.expectError(error.MissingDynamicModuleSize, pcs.reconstruct(recon_system, &.{}));
-    try std.testing.expectError(error.DynamicModuleSizeBelowMinimum, pcs.reconstruct(recon_system, &[_]usize{2}));
+}
+
+test "reconstruct: accepts a dynamic size below the column's declared min_size_log2" {
+    // dyn.min_size_log2 documents the smallest runtime size at which every RAW
+    // shift of a column is still distinct (no two shifts alias to the same
+    // domain point); it is NOT an enforced floor. An honest proof CAN run a
+    // dynamic module at a smaller, aliasing size: prover-ray's own
+    // RecoverBatchClaims dedupes aliasing openings into a single FRI claim
+    // before ever building the batch (and every prover computes byte-identical
+    // claimed values for aliasing raw shifts, since the shift is applied via
+    // omega_n^k with n the RUNTIME size — see wiop.LagrangeEval.evalPolynomials).
+    // reconstructQueryValueAt dedupes the same way when summing the DEEP
+    // quotient, so verify() stays correct at this size too (this column has
+    // only one shift, so there is nothing to dedupe here — this test only pins
+    // that `reconstruct` itself no longer rejects the size).
+    const recon = try pcs.reconstruct(recon_system, &[_]usize{2});
+    try std.testing.expectEqual(@as(u8, 1), recon.entry_size_log2[recon.col_to_entry[0]]);
 }
 
 test "routeInputRoots follows input-opening order as dynamic sizes change" {

--- a/verifier-ray/test/vanishing_test.zig
+++ b/verifier-ray/test/vanishing_test.zig
@@ -166,6 +166,122 @@ test "lagrange selector rejects an in-domain evaluation coin" {
     }
 }
 
+// dynSelectorSystem builds a single-bucket DYNAMIC module (size from
+// module_sizes[0]) whose sole vanishing is the bare selector L_position — the
+// dynamic analogue of the static fixture in the in-domain test above, for
+// exercising the runtime position bounds check against a proof-supplied size.
+fn dynSelectorSystem(comptime position: i32) vanishing.System {
+    const S = struct {
+        const expressions = [_]vanishing.ExprNode{.{ .lagrange_selector = position }};
+        const vanishings = [_]vanishing.Vanishing{.{ .expression = 0 }};
+        const buckets = [_]vanishing.Bucket{.{ .ratio = 1, .vanishings = &vanishings, .quotient_claim_offset = 0 }};
+        const modules = [_]vanishing.Module{.{
+            .size = .{ .dynamic = 0 },
+            .expressions = &expressions,
+            .buckets = &buckets,
+            .witness_claim_offset = 0,
+            .merge_coin_index = 0,
+            .eval_coin_index = 1,
+        }};
+    };
+    return .{ .modules = &S.modules, .dynamic_module_count = 1, .total_witness_claims = 0, .total_quotient_claims = 1 };
+}
+
+// dynCancelledSystem is dynSelectorSystem's analogue for the cancellation
+// path: a constant-1 vanishing carrying one cancelled position, so
+// cancellationAtPoint (not evalLagrangeSelector) resolves `position` against
+// the proof-supplied size.
+fn dynCancelledSystem(comptime position: i32) vanishing.System {
+    const S = struct {
+        const expressions = [_]vanishing.ExprNode{.{ .constant = field.Element.init(1) }};
+        const cancelled = [_]i32{position};
+        const vanishings = [_]vanishing.Vanishing{.{ .expression = 0, .cancelled_positions = &cancelled }};
+        const buckets = [_]vanishing.Bucket{.{ .ratio = 1, .vanishings = &vanishings, .quotient_claim_offset = 0 }};
+        const modules = [_]vanishing.Module{.{
+            .size = .{ .dynamic = 0 },
+            .expressions = &expressions,
+            .buckets = &buckets,
+            .witness_claim_offset = 0,
+            .merge_coin_index = 0,
+            .eval_coin_index = 1,
+        }};
+    };
+    return .{ .modules = &S.modules, .dynamic_module_count = 1, .total_witness_claims = 0, .total_quotient_claims = 1 };
+}
+
+test "lagrange selector rejects positions outside [-n, n) for dynamic modules" {
+    // module_sizes is proof-supplied: a hostile size can push a codegen-baked
+    // position out of the addressable range [-n, n). Below n = 4, an
+    // off-domain eval coin r = 2, and a zero quotient claim.
+    const n = 4;
+    const sizes = [_]usize{n};
+    const quotient_claims = [_]ext.Ext{ext.Ext.zero()};
+    const off_domain = ext.Ext.lift(field.Element.init(2)); // 2 is not a 4th root of unity
+    const all_coins = [_]ext.Ext{ ext.Ext.one(), off_domain };
+    const ctx = protocol.Context{ .all_coins = &all_coins, .rounds = &.{} };
+    const input = vanishing.CheckInput{
+        .ctx = ctx,
+        .witness_claims = &.{},
+        .quotient_claims = &quotient_claims,
+        .module_sizes = &sizes,
+    };
+
+    // position == n: one past the last row. Without the bounds check the
+    // root-of-unity exponentiation would silently reduce it mod n and evaluate
+    // L_0 — a different selector than the constraint declares.
+    try std.testing.expectError(
+        error.LagrangeSelectorPositionOutOfRange,
+        vanishing.verify(dynSelectorSystem(n), input),
+    );
+
+    // position == -n-1: one below the first addressable end-relative row.
+    // Without the bounds check normalizePosition's usize subtraction (n - n-1)
+    // underflows.
+    try std.testing.expectError(
+        error.LagrangeSelectorPositionOutOfRange,
+        vanishing.verify(dynSelectorSystem(-n - 1), input),
+    );
+
+    // position == -n: the valid boundary (resolves to row 0). It must clear
+    // the bounds check and proceed to the ordinary identity check, which fails
+    // here (L_0(2) != 0 while the quotient claim is zero) — confirming the
+    // rejections above were specifically the bounds guard.
+    try std.testing.expectError(
+        error.QuotientIdentityMismatch,
+        vanishing.verify(dynSelectorSystem(-n), input),
+    );
+}
+
+test "cancelled positions get the same dynamic bounds check" {
+    const n = 4;
+    const sizes = [_]usize{n};
+    const quotient_claims = [_]ext.Ext{ext.Ext.zero()};
+    const off_domain = ext.Ext.lift(field.Element.init(2));
+    const all_coins = [_]ext.Ext{ ext.Ext.one(), off_domain };
+    const ctx = protocol.Context{ .all_coins = &all_coins, .rounds = &.{} };
+    const input = vanishing.CheckInput{
+        .ctx = ctx,
+        .witness_claims = &.{},
+        .quotient_claims = &quotient_claims,
+        .module_sizes = &sizes,
+    };
+
+    try std.testing.expectError(
+        error.LagrangeSelectorPositionOutOfRange,
+        vanishing.verify(dynCancelledSystem(n), input),
+    );
+    try std.testing.expectError(
+        error.LagrangeSelectorPositionOutOfRange,
+        vanishing.verify(dynCancelledSystem(-n - 1), input),
+    );
+    // Valid boundary: -n resolves to row 0, C(r) = r - 1 = 1 at r = 2, so the
+    // identity check runs (and fails against the zero quotient claim).
+    try std.testing.expectError(
+        error.QuotientIdentityMismatch,
+        vanishing.verify(dynCancelledSystem(-n), input),
+    );
+}
+
 const ProofData = struct {
     proof_rounds: []const protocol.RoundMessage,
     public_inputs: []const protocol.Scalar,

--- a/verifier-ray/testdata/generate/go.mod
+++ b/verifier-ray/testdata/generate/go.mod
@@ -3,7 +3,7 @@ module github.com/consensys/linea-monorepo/verifier-ray/testdata/generate
 go 1.25.7
 
 require (
-	github.com/LFDT-Lineth/lineth-monorepo/prover-ray v0.0.0-20260817033906-b91dcde0972f
+	github.com/LFDT-Lineth/lineth-monorepo/prover-ray v0.0.0-20260827095445-9c51af6cc3b1
 	github.com/consensys/linea-monorepo/verifier-ray/codegen v0.0.0
 )
 

--- a/verifier-ray/testdata/generate/go.sum
+++ b/verifier-ray/testdata/generate/go.sum
@@ -1,15 +1,11 @@
-github.com/LFDT-Lineth/lineth-monorepo/prover-ray v0.0.0-20260811123635-a88dfd54fad0 h1:yNY/K9xaiVEh33G8O+A8VaZqN5Ac7b2YdC8y9V74FNQ=
-github.com/LFDT-Lineth/lineth-monorepo/prover-ray v0.0.0-20260811123635-a88dfd54fad0/go.mod h1:68nFvO0Fy0oBJM/ssYjlExChHkM1aJWt3UiK66Z3Mzs=
-github.com/LFDT-Lineth/lineth-monorepo/prover-ray v0.0.0-20260817033906-b91dcde0972f h1:piFu+6cjKw+ZOYFv10jegCby8ORnXXzIqER8YuWH9gg=
-github.com/LFDT-Lineth/lineth-monorepo/prover-ray v0.0.0-20260817033906-b91dcde0972f/go.mod h1:h94O41m5F00Yyf2uZJmpmzoZ9Ch5fawoZMSR3iX+bTc=
+github.com/LFDT-Lineth/lineth-monorepo/prover-ray v0.0.0-20260827095445-9c51af6cc3b1 h1:7jkMwDOucHpfrvdBJQq5+HU8TLJe4EGHb1K3v0OJ8Ns=
+github.com/LFDT-Lineth/lineth-monorepo/prover-ray v0.0.0-20260827095445-9c51af6cc3b1/go.mod h1:+ZCrSWb2pdQMZgYTRvbiYBY8kXxSSdSsUAk0jpj5x78=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/consensys/gnark v0.14.1-0.20260219004710-bbfb2f70a565 h1:NlOAmbLYsVb/hcuOBxza6CAA+233tB0eFiunGVEMyv4=
 github.com/consensys/gnark v0.14.1-0.20260219004710-bbfb2f70a565/go.mod h1:EoWWbEboQRydCqJDSA7zrFxucIeoy/5R+MDx04oFpF4=
-github.com/consensys/gnark-crypto v0.20.2-0.20260806172022-e2a02f711389 h1:Tv/RvAXh6IhI9wNipgUTdY1KFDgsDA/hb+6sucFEbjw=
-github.com/consensys/gnark-crypto v0.20.2-0.20260806172022-e2a02f711389/go.mod h1:aODe15M1eN2z4gLryLOSZ0rx6DgrahcIw8TuzPurR1c=
 github.com/consensys/gnark-crypto v0.20.2-0.20260807171631-a71790dd0fe3 h1:+3Q/7HTCH/PCQknIIOGUbwbowgCPWd2JZFIiiy9+eeM=
 github.com/consensys/gnark-crypto v0.20.2-0.20260807171631-a71790dd0fe3/go.mod h1:aODe15M1eN2z4gLryLOSZ0rx6DgrahcIw8TuzPurR1c=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/verifier-ray/testdata/generated/vanishing.zig
+++ b/verifier-ray/testdata/generated/vanishing.zig
@@ -249,7 +249,7 @@ pub const system_2_public_input = protocol.public_input.Spec{
 // expression: "geo"
 const system_2_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "col"
-    .{ .constant = field.Element.init(2) },
+    .{ .constant = .{ .value = 2 } },
     .{ .column_claim = 1 }, // col: "col"
     .{ .op = .{ .operator = .mul, .operands = &.{ 1, 2 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 3 } } },
@@ -698,7 +698,7 @@ pub const system_6_public_input = protocol.public_input.Spec{
 // expression: "const"
 const system_6_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "col"
-    .{ .constant = field.Element.init(7) },
+    .{ .constant = .{ .value = 7 } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 1 } } },
 };
 
@@ -1024,11 +1024,11 @@ pub const system_9_public_input = protocol.public_input.Spec{
 // expression: "lin"
 const system_9_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "a"
-    .{ .constant = field.Element.init(2) },
+    .{ .constant = .{ .value = 2 } },
     .{ .column_claim = 1 }, // col: "b"
     .{ .op = .{ .operator = .mul, .operands = &.{ 1, 2 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 3 } } },
-    .{ .constant = field.Element.init(3) },
+    .{ .constant = .{ .value = 3 } },
     .{ .column_claim = 2 }, // col: "c"
     .{ .op = .{ .operator = .mul, .operands = &.{ 5, 6 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 4, 7 } } },
@@ -1251,7 +1251,7 @@ pub const system_11_public_input = protocol.public_input.Spec{
 
 const system_11_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "a"
-    .{ .constant = field.Element.init(4) },
+    .{ .constant = .{ .value = 4 } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 1 } } },
     .{ .column_claim = 1 }, // col: "b"
     .{ .column_claim = 0 }, // col: "a"
@@ -1496,7 +1496,7 @@ const system_13_module_0_buckets = [_]vanishing.Bucket{
 // expression: "b-const"
 const system_13_module_1_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "colB"
-    .{ .constant = field.Element.init(7) },
+    .{ .constant = .{ .value = 7 } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 1 } } },
 };
 
@@ -1610,7 +1610,7 @@ const system_14_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "col"
     .{ .column_claim = 1 }, // col: "col"
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 1 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 2, 3 } } },
 };
 
@@ -1719,7 +1719,7 @@ pub const system_15_public_input = protocol.public_input.Spec{
 const system_15_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "sel"
     .{ .column_claim = 1 }, // col: "col"
-    .{ .constant = field.Element.init(9) },
+    .{ .constant = .{ .value = 9 } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 0, 3 } } },
 };
@@ -3002,7 +3002,7 @@ const system_26_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "col"
     .{ .column_claim = 1 }, // col: "col"
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 1 } } },
-    .{ .constant = field.Element.init(2) },
+    .{ .constant = .{ .value = 2 } },
     .{ .column_claim = 2 }, // col: "col"
     .{ .op = .{ .operator = .mul, .operands = &.{ 3, 4 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 2, 5 } } },
@@ -3546,12 +3546,12 @@ const system_31_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 1 }, // col: "z-b0-k0"
     .{ .column_claim = 2 }, // col: "z-b0-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 3, 4 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 5 } } },
     .{ .column_claim = 0 }, // col: "num"
     .{ .column_claim = 1 }, // col: "z-b0-k0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 8, 9 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 7, 10 } } },
     .{ .lagrange_selector = 0 },
@@ -3666,7 +3666,7 @@ const system_32_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 2 }, // col: "z-b0-k0"
     .{ .column_claim = 3 }, // col: "z-b0-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 3, 4 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 5, 6 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 2, 7 } } },
     .{ .cell_value = .{ .round = 1, .index = 1 } }, // cell: "result"
@@ -3678,7 +3678,7 @@ const system_32_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 1 }, // col: "num"
     .{ .op = .{ .operator = .mul, .operands = &.{ 14, 15 } } },
     .{ .column_claim = 2 }, // col: "z-b0-k0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 17, 18 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 16, 19 } } },
     .{ .lagrange_selector = 0 },
@@ -3795,7 +3795,7 @@ const system_33_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 2 }, // col: "z-b0-k0"
     .{ .column_claim = 3 }, // col: "z-b0-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 3, 4 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 5, 6 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 2, 7 } } },
     .{ .cell_value = .{ .round = 1, .index = 1 } }, // cell: "result"
@@ -3807,7 +3807,7 @@ const system_33_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 1 }, // col: "num"
     .{ .op = .{ .operator = .mul, .operands = &.{ 14, 15 } } },
     .{ .column_claim = 2 }, // col: "z-b0-k0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 17, 18 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 16, 19 } } },
     .{ .lagrange_selector = 0 },
@@ -4049,29 +4049,29 @@ pub const system_35_public_input = protocol.public_input.Spec{
 
 const system_35_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "c0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 0, 1 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 2, 3 } } },
     .{ .column_claim = 1 }, // col: "c1"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 5, 6 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 7, 8 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 4, 9 } } },
     .{ .column_claim = 2 }, // col: "c2"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 13, 14 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 10, 15 } } },
     .{ .column_claim = 3 }, // col: "z-b0-k0"
     .{ .column_claim = 4 }, // col: "z-b0-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 17, 18 } } },
-    .{ .constant = field.Element.init(1) },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 20, 21 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 22, 23 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 19, 24 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 16, 25 } } },
@@ -4079,31 +4079,31 @@ const system_35_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 6 }, // col: "z-b0-k1"
     .{ .column_claim = 7 }, // col: "z-b0-k1"
     .{ .op = .{ .operator = .sub, .operands = &.{ 28, 29 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 30, 31 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 27, 32 } } },
     .{ .column_claim = 0 }, // col: "c0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 34, 35 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 36, 37 } } },
     .{ .column_claim = 1 }, // col: "c1"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 39, 40 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 41, 42 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 38, 43 } } },
     .{ .column_claim = 2 }, // col: "c2"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 45, 46 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 47, 48 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 44, 49 } } },
     .{ .column_claim = 3 }, // col: "z-b0-k0"
-    .{ .constant = field.Element.init(1) },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 52, 53 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 54, 55 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 51, 56 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 50, 57 } } },
@@ -4116,7 +4116,7 @@ const system_35_module_0_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .mul, .operands = &.{ 63, 64 } } },
     .{ .column_claim = 5 }, // col: "c3"
     .{ .column_claim = 6 }, // col: "z-b0-k1"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 67, 68 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 66, 69 } } },
     .{ .lagrange_selector = 0 },
@@ -4250,12 +4250,12 @@ const system_36_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 1 }, // col: "z-b0-k0"
     .{ .column_claim = 2 }, // col: "z-b0-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 3, 4 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 5 } } },
     .{ .column_claim = 0 }, // col: "cA"
     .{ .column_claim = 1 }, // col: "z-b0-k0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 8, 9 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 7, 10 } } },
     .{ .lagrange_selector = 0 },
@@ -4287,7 +4287,7 @@ const system_36_module_1_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 2 }, // col: "z-b1-k0"
     .{ .column_claim = 3 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 3, 4 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 5, 6 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 2, 7 } } },
     .{ .cell_value = .{ .round = 1, .index = 2 } }, // cell: "result"
@@ -4299,7 +4299,7 @@ const system_36_module_1_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 1 }, // col: "cB"
     .{ .op = .{ .operator = .mul, .operands = &.{ 14, 15 } } },
     .{ .column_claim = 2 }, // col: "z-b1-k0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 17, 18 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 16, 19 } } },
     .{ .lagrange_selector = 0 },
@@ -4420,7 +4420,7 @@ pub const system_37_public_input = protocol.public_input.Spec{
 const system_37_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "num"
     .{ .column_claim = 1 }, // col: "z-b0-k0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 1, 2 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 3 } } },
     .{ .lagrange_selector = 0 },
@@ -4527,12 +4527,12 @@ pub const system_38_public_input = protocol.public_input.Spec{
 
 const system_38_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "filterS"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 0, 1 } } },
     .{ .column_claim = 1 }, // col: "z-b0-k0"
     .{ .column_claim = 2 }, // col: "z-b0-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 3, 4 } } },
-    .{ .constant = field.Element.init(7) },
+    .{ .constant = .{ .value = 7 } },
     .{ .column_claim = 3 }, // col: "S"
     .{ .op = .{ .operator = .add, .operands = &.{ 6, 7 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 5, 8 } } },
@@ -4543,10 +4543,10 @@ const system_38_module_0_expressions = [_]vanishing.ExprNode{
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 13, 14 } } },
     .{ .column_claim = 0 }, // col: "filterS"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 16, 17 } } },
     .{ .column_claim = 1 }, // col: "z-b0-k0"
-    .{ .constant = field.Element.init(7) },
+    .{ .constant = .{ .value = 7 } },
     .{ .column_claim = 3 }, // col: "S"
     .{ .op = .{ .operator = .add, .operands = &.{ 20, 21 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 19, 22 } } },
@@ -4578,7 +4578,7 @@ const system_38_module_1_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .column_claim = 2 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 2, 3 } } },
-    .{ .constant = field.Element.init(7) },
+    .{ .constant = .{ .value = 7 } },
     .{ .column_claim = 3 }, // col: "T"
     .{ .op = .{ .operator = .add, .operands = &.{ 5, 6 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 4, 7 } } },
@@ -4591,7 +4591,7 @@ const system_38_module_1_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "M"
     .{ .op = .{ .operator = .negate, .operands = &.{15} } },
     .{ .column_claim = 1 }, // col: "z-b1-k0"
-    .{ .constant = field.Element.init(7) },
+    .{ .constant = .{ .value = 7 } },
     .{ .column_claim = 3 }, // col: "T"
     .{ .op = .{ .operator = .add, .operands = &.{ 18, 19 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 17, 20 } } },
@@ -4716,56 +4716,56 @@ pub const system_39_public_input = protocol.public_input.Spec{
 
 const system_39_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "c0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 0, 1 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 2, 3 } } },
     .{ .column_claim = 1 }, // col: "c1"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 5, 6 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 7, 8 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 4, 9 } } },
     .{ .column_claim = 2 }, // col: "c2"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 13, 14 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 10, 15 } } },
     .{ .column_claim = 3 }, // col: "z-b0-k0"
     .{ .column_claim = 4 }, // col: "z-b0-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 17, 18 } } },
-    .{ .constant = field.Element.init(1) },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 20, 21 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 22, 23 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 19, 24 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 16, 25 } } },
     .{ .column_claim = 5 }, // col: "c3"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 27, 28 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 29, 30 } } },
     .{ .column_claim = 6 }, // col: "c4"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 32, 33 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 34, 35 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 31, 36 } } },
     .{ .column_claim = 7 }, // col: "c5"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 38, 39 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 40, 41 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 37, 42 } } },
     .{ .column_claim = 8 }, // col: "z-b0-k1"
     .{ .column_claim = 9 }, // col: "z-b0-k1"
     .{ .op = .{ .operator = .sub, .operands = &.{ 44, 45 } } },
-    .{ .constant = field.Element.init(1) },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 47, 48 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 49, 50 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 46, 51 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 43, 52 } } },
@@ -4773,31 +4773,31 @@ const system_39_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 11 }, // col: "z-b0-k2"
     .{ .column_claim = 12 }, // col: "z-b0-k2"
     .{ .op = .{ .operator = .sub, .operands = &.{ 55, 56 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 57, 58 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 54, 59 } } },
     .{ .column_claim = 0 }, // col: "c0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 61, 62 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 63, 64 } } },
     .{ .column_claim = 1 }, // col: "c1"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 66, 67 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 68, 69 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 65, 70 } } },
     .{ .column_claim = 2 }, // col: "c2"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 72, 73 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 74, 75 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 71, 76 } } },
     .{ .column_claim = 3 }, // col: "z-b0-k0"
-    .{ .constant = field.Element.init(1) },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 79, 80 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 81, 82 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 78, 83 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 77, 84 } } },
@@ -4809,27 +4809,27 @@ const system_39_module_0_expressions = [_]vanishing.ExprNode{
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 90, 91 } } },
     .{ .column_claim = 5 }, // col: "c3"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 93, 94 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 95, 96 } } },
     .{ .column_claim = 6 }, // col: "c4"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 98, 99 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 100, 101 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 97, 102 } } },
     .{ .column_claim = 7 }, // col: "c5"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 104, 105 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 106, 107 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 103, 108 } } },
     .{ .column_claim = 8 }, // col: "z-b0-k1"
-    .{ .constant = field.Element.init(1) },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 111, 112 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 113, 114 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 110, 115 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 109, 116 } } },
@@ -4842,7 +4842,7 @@ const system_39_module_0_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .mul, .operands = &.{ 122, 123 } } },
     .{ .column_claim = 10 }, // col: "c6"
     .{ .column_claim = 11 }, // col: "z-b0-k2"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 126, 127 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 125, 128 } } },
     .{ .lagrange_selector = 0 },
@@ -4989,12 +4989,12 @@ const system_40_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 1 }, // col: "z-b0-k0"
     .{ .column_claim = 2 }, // col: "z-b0-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 3, 4 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 5 } } },
     .{ .column_claim = 0 }, // col: "num"
     .{ .column_claim = 1 }, // col: "z-b0-k0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 8, 9 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 7, 10 } } },
     .{ .lagrange_selector = 0 },
@@ -5107,19 +5107,19 @@ const system_41_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 1 }, // col: "z-b0-k0"
     .{ .column_claim = 2 }, // col: "z-b0-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 3, 4 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 5 } } },
     .{ .column_claim = 3 }, // col: "c2"
     .{ .column_claim = 4 }, // col: "z-b0-k0"
     .{ .column_claim = 5 }, // col: "z-b0-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 8, 9 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 10, 11 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 7, 12 } } },
     .{ .column_claim = 0 }, // col: "c1"
     .{ .column_claim = 1 }, // col: "z-b0-k0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 15, 16 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 14, 17 } } },
     .{ .lagrange_selector = 0 },
@@ -5131,7 +5131,7 @@ const system_41_module_0_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .mul, .operands = &.{ 23, 24 } } },
     .{ .column_claim = 3 }, // col: "c2"
     .{ .column_claim = 4 }, // col: "z-b0-k0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 27, 28 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 26, 29 } } },
     .{ .lagrange_selector = 0 },
@@ -5384,64 +5384,64 @@ const system_43_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "flt"
     .{ .column_claim = 1 }, // col: "n1"
     .{ .op = .{ .operator = .mul, .operands = &.{ 0, 1 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 2, 3 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 4, 5 } } },
     .{ .column_claim = 0 }, // col: "flt"
     .{ .column_claim = 2 }, // col: "n2"
     .{ .op = .{ .operator = .mul, .operands = &.{ 7, 8 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 9, 10 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 6, 13 } } },
     .{ .column_claim = 0 }, // col: "flt"
     .{ .column_claim = 3 }, // col: "n3"
     .{ .op = .{ .operator = .mul, .operands = &.{ 15, 16 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 17, 18 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 19, 20 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 14, 21 } } },
     .{ .column_claim = 4 }, // col: "z-b0-k0"
     .{ .column_claim = 5 }, // col: "z-b0-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 23, 24 } } },
-    .{ .constant = field.Element.init(1) },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 26, 27 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 28, 29 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 25, 30 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 22, 31 } } },
     .{ .column_claim = 0 }, // col: "flt"
     .{ .column_claim = 1 }, // col: "n1"
     .{ .op = .{ .operator = .mul, .operands = &.{ 33, 34 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 35, 36 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 37, 38 } } },
     .{ .column_claim = 0 }, // col: "flt"
     .{ .column_claim = 2 }, // col: "n2"
     .{ .op = .{ .operator = .mul, .operands = &.{ 40, 41 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 42, 43 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 44, 45 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 39, 46 } } },
     .{ .column_claim = 0 }, // col: "flt"
     .{ .column_claim = 3 }, // col: "n3"
     .{ .op = .{ .operator = .mul, .operands = &.{ 48, 49 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 50, 51 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 52, 53 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 47, 54 } } },
     .{ .column_claim = 4 }, // col: "z-b0-k0"
-    .{ .constant = field.Element.init(1) },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 57, 58 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 59, 60 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 56, 61 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 55, 62 } } },
@@ -5613,7 +5613,7 @@ const system_44_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_44_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -5627,7 +5627,7 @@ const system_44_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 9, 10 } } },
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 2 }, // col: "S"
@@ -5811,7 +5811,7 @@ const system_45_module_0_buckets = [_]vanishing.Bucket{
 
 const system_45_module_1_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "filterS"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 0, 1 } } },
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .column_claim = 2 }, // col: "z-b1-k0"
@@ -5827,7 +5827,7 @@ const system_45_module_1_expressions = [_]vanishing.ExprNode{
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 13, 14 } } },
     .{ .column_claim = 0 }, // col: "filterS"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 16, 17 } } },
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
@@ -6020,7 +6020,7 @@ const system_46_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_46_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -6028,7 +6028,7 @@ const system_46_module_1_expressions = [_]vanishing.ExprNode{
     .{ .coin_value = 1 }, // coin: "alpha"
     .{ .column_claim = 2 }, // col: "S"
     .{ .op = .{ .operator = .mul, .operands = &.{ 5, 6 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .add, .operands = &.{ 7, 8 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 4, 9 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 3, 10 } } },
@@ -6038,13 +6038,13 @@ const system_46_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 13, 14 } } },
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 15, 16 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .coin_value = 1 }, // coin: "alpha"
     .{ .column_claim = 2 }, // col: "S"
     .{ .op = .{ .operator = .mul, .operands = &.{ 21, 22 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .add, .operands = &.{ 23, 24 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 20, 25 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 19, 26 } } },
@@ -6235,7 +6235,7 @@ const system_47_module_0_buckets = [_]vanishing.Bucket{
 
 const system_47_module_1_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "filterS"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 0, 1 } } },
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .column_claim = 2 }, // col: "z-b1-k0"
@@ -6244,7 +6244,7 @@ const system_47_module_1_expressions = [_]vanishing.ExprNode{
     .{ .coin_value = 1 }, // coin: "alpha"
     .{ .column_claim = 3 }, // col: "S"
     .{ .op = .{ .operator = .mul, .operands = &.{ 7, 8 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .add, .operands = &.{ 9, 10 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 6, 11 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 5, 12 } } },
@@ -6255,14 +6255,14 @@ const system_47_module_1_expressions = [_]vanishing.ExprNode{
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 17, 18 } } },
     .{ .column_claim = 0 }, // col: "filterS"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 20, 21 } } },
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .coin_value = 1 }, // coin: "alpha"
     .{ .column_claim = 3 }, // col: "S"
     .{ .op = .{ .operator = .mul, .operands = &.{ 25, 26 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .add, .operands = &.{ 27, 28 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 24, 29 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 23, 30 } } },
@@ -6453,7 +6453,7 @@ const system_48_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_48_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -6471,7 +6471,7 @@ const system_48_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 13, 14 } } },
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 15, 16 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .coin_value = 1 }, // coin: "alpha"
@@ -6660,7 +6660,7 @@ const system_49_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_49_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -6674,7 +6674,7 @@ const system_49_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 9, 10 } } },
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 2 }, // col: "S1"
@@ -6703,7 +6703,7 @@ const system_49_module_1_buckets = [_]vanishing.Bucket{
 };
 
 const system_49_module_2_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b2-k0"
     .{ .column_claim = 1 }, // col: "z-b2-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -6717,7 +6717,7 @@ const system_49_module_2_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 9, 10 } } },
     .{ .lagrange_selector = 1 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b2-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 2 }, // col: "S2"
@@ -6956,7 +6956,7 @@ const system_50_module_1_buckets = [_]vanishing.Bucket{
 };
 
 const system_50_module_2_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -6970,7 +6970,7 @@ const system_50_module_2_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 9, 10 } } },
     .{ .lagrange_selector = 1 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 2 }, // col: "S1"
@@ -6999,7 +6999,7 @@ const system_50_module_2_buckets = [_]vanishing.Bucket{
 };
 
 const system_50_module_3_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b3-k0"
     .{ .column_claim = 1 }, // col: "z-b3-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -7013,7 +7013,7 @@ const system_50_module_3_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 9, 10 } } },
     .{ .lagrange_selector = 1 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b3-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 2 }, // col: "S2"
@@ -7242,7 +7242,7 @@ const system_51_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_51_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -7254,7 +7254,7 @@ const system_51_module_1_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 3 }, // col: "Sx"
     .{ .op = .{ .operator = .add, .operands = &.{ 8, 9 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 5, 10 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .add, .operands = &.{ 11, 12 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 4, 13 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 3, 14 } } },
@@ -7264,7 +7264,7 @@ const system_51_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 17, 18 } } },
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 19, 20 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .coin_value = 1 }, // coin: "alpha"
@@ -7274,7 +7274,7 @@ const system_51_module_1_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 3 }, // col: "Sx"
     .{ .op = .{ .operator = .add, .operands = &.{ 28, 29 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 25, 30 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .add, .operands = &.{ 31, 32 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 24, 33 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 23, 34 } } },
@@ -7458,7 +7458,7 @@ const system_52_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_52_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -7472,7 +7472,7 @@ const system_52_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 9, 10 } } },
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 2 }, // col: "S"
@@ -7655,7 +7655,7 @@ const system_53_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_53_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -7664,7 +7664,7 @@ const system_53_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .add, .operands = &.{ 4, 5 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 3, 6 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 7 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 2 }, // col: "S"
@@ -7852,7 +7852,7 @@ const system_54_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_54_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -7866,7 +7866,7 @@ const system_54_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 9, 10 } } },
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 2 }, // col: "S"
@@ -8050,7 +8050,7 @@ const system_55_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_55_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -8064,7 +8064,7 @@ const system_55_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 9, 10 } } },
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 2 }, // col: "S1"
@@ -8093,7 +8093,7 @@ const system_55_module_1_buckets = [_]vanishing.Bucket{
 };
 
 const system_55_module_2_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b2-k0"
     .{ .column_claim = 1 }, // col: "z-b2-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -8107,7 +8107,7 @@ const system_55_module_2_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 9, 10 } } },
     .{ .lagrange_selector = 1 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b2-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 2 }, // col: "S2"
@@ -8317,7 +8317,7 @@ const system_56_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_56_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -8339,7 +8339,7 @@ const system_56_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 17, 18 } } },
     .{ .lagrange_selector = 1 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 19, 20 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .coin_value = 1 }, // coin: "alpha"
@@ -8522,7 +8522,7 @@ const system_57_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_57_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 1 }, // col: "S"
@@ -8706,7 +8706,7 @@ const system_58_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_58_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -8720,7 +8720,7 @@ const system_58_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 9, 10 } } },
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 2 }, // col: "S"
@@ -8903,7 +8903,7 @@ const system_59_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_59_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -8917,7 +8917,7 @@ const system_59_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 9, 10 } } },
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 2 }, // col: "S"
@@ -9101,7 +9101,7 @@ const system_60_module_0_buckets = [_]vanishing.Bucket{
 
 const system_60_module_1_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "filterS"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 0, 1 } } },
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .column_claim = 2 }, // col: "z-b1-k0"
@@ -9117,7 +9117,7 @@ const system_60_module_1_expressions = [_]vanishing.ExprNode{
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 13, 14 } } },
     .{ .column_claim = 0 }, // col: "filterS"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 16, 17 } } },
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
@@ -9257,12 +9257,12 @@ pub const system_61_public_input = protocol.public_input.Spec{
 // scenario: "rc-distinct"
 
 const system_61_module_0_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 0 }, // col: "colB"
     .{ .op = .{ .operator = .add, .operands = &.{ 1, 2 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 0, 3 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 1 }, // col: "colA"
     .{ .op = .{ .operator = .add, .operands = &.{ 6, 7 } } },
@@ -9280,12 +9280,12 @@ const system_61_module_0_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .mul, .operands = &.{ 16, 19 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 13, 20 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 10, 21 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 0 }, // col: "colB"
     .{ .op = .{ .operator = .add, .operands = &.{ 24, 25 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 23, 26 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 1 }, // col: "colA"
     .{ .op = .{ .operator = .add, .operands = &.{ 29, 30 } } },
@@ -9783,7 +9783,7 @@ pub const system_64_public_input = protocol.public_input.Spec{
 const system_64_module_0_expressions = [_]vanishing.ExprNode{
     .{ .lagrange_selector = 1 },
     .{ .column_claim = 0 }, // col: "col"
-    .{ .constant = field.Element.init(99) },
+    .{ .constant = .{ .value = 99 } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 0, 3 } } },
 };
@@ -9891,7 +9891,7 @@ pub const system_65_public_input = protocol.public_input.Spec{
 const system_65_module_0_expressions = [_]vanishing.ExprNode{
     .{ .lagrange_selector = 1 },
     .{ .column_claim = 0 }, // col: "col"
-    .{ .constant = field.Element.init(99) },
+    .{ .constant = .{ .value = 99 } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 0, 3 } } },
 };
@@ -10073,7 +10073,7 @@ const system_66_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_66_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -10103,7 +10103,7 @@ const system_66_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 25, 26 } } },
     .{ .lagrange_selector = 1023 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 27, 28 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .coin_value = 1 }, // coin: "alpha"

--- a/verifier-ray/testdata/generated/verify.zig
+++ b/verifier-ray/testdata/generated/verify.zig
@@ -360,7 +360,7 @@ pub const system_2_public_input = protocol.public_input.Spec{
 // expression: "geo"
 const system_2_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "col"
-    .{ .constant = field.Element.init(2) },
+    .{ .constant = .{ .value = 2 } },
     .{ .column_claim = 1 }, // col: "col"
     .{ .op = .{ .operator = .mul, .operands = &.{ 1, 2 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 3 } } },
@@ -1001,7 +1001,7 @@ pub const system_6_public_input = protocol.public_input.Spec{
 // expression: "const"
 const system_6_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "col"
-    .{ .constant = field.Element.init(7) },
+    .{ .constant = .{ .value = 7 } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 1 } } },
 };
 
@@ -1462,11 +1462,11 @@ pub const system_9_public_input = protocol.public_input.Spec{
 // expression: "lin"
 const system_9_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "a"
-    .{ .constant = field.Element.init(2) },
+    .{ .constant = .{ .value = 2 } },
     .{ .column_claim = 1 }, // col: "b"
     .{ .op = .{ .operator = .mul, .operands = &.{ 1, 2 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 3 } } },
-    .{ .constant = field.Element.init(3) },
+    .{ .constant = .{ .value = 3 } },
     .{ .column_claim = 2 }, // col: "c"
     .{ .op = .{ .operator = .mul, .operands = &.{ 5, 6 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 4, 7 } } },
@@ -1787,7 +1787,7 @@ pub const system_11_public_input = protocol.public_input.Spec{
 
 const system_11_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "a"
-    .{ .constant = field.Element.init(4) },
+    .{ .constant = .{ .value = 4 } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 1 } } },
     .{ .column_claim = 1 }, // col: "b"
     .{ .column_claim = 0 }, // col: "a"
@@ -2124,7 +2124,7 @@ const system_13_module_0_buckets = [_]vanishing.Bucket{
 // expression: "b-const"
 const system_13_module_1_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "colB"
-    .{ .constant = field.Element.init(7) },
+    .{ .constant = .{ .value = 7 } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 1 } } },
 };
 
@@ -2289,7 +2289,7 @@ const system_14_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "col"
     .{ .column_claim = 1 }, // col: "col"
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 1 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 2, 3 } } },
 };
 
@@ -2443,7 +2443,7 @@ pub const system_15_public_input = protocol.public_input.Spec{
 const system_15_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "sel"
     .{ .column_claim = 1 }, // col: "col"
-    .{ .constant = field.Element.init(9) },
+    .{ .constant = .{ .value = 9 } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 0, 3 } } },
 };
@@ -4272,7 +4272,7 @@ const system_26_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "col"
     .{ .column_claim = 1 }, // col: "col"
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 1 } } },
-    .{ .constant = field.Element.init(2) },
+    .{ .constant = .{ .value = 2 } },
     .{ .column_claim = 2 }, // col: "col"
     .{ .op = .{ .operator = .mul, .operands = &.{ 3, 4 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 2, 5 } } },
@@ -5121,12 +5121,12 @@ const system_31_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 1 }, // col: "z-b0-k0"
     .{ .column_claim = 2 }, // col: "z-b0-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 3, 4 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 5 } } },
     .{ .column_claim = 0 }, // col: "num"
     .{ .column_claim = 1 }, // col: "z-b0-k0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 8, 9 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 7, 10 } } },
     .{ .lagrange_selector = 0 },
@@ -5280,7 +5280,7 @@ const system_32_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 2 }, // col: "z-b0-k0"
     .{ .column_claim = 3 }, // col: "z-b0-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 3, 4 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 5, 6 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 2, 7 } } },
     .{ .cell_value = .{ .round = 1, .index = 1 } }, // cell: "result"
@@ -5292,7 +5292,7 @@ const system_32_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 1 }, // col: "num"
     .{ .op = .{ .operator = .mul, .operands = &.{ 14, 15 } } },
     .{ .column_claim = 2 }, // col: "z-b0-k0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 17, 18 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 16, 19 } } },
     .{ .lagrange_selector = 0 },
@@ -5460,7 +5460,7 @@ const system_33_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 2 }, // col: "z-b0-k0"
     .{ .column_claim = 3 }, // col: "z-b0-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 3, 4 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 5, 6 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 2, 7 } } },
     .{ .cell_value = .{ .round = 1, .index = 1 } }, // cell: "result"
@@ -5472,7 +5472,7 @@ const system_33_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 1 }, // col: "num"
     .{ .op = .{ .operator = .mul, .operands = &.{ 14, 15 } } },
     .{ .column_claim = 2 }, // col: "z-b0-k0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 17, 18 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 16, 19 } } },
     .{ .lagrange_selector = 0 },
@@ -5820,29 +5820,29 @@ pub const system_35_public_input = protocol.public_input.Spec{
 
 const system_35_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "c0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 0, 1 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 2, 3 } } },
     .{ .column_claim = 1 }, // col: "c1"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 5, 6 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 7, 8 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 4, 9 } } },
     .{ .column_claim = 2 }, // col: "c2"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 13, 14 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 10, 15 } } },
     .{ .column_claim = 3 }, // col: "z-b0-k0"
     .{ .column_claim = 4 }, // col: "z-b0-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 17, 18 } } },
-    .{ .constant = field.Element.init(1) },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 20, 21 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 22, 23 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 19, 24 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 16, 25 } } },
@@ -5850,31 +5850,31 @@ const system_35_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 6 }, // col: "z-b0-k1"
     .{ .column_claim = 7 }, // col: "z-b0-k1"
     .{ .op = .{ .operator = .sub, .operands = &.{ 28, 29 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 30, 31 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 27, 32 } } },
     .{ .column_claim = 0 }, // col: "c0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 34, 35 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 36, 37 } } },
     .{ .column_claim = 1 }, // col: "c1"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 39, 40 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 41, 42 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 38, 43 } } },
     .{ .column_claim = 2 }, // col: "c2"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 45, 46 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 47, 48 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 44, 49 } } },
     .{ .column_claim = 3 }, // col: "z-b0-k0"
-    .{ .constant = field.Element.init(1) },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 52, 53 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 54, 55 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 51, 56 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 50, 57 } } },
@@ -5887,7 +5887,7 @@ const system_35_module_0_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .mul, .operands = &.{ 63, 64 } } },
     .{ .column_claim = 5 }, // col: "c3"
     .{ .column_claim = 6 }, // col: "z-b0-k1"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 67, 68 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 66, 69 } } },
     .{ .lagrange_selector = 0 },
@@ -6094,12 +6094,12 @@ const system_36_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 1 }, // col: "z-b0-k0"
     .{ .column_claim = 2 }, // col: "z-b0-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 3, 4 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 5 } } },
     .{ .column_claim = 0 }, // col: "cA"
     .{ .column_claim = 1 }, // col: "z-b0-k0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 8, 9 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 7, 10 } } },
     .{ .lagrange_selector = 0 },
@@ -6131,7 +6131,7 @@ const system_36_module_1_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 2 }, // col: "z-b1-k0"
     .{ .column_claim = 3 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 3, 4 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 5, 6 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 2, 7 } } },
     .{ .cell_value = .{ .round = 1, .index = 2 } }, // cell: "result"
@@ -6143,7 +6143,7 @@ const system_36_module_1_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 1 }, // col: "cB"
     .{ .op = .{ .operator = .mul, .operands = &.{ 14, 15 } } },
     .{ .column_claim = 2 }, // col: "z-b1-k0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 17, 18 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 16, 19 } } },
     .{ .lagrange_selector = 0 },
@@ -6329,7 +6329,7 @@ pub const system_37_public_input = protocol.public_input.Spec{
 const system_37_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "num"
     .{ .column_claim = 1 }, // col: "z-b0-k0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 1, 2 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 3 } } },
     .{ .lagrange_selector = 0 },
@@ -6473,12 +6473,12 @@ pub const system_38_public_input = protocol.public_input.Spec{
 
 const system_38_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "filterS"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 0, 1 } } },
     .{ .column_claim = 1 }, // col: "z-b0-k0"
     .{ .column_claim = 2 }, // col: "z-b0-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 3, 4 } } },
-    .{ .constant = field.Element.init(7) },
+    .{ .constant = .{ .value = 7 } },
     .{ .column_claim = 3 }, // col: "S"
     .{ .op = .{ .operator = .add, .operands = &.{ 6, 7 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 5, 8 } } },
@@ -6489,10 +6489,10 @@ const system_38_module_0_expressions = [_]vanishing.ExprNode{
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 13, 14 } } },
     .{ .column_claim = 0 }, // col: "filterS"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 16, 17 } } },
     .{ .column_claim = 1 }, // col: "z-b0-k0"
-    .{ .constant = field.Element.init(7) },
+    .{ .constant = .{ .value = 7 } },
     .{ .column_claim = 3 }, // col: "S"
     .{ .op = .{ .operator = .add, .operands = &.{ 20, 21 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 19, 22 } } },
@@ -6524,7 +6524,7 @@ const system_38_module_1_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .column_claim = 2 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 2, 3 } } },
-    .{ .constant = field.Element.init(7) },
+    .{ .constant = .{ .value = 7 } },
     .{ .column_claim = 3 }, // col: "T"
     .{ .op = .{ .operator = .add, .operands = &.{ 5, 6 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 4, 7 } } },
@@ -6537,7 +6537,7 @@ const system_38_module_1_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "M"
     .{ .op = .{ .operator = .negate, .operands = &.{15} } },
     .{ .column_claim = 1 }, // col: "z-b1-k0"
-    .{ .constant = field.Element.init(7) },
+    .{ .constant = .{ .value = 7 } },
     .{ .column_claim = 3 }, // col: "T"
     .{ .op = .{ .operator = .add, .operands = &.{ 18, 19 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 17, 20 } } },
@@ -6739,56 +6739,56 @@ pub const system_39_public_input = protocol.public_input.Spec{
 
 const system_39_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "c0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 0, 1 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 2, 3 } } },
     .{ .column_claim = 1 }, // col: "c1"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 5, 6 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 7, 8 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 4, 9 } } },
     .{ .column_claim = 2 }, // col: "c2"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 13, 14 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 10, 15 } } },
     .{ .column_claim = 3 }, // col: "z-b0-k0"
     .{ .column_claim = 4 }, // col: "z-b0-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 17, 18 } } },
-    .{ .constant = field.Element.init(1) },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 20, 21 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 22, 23 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 19, 24 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 16, 25 } } },
     .{ .column_claim = 5 }, // col: "c3"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 27, 28 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 29, 30 } } },
     .{ .column_claim = 6 }, // col: "c4"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 32, 33 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 34, 35 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 31, 36 } } },
     .{ .column_claim = 7 }, // col: "c5"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 38, 39 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 40, 41 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 37, 42 } } },
     .{ .column_claim = 8 }, // col: "z-b0-k1"
     .{ .column_claim = 9 }, // col: "z-b0-k1"
     .{ .op = .{ .operator = .sub, .operands = &.{ 44, 45 } } },
-    .{ .constant = field.Element.init(1) },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 47, 48 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 49, 50 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 46, 51 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 43, 52 } } },
@@ -6796,31 +6796,31 @@ const system_39_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 11 }, // col: "z-b0-k2"
     .{ .column_claim = 12 }, // col: "z-b0-k2"
     .{ .op = .{ .operator = .sub, .operands = &.{ 55, 56 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 57, 58 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 54, 59 } } },
     .{ .column_claim = 0 }, // col: "c0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 61, 62 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 63, 64 } } },
     .{ .column_claim = 1 }, // col: "c1"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 66, 67 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 68, 69 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 65, 70 } } },
     .{ .column_claim = 2 }, // col: "c2"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 72, 73 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 74, 75 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 71, 76 } } },
     .{ .column_claim = 3 }, // col: "z-b0-k0"
-    .{ .constant = field.Element.init(1) },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 79, 80 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 81, 82 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 78, 83 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 77, 84 } } },
@@ -6832,27 +6832,27 @@ const system_39_module_0_expressions = [_]vanishing.ExprNode{
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 90, 91 } } },
     .{ .column_claim = 5 }, // col: "c3"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 93, 94 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 95, 96 } } },
     .{ .column_claim = 6 }, // col: "c4"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 98, 99 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 100, 101 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 97, 102 } } },
     .{ .column_claim = 7 }, // col: "c5"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 104, 105 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 106, 107 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 103, 108 } } },
     .{ .column_claim = 8 }, // col: "z-b0-k1"
-    .{ .constant = field.Element.init(1) },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 111, 112 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 113, 114 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 110, 115 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 109, 116 } } },
@@ -6865,7 +6865,7 @@ const system_39_module_0_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .mul, .operands = &.{ 122, 123 } } },
     .{ .column_claim = 10 }, // col: "c6"
     .{ .column_claim = 11 }, // col: "z-b0-k2"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 126, 127 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 125, 128 } } },
     .{ .lagrange_selector = 0 },
@@ -7103,12 +7103,12 @@ const system_40_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 1 }, // col: "z-b0-k0"
     .{ .column_claim = 2 }, // col: "z-b0-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 3, 4 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 5 } } },
     .{ .column_claim = 0 }, // col: "num"
     .{ .column_claim = 1 }, // col: "z-b0-k0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 8, 9 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 7, 10 } } },
     .{ .lagrange_selector = 0 },
@@ -7260,19 +7260,19 @@ const system_41_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 1 }, // col: "z-b0-k0"
     .{ .column_claim = 2 }, // col: "z-b0-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 3, 4 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 5 } } },
     .{ .column_claim = 3 }, // col: "c2"
     .{ .column_claim = 4 }, // col: "z-b0-k0"
     .{ .column_claim = 5 }, // col: "z-b0-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 8, 9 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 10, 11 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 7, 12 } } },
     .{ .column_claim = 0 }, // col: "c1"
     .{ .column_claim = 1 }, // col: "z-b0-k0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 15, 16 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 14, 17 } } },
     .{ .lagrange_selector = 0 },
@@ -7284,7 +7284,7 @@ const system_41_module_0_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .mul, .operands = &.{ 23, 24 } } },
     .{ .column_claim = 3 }, // col: "c2"
     .{ .column_claim = 4 }, // col: "z-b0-k0"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 27, 28 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 26, 29 } } },
     .{ .lagrange_selector = 0 },
@@ -7637,64 +7637,64 @@ const system_43_module_0_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "flt"
     .{ .column_claim = 1 }, // col: "n1"
     .{ .op = .{ .operator = .mul, .operands = &.{ 0, 1 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 2, 3 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 4, 5 } } },
     .{ .column_claim = 0 }, // col: "flt"
     .{ .column_claim = 2 }, // col: "n2"
     .{ .op = .{ .operator = .mul, .operands = &.{ 7, 8 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 9, 10 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 6, 13 } } },
     .{ .column_claim = 0 }, // col: "flt"
     .{ .column_claim = 3 }, // col: "n3"
     .{ .op = .{ .operator = .mul, .operands = &.{ 15, 16 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 17, 18 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 19, 20 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 14, 21 } } },
     .{ .column_claim = 4 }, // col: "z-b0-k0"
     .{ .column_claim = 5 }, // col: "z-b0-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 23, 24 } } },
-    .{ .constant = field.Element.init(1) },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 26, 27 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 28, 29 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 25, 30 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 22, 31 } } },
     .{ .column_claim = 0 }, // col: "flt"
     .{ .column_claim = 1 }, // col: "n1"
     .{ .op = .{ .operator = .mul, .operands = &.{ 33, 34 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 35, 36 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 37, 38 } } },
     .{ .column_claim = 0 }, // col: "flt"
     .{ .column_claim = 2 }, // col: "n2"
     .{ .op = .{ .operator = .mul, .operands = &.{ 40, 41 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 42, 43 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 44, 45 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 39, 46 } } },
     .{ .column_claim = 0 }, // col: "flt"
     .{ .column_claim = 3 }, // col: "n3"
     .{ .op = .{ .operator = .mul, .operands = &.{ 48, 49 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 50, 51 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 52, 53 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 47, 54 } } },
     .{ .column_claim = 4 }, // col: "z-b0-k0"
-    .{ .constant = field.Element.init(1) },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 57, 58 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 59, 60 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 56, 61 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 55, 62 } } },
@@ -7941,7 +7941,7 @@ const system_44_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_44_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -7955,7 +7955,7 @@ const system_44_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 9, 10 } } },
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 2 }, // col: "S"
@@ -8212,7 +8212,7 @@ const system_45_module_0_buckets = [_]vanishing.Bucket{
 
 const system_45_module_1_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "filterS"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 0, 1 } } },
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .column_claim = 2 }, // col: "z-b1-k0"
@@ -8228,7 +8228,7 @@ const system_45_module_1_expressions = [_]vanishing.ExprNode{
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 13, 14 } } },
     .{ .column_claim = 0 }, // col: "filterS"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 16, 17 } } },
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
@@ -8498,7 +8498,7 @@ const system_46_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_46_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -8506,7 +8506,7 @@ const system_46_module_1_expressions = [_]vanishing.ExprNode{
     .{ .coin_value = 1 }, // coin: "alpha"
     .{ .column_claim = 2 }, // col: "S"
     .{ .op = .{ .operator = .mul, .operands = &.{ 5, 6 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .add, .operands = &.{ 7, 8 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 4, 9 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 3, 10 } } },
@@ -8516,13 +8516,13 @@ const system_46_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 13, 14 } } },
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 15, 16 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .coin_value = 1 }, // coin: "alpha"
     .{ .column_claim = 2 }, // col: "S"
     .{ .op = .{ .operator = .mul, .operands = &.{ 21, 22 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .add, .operands = &.{ 23, 24 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 20, 25 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 19, 26 } } },
@@ -8790,7 +8790,7 @@ const system_47_module_0_buckets = [_]vanishing.Bucket{
 
 const system_47_module_1_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "filterS"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 0, 1 } } },
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .column_claim = 2 }, // col: "z-b1-k0"
@@ -8799,7 +8799,7 @@ const system_47_module_1_expressions = [_]vanishing.ExprNode{
     .{ .coin_value = 1 }, // coin: "alpha"
     .{ .column_claim = 3 }, // col: "S"
     .{ .op = .{ .operator = .mul, .operands = &.{ 7, 8 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .add, .operands = &.{ 9, 10 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 6, 11 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 5, 12 } } },
@@ -8810,14 +8810,14 @@ const system_47_module_1_expressions = [_]vanishing.ExprNode{
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 17, 18 } } },
     .{ .column_claim = 0 }, // col: "filterS"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 20, 21 } } },
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .coin_value = 1 }, // coin: "alpha"
     .{ .column_claim = 3 }, // col: "S"
     .{ .op = .{ .operator = .mul, .operands = &.{ 25, 26 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .add, .operands = &.{ 27, 28 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 24, 29 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 23, 30 } } },
@@ -9089,7 +9089,7 @@ const system_48_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_48_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -9107,7 +9107,7 @@ const system_48_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 13, 14 } } },
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 15, 16 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .coin_value = 1 }, // coin: "alpha"
@@ -9377,7 +9377,7 @@ const system_49_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_49_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -9391,7 +9391,7 @@ const system_49_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 9, 10 } } },
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 2 }, // col: "S1"
@@ -9420,7 +9420,7 @@ const system_49_module_1_buckets = [_]vanishing.Bucket{
 };
 
 const system_49_module_2_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b2-k0"
     .{ .column_claim = 1 }, // col: "z-b2-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -9434,7 +9434,7 @@ const system_49_module_2_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 9, 10 } } },
     .{ .lagrange_selector = 1 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b2-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 2 }, // col: "S2"
@@ -9768,7 +9768,7 @@ const system_50_module_1_buckets = [_]vanishing.Bucket{
 };
 
 const system_50_module_2_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -9782,7 +9782,7 @@ const system_50_module_2_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 9, 10 } } },
     .{ .lagrange_selector = 1 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 2 }, // col: "S1"
@@ -9811,7 +9811,7 @@ const system_50_module_2_buckets = [_]vanishing.Bucket{
 };
 
 const system_50_module_3_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b3-k0"
     .{ .column_claim = 1 }, // col: "z-b3-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -9825,7 +9825,7 @@ const system_50_module_3_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 9, 10 } } },
     .{ .lagrange_selector = 1 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b3-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 2 }, // col: "S2"
@@ -10175,7 +10175,7 @@ const system_51_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_51_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -10187,7 +10187,7 @@ const system_51_module_1_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 3 }, // col: "Sx"
     .{ .op = .{ .operator = .add, .operands = &.{ 8, 9 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 5, 10 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .add, .operands = &.{ 11, 12 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 4, 13 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 3, 14 } } },
@@ -10197,7 +10197,7 @@ const system_51_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 17, 18 } } },
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 19, 20 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .coin_value = 1 }, // coin: "alpha"
@@ -10207,7 +10207,7 @@ const system_51_module_1_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 3 }, // col: "Sx"
     .{ .op = .{ .operator = .add, .operands = &.{ 28, 29 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 25, 30 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .add, .operands = &.{ 31, 32 } } },
     .{ .op = .{ .operator = .add, .operands = &.{ 24, 33 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 23, 34 } } },
@@ -10476,7 +10476,7 @@ const system_52_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_52_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -10490,7 +10490,7 @@ const system_52_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 9, 10 } } },
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 2 }, // col: "S"
@@ -10746,7 +10746,7 @@ const system_53_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_53_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -10755,7 +10755,7 @@ const system_53_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .add, .operands = &.{ 4, 5 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 3, 6 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 0, 7 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 2 }, // col: "S"
@@ -11016,7 +11016,7 @@ const system_54_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_54_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -11030,7 +11030,7 @@ const system_54_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 9, 10 } } },
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 2 }, // col: "S"
@@ -11288,7 +11288,7 @@ const system_55_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_55_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -11302,7 +11302,7 @@ const system_55_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 9, 10 } } },
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 2 }, // col: "S1"
@@ -11331,7 +11331,7 @@ const system_55_module_1_buckets = [_]vanishing.Bucket{
 };
 
 const system_55_module_2_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b2-k0"
     .{ .column_claim = 1 }, // col: "z-b2-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -11345,7 +11345,7 @@ const system_55_module_2_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 9, 10 } } },
     .{ .lagrange_selector = 1 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b2-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 2 }, // col: "S2"
@@ -11650,7 +11650,7 @@ const system_56_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_56_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -11672,7 +11672,7 @@ const system_56_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 17, 18 } } },
     .{ .lagrange_selector = 1 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 19, 20 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .coin_value = 1 }, // coin: "alpha"
@@ -11944,7 +11944,7 @@ const system_57_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_57_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 1 }, // col: "S"
@@ -12197,7 +12197,7 @@ const system_58_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_58_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -12211,7 +12211,7 @@ const system_58_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 9, 10 } } },
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 2 }, // col: "S"
@@ -12468,7 +12468,7 @@ const system_59_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_59_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -12482,7 +12482,7 @@ const system_59_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 9, 10 } } },
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 11, 12 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 2 }, // col: "S"
@@ -12739,7 +12739,7 @@ const system_60_module_0_buckets = [_]vanishing.Bucket{
 
 const system_60_module_1_expressions = [_]vanishing.ExprNode{
     .{ .column_claim = 0 }, // col: "filterS"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 0, 1 } } },
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .column_claim = 2 }, // col: "z-b1-k0"
@@ -12755,7 +12755,7 @@ const system_60_module_1_expressions = [_]vanishing.ExprNode{
     .{ .lagrange_selector = 3 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 13, 14 } } },
     .{ .column_claim = 0 }, // col: "filterS"
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 16, 17 } } },
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
@@ -12972,12 +12972,12 @@ pub const system_61_public_input = protocol.public_input.Spec{
 // scenario: "rc-distinct"
 
 const system_61_module_0_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 0 }, // col: "colB"
     .{ .op = .{ .operator = .add, .operands = &.{ 1, 2 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 0, 3 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 1 }, // col: "colA"
     .{ .op = .{ .operator = .add, .operands = &.{ 6, 7 } } },
@@ -12995,12 +12995,12 @@ const system_61_module_0_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .mul, .operands = &.{ 16, 19 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 13, 20 } } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 10, 21 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 0 }, // col: "colB"
     .{ .op = .{ .operator = .add, .operands = &.{ 24, 25 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 23, 26 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .column_claim = 1 }, // col: "colA"
     .{ .op = .{ .operator = .add, .operands = &.{ 29, 30 } } },
@@ -13704,7 +13704,7 @@ pub const system_64_public_input = protocol.public_input.Spec{
 const system_64_module_0_expressions = [_]vanishing.ExprNode{
     .{ .lagrange_selector = 1 },
     .{ .column_claim = 0 }, // col: "col"
-    .{ .constant = field.Element.init(99) },
+    .{ .constant = .{ .value = 99 } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 0, 3 } } },
 };
@@ -13855,7 +13855,7 @@ pub const system_65_public_input = protocol.public_input.Spec{
 const system_65_module_0_expressions = [_]vanishing.ExprNode{
     .{ .lagrange_selector = 1 },
     .{ .column_claim = 0 }, // col: "col"
-    .{ .constant = field.Element.init(99) },
+    .{ .constant = .{ .value = 99 } },
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
     .{ .op = .{ .operator = .mul, .operands = &.{ 0, 3 } } },
 };
@@ -14080,7 +14080,7 @@ const system_66_module_0_buckets = [_]vanishing.Bucket{
 };
 
 const system_66_module_1_expressions = [_]vanishing.ExprNode{
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .column_claim = 1 }, // col: "z-b1-k0"
     .{ .op = .{ .operator = .sub, .operands = &.{ 1, 2 } } },
@@ -14110,7 +14110,7 @@ const system_66_module_1_expressions = [_]vanishing.ExprNode{
     .{ .op = .{ .operator = .sub, .operands = &.{ 25, 26 } } },
     .{ .lagrange_selector = 1023 },
     .{ .op = .{ .operator = .mul, .operands = &.{ 27, 28 } } },
-    .{ .constant = field.Element.init(1) },
+    .{ .constant = .{ .value = 1 } },
     .{ .column_claim = 0 }, // col: "z-b1-k0"
     .{ .coin_value = 0 }, // coin: "gamma"
     .{ .coin_value = 1 }, // coin: "alpha"


### PR DESCRIPTION
## What

Three independent bugfixes surfaced while running a real, full-scale RISC-V proof through the Zig verifier (smaller synthetic fixtures didn't exercise any of these paths):

1. **PCS aliasing-shift false rejection** (`src/query/pcs.zig`, `test/pcs_test.zig`)
   `reconstruct()` rejected honest dynamic-module sizes when two raw shifts aliased to the same domain point, while prover-ray's `RecoverBatchClaims` legitimately dedupes them before batching. Applies the same dedup in `reconstructQueryValueAt` instead of enforcing `dyn.min_size_log2` as a floor.

2. **Comptime monomorphization blowup in vanishing evaluation** (`src/query/vanishing.zig`, `src/query/logderivativesum.zig`, `codegen/vanishing_zig.go`)
   `evalExpr`/`evalOp` took the expression-tree index/op as `comptime` parameters, so Zig generated a distinct function instantiation per unique node ever evaluated. Real arithmetization modules carry thousands of expression nodes, which blew up into a stack overflow well before any actual recursion-depth problem. Makes `expr_index`/`op` ordinary runtime parameters while keeping `module`/`static_n` comptime, bounding recursion by each module's actual (shallow) expression-tree depth. Also raises the comptime branch-eval quota in `logderivativesum.zig`, and switches codegen's constant-literal emission from `field.Element.init(...)` to a direct struct literal — same "large real module exceeds default comptime limits" family of fix. Includes regenerated `testdata/generated/{vanishing,verify}.zig` fixtures reflecting that literal-syntax change (otherwise `make verify-testdata` would fail).

3. **Stale `prover-ray` module pin breaks the codegen/testdata-generate build** (`codegen/go.mod`, `testdata/generate/go.mod`)
   Both modules required a `prover-ray` pseudo-version pinned to an older commit whose own `go.mod` declares `github.com/LFDT-Lineth/zkc v1.2.25-...`, while this branch's own base (`fixup/bug-in-proofserialization-roundcount`) is already at `zkc v1.2.27`. Any `prover-ray` package that calls a zkc API only present in the newer version breaks `go build`/`make generate-testdata` against the stale pin. Bumps both requirements to the pseudo-version for that base commit (`v0.0.0-20260824082906-f6a0ec502d4d`), so both modules resolve through the real module proxy like every other dependency, rather than pointing at a stale point-in-time snapshot.



Part 1 of a split of #3832.

## Testing

`zig build test`: 76/76 passing. `go test ./codegen/...`: passing. `make generate-testdata` / `make verify-testdata`: passing (no drift) with `prover-ray` resolved via the real module proxy.