### PR TITLE
chore(ci): add injectible besu package image name in e2e local stack …

### DIFF
--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -115,17 +115,6 @@ runs:
         mkdir -p tmp/local/traces/v2/conflated
         chmod -R a+rw tmp/local/
 
-    - name: Pull all external-to-monorepo images with retry
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
-      if: ${{ inputs.linea_besu_package_tag == '' }}
-      with:
-        max_attempts: 10
-        retry_on: error
-        retry_wait_seconds: 30
-        timeout_minutes: 10
-        command: |
-          cd ${{ inputs.working-directory }} && make docker-pull-images-external-to-monorepo
-
     - name: Download local docker image artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       continue-on-error: true
@@ -225,6 +214,16 @@ runs:
         # Propagate the tag to later steps (e.g. compose spin-up) regardless of artifact presence.
         # BESU_PACKAGE_IMAGE_NAME is exported unconditionally in the earlier "Set Docker image tags" step.
         echo "LINEA_BESU_PACKAGE_TAG=${LINEA_BESU_PACKAGE_TAG}" >> "$GITHUB_ENV"
+    
+    - name: Pull all external-to-monorepo images with retry
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
+      with:
+        max_attempts: 10
+        retry_on: error
+        retry_wait_seconds: 30
+        timeout_minutes: 10
+        command: |
+          cd ${{ inputs.working-directory }} && make docker-pull-images-external-to-monorepo
 
     - name: Spin up fresh environment with retry
       shell: bash

--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -11,6 +11,14 @@ inputs:
   linea_besu_package_tag:
     required: false
     default: ''
+  linea_besu_package_image_name:
+    description: 'linea-besu-package Docker image name (overrides the compose default)'
+    required: false
+    default: consensys/linea-besu-package
+  linea_besu_package_artifact_filename:
+    description: 'Filename of the gzipped besu-package image tarball inside tmp/artifacts'
+    required: false
+    default: linea-besu-package-images.tar.gz
   coordinator_tag:
     required: false
     default: ''
@@ -201,16 +209,20 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       env:
         LINEA_BESU_PACKAGE_TAG: ${{ inputs.linea_besu_package_tag }}
+        BESU_PACKAGE_IMAGE_NAME: ${{ inputs.linea_besu_package_image_name }}
+        BESU_PACKAGE_ARTIFACT_FILENAME: ${{ inputs.linea_besu_package_artifact_filename }}
       run: |
         set -euo pipefail
-        artifact_path="$GITHUB_WORKSPACE/${{ inputs.working-directory }}/tmp/artifacts/linea-besu-package-images.tar.gz"
+        artifact_path="$GITHUB_WORKSPACE/${{ inputs.working-directory }}/tmp/artifacts/${BESU_PACKAGE_ARTIFACT_FILENAME}"
         if [ -f "$artifact_path" ]; then
           gunzip -c "$artifact_path" | docker load
         else
           echo "No artifact at ${artifact_path}; skipping docker load."
         fi
-        # Propagate the tag to later steps (e.g. compose spin-up) regardless of artifact presence.
+        # Propagate the tag and image name to later steps (e.g. compose spin-up) regardless of
+        # artifact presence. BESU_PACKAGE_IMAGE_NAME overrides the compose default image name.
         echo "LINEA_BESU_PACKAGE_TAG=${LINEA_BESU_PACKAGE_TAG}" >> "$GITHUB_ENV"
+        echo "BESU_PACKAGE_IMAGE_NAME=${BESU_PACKAGE_IMAGE_NAME}" >> "$GITHUB_ENV"
 
     - name: Spin up fresh environment with retry
       shell: bash

--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -174,6 +174,7 @@ runs:
         MARU_IMAGE_NAME: ${{ inputs.maru_image_name }}
         MARU_TAG: ${{ inputs.maru_tag }}
         MARU_JAR: ${{ inputs.maru_jar }}
+        BESU_PACKAGE_IMAGE_NAME: ${{ inputs.linea_besu_package_image_name }}
       run: |
         set -euo pipefail
         for service in coordinator postman transaction-exclusion-api prover maru; do
@@ -202,6 +203,9 @@ runs:
         echo "LINEA_COORDINATOR_JAR=${LINEA_COORDINATOR_JAR}" >> "$GITHUB_ENV"
         echo "MARU_IMAGE_NAME=${MARU_IMAGE_NAME}" >> "$GITHUB_ENV"
         echo "MARU_JAR=${MARU_JAR}" >> "$GITHUB_ENV"
+        # Exported unconditionally (like the coordinator/maru image names above) so a caller can
+        # override the besu-package image name even when no tag/artifact is supplied.
+        echo "BESU_PACKAGE_IMAGE_NAME=${BESU_PACKAGE_IMAGE_NAME}" >> "$GITHUB_ENV"
 
     - name: Load linea-besu-package Docker image
       if: ${{ inputs.linea_besu_package_tag != '' }}
@@ -209,7 +213,6 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       env:
         LINEA_BESU_PACKAGE_TAG: ${{ inputs.linea_besu_package_tag }}
-        BESU_PACKAGE_IMAGE_NAME: ${{ inputs.linea_besu_package_image_name }}
         BESU_PACKAGE_ARTIFACT_FILENAME: ${{ inputs.linea_besu_package_artifact_filename }}
       run: |
         set -euo pipefail
@@ -219,10 +222,9 @@ runs:
         else
           echo "No artifact at ${artifact_path}; skipping docker load."
         fi
-        # Propagate the tag and image name to later steps (e.g. compose spin-up) regardless of
-        # artifact presence. BESU_PACKAGE_IMAGE_NAME overrides the compose default image name.
+        # Propagate the tag to later steps (e.g. compose spin-up) regardless of artifact presence.
+        # BESU_PACKAGE_IMAGE_NAME is exported unconditionally in the earlier "Set Docker image tags" step.
         echo "LINEA_BESU_PACKAGE_TAG=${LINEA_BESU_PACKAGE_TAG}" >> "$GITHUB_ENV"
-        echo "BESU_PACKAGE_IMAGE_NAME=${BESU_PACKAGE_IMAGE_NAME}" >> "$GITHUB_ENV"
 
     - name: Spin up fresh environment with retry
       shell: bash

--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -216,6 +216,11 @@ runs:
         echo "LINEA_BESU_PACKAGE_TAG=${LINEA_BESU_PACKAGE_TAG}" >> "$GITHUB_ENV"
     
     - name: Pull all external-to-monorepo images with retry
+      # Skip when a besu-package artifact/tag is supplied: the besu-package services carry the
+      # external-to-monorepo profile, so this pull would fetch ${BESU_PACKAGE_IMAGE_NAME}:${LINEA_BESU_PACKAGE_TAG}
+      # from the registry — failing on unpublished CI tags, or overwriting the image just loaded from
+      # the artifact. Genuinely-missing external images are still pulled by compose on spin-up.
+      if: ${{ inputs.linea_besu_package_tag == '' }}
       uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
       with:
         max_attempts: 10

--- a/docker/compose-spec-l1-services.yml
+++ b/docker/compose-spec-l1-services.yml
@@ -2,7 +2,7 @@ services:
   l1-el-node:
     container_name: l1-el-node
     hostname: l1-el-node
-    image: consensys/linea-besu-package:${LINEA_BESU_PACKAGE_TAG:-2.1.1-20260811-0f74f55}
+    image: ${BESU_PACKAGE_IMAGE_NAME:-consensys/linea-besu-package}:${LINEA_BESU_PACKAGE_TAG:-2.1.1-20260811-0f74f55}
     profiles: [ "l1", "debug", "external-to-monorepo" ]
     depends_on:
       l1-node-genesis-generator:

--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -58,7 +58,7 @@ services:
   sequencer:
     hostname: sequencer
     container_name: sequencer
-    image: consensys/linea-besu-package:${LINEA_BESU_PACKAGE_TAG:-2.1.1-20260811-0f74f55}
+    image: ${BESU_PACKAGE_IMAGE_NAME:-consensys/linea-besu-package}:${LINEA_BESU_PACKAGE_TAG:-2.1.1-20260811-0f74f55}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       l2-genesis-initialization:
@@ -146,7 +146,7 @@ services:
   l2-node-besu:
     hostname: l2-node-besu
     container_name: l2-node-besu
-    image: consensys/linea-besu-package:${LINEA_BESU_PACKAGE_TAG:-2.1.1-20260811-0f74f55}
+    image: ${BESU_PACKAGE_IMAGE_NAME:-consensys/linea-besu-package}:${LINEA_BESU_PACKAGE_TAG:-2.1.1-20260811-0f74f55}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       sequencer:
@@ -686,7 +686,7 @@ services:
         ipv4_address: 10.10.10.205
 
   zkbesu-shomei-sr:
-    image: consensys/linea-besu-package:${LINEA_BESU_PACKAGE_TAG:-2.1.1-20260811-0f74f55}
+    image: ${BESU_PACKAGE_IMAGE_NAME:-consensys/linea-besu-package}:${LINEA_BESU_PACKAGE_TAG:-2.1.1-20260811-0f74f55}
     hostname: zkbesu-shomei-sr
     container_name: zkbesu-shomei-sr
     profiles: [ "staterecovery", "external-to-monorepo" ]


### PR DESCRIPTION
…and in the run-e2e-tests action

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI e2e wiring and Docker Compose image references; no runtime application or security-sensitive logic is modified.
> 
> **Overview**
> E2E CI can now override which **linea-besu-package** image and artifact tarball are used, and compose picks that up via **`BESU_PACKAGE_IMAGE_NAME`** instead of a hardcoded `consensys/linea-besu-package` on L1/L2 besu services.
> 
> The **`run-e2e-tests`** composite action adds optional inputs for image name and artifact filename, exports **`BESU_PACKAGE_IMAGE_NAME`** to the job environment (even without a besu tag), and loads besu from a configurable path under `tmp/artifacts`. The **external-to-monorepo** image pull step runs **after** besu load and is **skipped** when `linea_besu_package_tag` is set, so CI does not pull or overwrite a locally loaded besu image with an unpublished registry tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ceacbae40c5cd776dd44482ccad9a72a45ac7d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->