### PR TITLE
docs(misc): add Lineth community call calendar link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ If you already have an understanding of the tech stack, use our [Get Started](do
 
 For developers looking to build services locally (such as, the coordinator), see our detailed [Local Development Guide](docs/local-development-guide.md).
 
+## Lineth community calls
+
+Find the details to join the monthly Lineth community call in the [Lineth calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lineth?view=week).
+
 ## Agent Documentation
 
 For AI coding agents and developer tools:


### PR DESCRIPTION
## Summary

Adds a "Lineth community calls" section to the README (after "Get started"), linking to the Lineth/LFDT community calendar: https://zoom-lfx.platform.linuxfoundation.org/meetings/lineth?view=week

Requested by Simon Nunes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no impact on runtime behavior, security, or release artifacts.
> 
> **Overview**
> Adds a **Lineth community calls** section to the root `README`, placed after **Get started** and before **Agent Documentation**.
> 
> The section points readers to the monthly call schedule via the [Lineth calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lineth?view=week) on the Linux Foundation meeting platform.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1b5156a1d11b3dcac1ddd174313cbe68d77c75e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->