### PR TITLE
fix(ci): derive e2e image configuration from artifacts

### DIFF
--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -11,14 +11,6 @@ inputs:
   linea_besu_package_tag:
     required: false
     default: ''
-  linea_besu_package_image_name:
-    description: 'linea-besu-package Docker image name (overrides the compose default)'
-    required: false
-    default: consensys/linea-besu-package
-  linea_besu_package_artifact_filename:
-    description: 'Filename of the gzipped besu-package image tarball inside tmp/artifacts'
-    required: false
-    default: linea-besu-package-images.tar.gz
   coordinator_tag:
     required: false
     default: ''
@@ -34,30 +26,6 @@ inputs:
   maru_tag:
     required: false
     default: ''
-  maru_image_name:
-    description: 'Maru Docker image name (overrides the compose default)'
-    required: false
-    default: consensys/maru
-  maru_jar:
-    description: 'Maru JAR filename to launch'
-    required: false
-    default: maru.jar
-  maru_artifact_name:
-    description: 'Artifact name prefix for the Maru Docker image'
-    required: false
-    default: linea-maru
-  linea_coordinator_image_name:
-    description: 'Coordinator Docker image name (overrides the compose default)'
-    required: false
-    default: consensys/linea-coordinator
-  linea_coordinator_jar:
-    description: 'Coordinator JAR filename to launch'
-    required: false
-    default: coordinator.jar
-  linea_coordinator_artifact_name:
-    description: 'Artifact name prefix for the coordinator Docker image'
-    required: false
-    default: linea-coordinator
   e2e-tests-with-ssh:
     description: Run end to end tests with ability to ssh into environment
     required: false
@@ -123,104 +91,65 @@ runs:
         path: ${{ github.workspace }}/${{ inputs.working-directory }}/tmp/artifacts
         merge-multiple: true
 
-    - name: Load Docker images from artifacts
+    - name: Load Docker image artifacts and select tags
+      id: load_images
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:
-        LINEA_COORDINATOR_ARTIFACT_NAME: ${{ inputs.linea_coordinator_artifact_name }}
-        MARU_ARTIFACT_NAME: ${{ inputs.maru_artifact_name }}
-      run: |
-        set -euo pipefail
-        for service in coordinator postman transaction-exclusion-api prover maru; do
-          if [ "$service" = "maru" ]; then
-            artifact_path="$GITHUB_WORKSPACE/${{ inputs.working-directory }}/tmp/artifacts/${MARU_ARTIFACT_NAME}-docker-image.tar.gz"
-          elif [ "$service" = "coordinator" ]; then
-            artifact_path="$GITHUB_WORKSPACE/${{ inputs.working-directory }}/tmp/artifacts/${LINEA_COORDINATOR_ARTIFACT_NAME}-docker-image.tar.gz"
-          else
-            artifact_path="$GITHUB_WORKSPACE/${{ inputs.working-directory }}/tmp/artifacts/linea-${service}-docker-image.tar.gz"
-          fi
-
-          if [ -f "$artifact_path" ]; then
-            echo "Loading ${service} from build artifact ${artifact_path}..."
-            gunzip -c "$artifact_path" | docker load
-          else
-            echo "No artifact found for ${service}, skipping."
-          fi
-        done
-
-    - name: Set Docker image tags
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
-      env:
-        LINEA_COORDINATOR_ARTIFACT_NAME: ${{ inputs.linea_coordinator_artifact_name }}
-        LINEA_COORDINATOR_IMAGE_NAME: ${{ inputs.linea_coordinator_image_name }}
-        LINEA_COORDINATOR_JAR: ${{ inputs.linea_coordinator_jar }}
+        IMAGE_TAG: ${{ inputs.image_tag }}
+        LINEA_BESU_PACKAGE_TAG: ${{ inputs.linea_besu_package_tag }}
         LINEA_COORDINATOR_TAG: ${{ inputs.coordinator_tag }}
         LINEA_POSTMAN_TAG: ${{ inputs.postman_tag }}
         LINEA_PROVER_TAG: ${{ inputs.prover_tag }}
         LINEA_TRANSACTION_EXCLUSION_API_TAG: ${{ inputs.tx_exclusion_api_tag }}
-        MARU_ARTIFACT_NAME: ${{ inputs.maru_artifact_name }}
-        MARU_IMAGE_NAME: ${{ inputs.maru_image_name }}
         MARU_TAG: ${{ inputs.maru_tag }}
-        MARU_JAR: ${{ inputs.maru_jar }}
-        BESU_PACKAGE_IMAGE_NAME: ${{ inputs.linea_besu_package_image_name }}
       run: |
         set -euo pipefail
-        for service in coordinator postman transaction-exclusion-api prover maru; do
-          if [ "$service" = "maru" ]; then
-            artifact_path="$GITHUB_WORKSPACE/${{ inputs.working-directory }}/tmp/artifacts/${MARU_ARTIFACT_NAME}-docker-image.tar.gz"
-            env_var="MARU_TAG"
-          elif [ "$service" = "coordinator" ]; then
-            artifact_path="$GITHUB_WORKSPACE/${{ inputs.working-directory }}/tmp/artifacts/${LINEA_COORDINATOR_ARTIFACT_NAME}-docker-image.tar.gz"
-            env_var="LINEA_COORDINATOR_TAG"
-          else
-            artifact_path="$GITHUB_WORKSPACE/${{ inputs.working-directory }}/tmp/artifacts/linea-${service}-docker-image.tar.gz"
-            env_var="LINEA_$(echo "${service}" | tr '[:lower:]-' '[:upper:]_')_TAG"
-          fi
+        artifact_dir="$GITHUB_WORKSPACE/${{ inputs.working-directory }}/tmp/artifacts"
+        loaded_images="$(mktemp)"
+        shopt -s nullglob
+        artifacts=("$artifact_dir"/*.tar.gz)
 
-          if [ -f "$artifact_path" ]; then
-            echo "${env_var}=${{ inputs.image_tag }}" >> "$GITHUB_ENV"
-          elif [ -z "${!env_var:-}" ]; then
-            # Fall back to "develop" only when the job-level env var is unset or empty.
-            echo "${env_var}=develop" >> "$GITHUB_ENV"
-          else
-            # Propagate the caller-supplied tag to later steps (e.g. compose spin-up).
-            echo "${env_var}=${!env_var}" >> "$GITHUB_ENV"
+        for artifact in "${artifacts[@]}"; do
+          if ! repo_tags="$(
+            tar -xOzf "$artifact" manifest.json 2>/dev/null |
+              jq -er '.[].RepoTags[]?'
+          )"; then
+            echo "Skipping non-Docker artifact ${artifact}."
+            continue
           fi
+          echo "Loading Docker image artifact ${artifact}..."
+          printf '%s\n' "$repo_tags" >> "$loaded_images"
+          gunzip -c "$artifact" | docker load
         done
-        echo "LINEA_COORDINATOR_IMAGE_NAME=${LINEA_COORDINATOR_IMAGE_NAME}" >> "$GITHUB_ENV"
-        echo "LINEA_COORDINATOR_JAR=${LINEA_COORDINATOR_JAR}" >> "$GITHUB_ENV"
-        echo "MARU_IMAGE_NAME=${MARU_IMAGE_NAME}" >> "$GITHUB_ENV"
-        echo "MARU_JAR=${MARU_JAR}" >> "$GITHUB_ENV"
-        # Exported unconditionally (like the coordinator/maru image names above) so a caller can
-        # override the besu-package image name even when no tag/artifact is supplied.
-        echo "BESU_PACKAGE_IMAGE_NAME=${BESU_PACKAGE_IMAGE_NAME}" >> "$GITHUB_ENV"
 
-    - name: Load linea-besu-package Docker image
-      if: ${{ inputs.linea_besu_package_tag != '' }}
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
-      env:
-        LINEA_BESU_PACKAGE_TAG: ${{ inputs.linea_besu_package_tag }}
-        BESU_PACKAGE_ARTIFACT_FILENAME: ${{ inputs.linea_besu_package_artifact_filename }}
-      run: |
-        set -euo pipefail
-        artifact_path="$GITHUB_WORKSPACE/${{ inputs.working-directory }}/tmp/artifacts/${BESU_PACKAGE_ARTIFACT_FILENAME}"
-        if [ -f "$artifact_path" ]; then
-          gunzip -c "$artifact_path" | docker load
-        else
-          echo "No artifact at ${artifact_path}; skipping docker load."
-        fi
-        # Propagate the tag to later steps (e.g. compose spin-up) regardless of artifact presence.
-        # BESU_PACKAGE_IMAGE_NAME is exported unconditionally in the earlier "Set Docker image tags" step.
-        echo "LINEA_BESU_PACKAGE_TAG=${LINEA_BESU_PACKAGE_TAG}" >> "$GITHUB_ENV"
+        while read -r env_var image; do
+          image_ref="${image}:${IMAGE_TAG}"
+          if grep -Fqx "$image_ref" "$loaded_images"; then
+            selected_tag="$IMAGE_TAG"
+            if [ "$env_var" = "LINEA_BESU_PACKAGE_TAG" ]; then
+              echo "besu_package_loaded=true" >> "$GITHUB_OUTPUT"
+            fi
+          elif [ -n "${!env_var:-}" ]; then
+            selected_tag="${!env_var}"
+          else
+            selected_tag="develop"
+          fi
+          echo "${env_var}=${selected_tag}" >> "$GITHUB_ENV"
+        done <<'EOF'
+        LINEA_BESU_PACKAGE_TAG consensys/linea-besu-package
+        LINEA_COORDINATOR_TAG consensys/linea-coordinator
+        LINEA_POSTMAN_TAG consensys/linea-postman
+        LINEA_PROVER_TAG consensys/linea-prover
+        LINEA_TRANSACTION_EXCLUSION_API_TAG consensys/linea-transaction-exclusion-api
+        MARU_TAG consensys/maru
+        EOF
     
     - name: Pull all external-to-monorepo images with retry
       # Skip when a besu-package artifact/tag is supplied: the besu-package services carry the
-      # external-to-monorepo profile, so this pull would fetch ${BESU_PACKAGE_IMAGE_NAME}:${LINEA_BESU_PACKAGE_TAG}
-      # from the registry — failing on unpublished CI tags, or overwriting the image just loaded from
-      # the artifact. Genuinely-missing external images are still pulled by compose on spin-up.
-      if: ${{ inputs.linea_besu_package_tag == '' }}
+      # external-to-monorepo profile, so this pull would fetch an unpublished CI tag or overwrite
+      # the image just loaded from the artifact. Missing external images are pulled on spin-up.
+      if: ${{ inputs.linea_besu_package_tag == '' && steps.load_images.outputs.besu_package_loaded != 'true' }}
       uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
       with:
         max_attempts: 10

--- a/coordinator/Dockerfile
+++ b/coordinator/Dockerfile
@@ -34,6 +34,9 @@ RUN mkdir -p logs /tmp/prover/request /tmp/prover/response
 
 COPY --from=builder /libs/** libs/
 
+ARG LINETH_APP_JAR=/opt/consensys/linea/coordinator/libs/coordinator.jar
+ENV LINETH_APP_JAR=$LINETH_APP_JAR
+
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
 ARG VCS_REF

--- a/docker/compose-spec-l1-services.yml
+++ b/docker/compose-spec-l1-services.yml
@@ -2,7 +2,7 @@ services:
   l1-el-node:
     container_name: l1-el-node
     hostname: l1-el-node
-    image: ${BESU_PACKAGE_IMAGE_NAME:-consensys/linea-besu-package}:${LINEA_BESU_PACKAGE_TAG:-2.1.1-20260811-0f74f55}
+    image: consensys/linea-besu-package:${LINEA_BESU_PACKAGE_TAG:-2.1.1-20260811-0f74f55}
     profiles: [ "l1", "debug", "external-to-monorepo" ]
     depends_on:
       l1-node-genesis-generator:

--- a/docker/compose-spec-l1-services.yml
+++ b/docker/compose-spec-l1-services.yml
@@ -2,7 +2,7 @@ services:
   l1-el-node:
     container_name: l1-el-node
     hostname: l1-el-node
-    image: consensys/linea-besu-package:${LINEA_BESU_PACKAGE_TAG:-2.1.1-20260811-0f74f55}
+    image: ${BESU_PACKAGE_IMAGE_NAME:-consensys/linea-besu-package}:${LINEA_BESU_PACKAGE_TAG:-2.1.1-20260811-0f74f55}
     profiles: [ "l1", "debug", "external-to-monorepo" ]
     depends_on:
       l1-node-genesis-generator:

--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -13,7 +13,7 @@ services:
       - ./config/coordinator/coordinator-config-v2.toml:/coordinator/coordinator-config-v2.toml:ro
 
   maru:
-    image: ${MARU_IMAGE_NAME:-consensys/maru}:${MARU_TAG:-1.3.0-20260714-ced387a}
+    image: consensys/maru:${MARU_TAG:-1.3.0-20260714-ced387a}
     hostname: maru
     container_name: maru
     profiles: [ "l2", "l2-bc", "debug" ]
@@ -22,17 +22,18 @@ services:
         condition: service_healthy
     environment:
       LINETH_USE_MARU_OVERRIDE_CONFIG: ${LINETH_USE_MARU_OVERRIDE_CONFIG:-false}
-      # Which jar to launch. Override to point at a different entrypoint jar.
-      MARU_COMMAND: exec java -Xmx384m -Dlog4j2.configurationFile=configs/log4j.xml -jar ${MARU_JAR:-maru.jar} --genesis-file /initialization/genesis-maru.json --config configs/config.toml
     command:
       - /bin/sh
       - -c
       - |
+        set -- java -Xmx384m -Dlog4j2.configurationFile=configs/log4j.xml \
+          -jar "$$LINETH_APP_JAR" \
+          --genesis-file /initialization/genesis-maru.json \
+          --config configs/config.toml
         if [ "$$LINETH_USE_MARU_OVERRIDE_CONFIG" = "true" ]; then
-          $$MARU_COMMAND --config configs/config.overrides.toml
-        else
-          $$MARU_COMMAND
+          set -- "$$@" --config configs/config.overrides.toml
         fi
+        exec "$$@"
 #    command: [ 'echo' , 'Forced exit to run in IntellIJ' ]
     volumes:
       - ./config/maru/sequencer.config.toml:/opt/consensys/maru/configs/config.toml:ro
@@ -58,7 +59,7 @@ services:
   sequencer:
     hostname: sequencer
     container_name: sequencer
-    image: ${BESU_PACKAGE_IMAGE_NAME:-consensys/linea-besu-package}:${LINEA_BESU_PACKAGE_TAG:-2.1.1-20260811-0f74f55}
+    image: consensys/linea-besu-package:${LINEA_BESU_PACKAGE_TAG:-2.1.1-20260811-0f74f55}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       l2-genesis-initialization:
@@ -146,7 +147,7 @@ services:
   l2-node-besu:
     hostname: l2-node-besu
     container_name: l2-node-besu
-    image: ${BESU_PACKAGE_IMAGE_NAME:-consensys/linea-besu-package}:${LINEA_BESU_PACKAGE_TAG:-2.1.1-20260811-0f74f55}
+    image: consensys/linea-besu-package:${LINEA_BESU_PACKAGE_TAG:-2.1.1-20260811-0f74f55}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       sequencer:
@@ -353,7 +354,7 @@ services:
   coordinator:
     hostname: coordinator
     container_name: coordinator
-    image: ${LINEA_COORDINATOR_IMAGE_NAME:-consensys/linea-coordinator}:${LINEA_COORDINATOR_TAG:-1.1.0-20260728-703923b}
+    image: consensys/linea-coordinator:${LINEA_COORDINATOR_TAG:-1.1.0-20260728-703923b}
     profiles: [ "l2", "debug" ]
     depends_on:
       l2-genesis-initialization:
@@ -384,8 +385,6 @@ services:
       config__override__l1_submission__data_availability: ${LINETH_COORDINATOR_DATA_AVAILABILITY:-ROLLUP}
       dev_LINETH_COORDINATOR_DISABLED: ${dev_LINETH_COORDINATOR_DISABLED:-false}
       CONFIG_OVERRIDE_OPTS: ''
-      # Which jar to launch from libs/. Override to point at a different entrypoint jar.
-      COORDINATOR_JAR: ${LINEA_COORDINATOR_JAR:-coordinator.jar}
     command:
       - sh
       - -c
@@ -399,7 +398,7 @@ services:
             -Dvertx.configurationFile=/var/lib/coordinator/vertx-options.json \
             -Dlog4j2.configurationFile=/var/lib/coordinator/log4j2-dev.xml \
             $$CONFIG_OVERRIDE_OPTS \
-            -jar libs/$$COORDINATOR_JAR \
+            -jar "$$LINETH_APP_JAR" \
             --traces-limits-v5 config/traces-limits-v5.toml \
             --smart-contract-errors config/smart-contract-errors.toml \
             --gas-price-cap-time-of-day-multipliers config/gas-price-cap-time-of-day-multipliers.toml \
@@ -686,7 +685,7 @@ services:
         ipv4_address: 10.10.10.205
 
   zkbesu-shomei-sr:
-    image: ${BESU_PACKAGE_IMAGE_NAME:-consensys/linea-besu-package}:${LINEA_BESU_PACKAGE_TAG:-2.1.1-20260811-0f74f55}
+    image: consensys/linea-besu-package:${LINEA_BESU_PACKAGE_TAG:-2.1.1-20260811-0f74f55}
     hostname: zkbesu-shomei-sr
     container_name: zkbesu-shomei-sr
     profiles: [ "staterecovery", "external-to-monorepo" ]

--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -27,7 +27,7 @@ services:
       - -c
       - |
         set -- java -Xmx384m -Dlog4j2.configurationFile=configs/log4j.xml \
-          -jar "$$LINETH_APP_JAR" \
+          -jar "$${LINETH_APP_JAR:-/opt/consensys/maru/maru.jar}" \
           --genesis-file /initialization/genesis-maru.json \
           --config configs/config.toml
         if [ "$$LINETH_USE_MARU_OVERRIDE_CONFIG" = "true" ]; then
@@ -398,7 +398,7 @@ services:
             -Dvertx.configurationFile=/var/lib/coordinator/vertx-options.json \
             -Dlog4j2.configurationFile=/var/lib/coordinator/log4j2-dev.xml \
             $$CONFIG_OVERRIDE_OPTS \
-            -jar "$$LINETH_APP_JAR" \
+            -jar "$${LINETH_APP_JAR:-/opt/consensys/linea/coordinator/libs/coordinator.jar}" \
             --traces-limits-v5 config/traces-limits-v5.toml \
             --smart-contract-errors config/smart-contract-errors.toml \
             --gas-price-cap-time-of-day-multipliers config/gas-price-cap-time-of-day-multipliers.toml \

--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -13,7 +13,7 @@ services:
       - ./config/coordinator/coordinator-config-v2.toml:/coordinator/coordinator-config-v2.toml:ro
 
   maru:
-    image: consensys/maru:${MARU_TAG:-1.3.0-20260714-ced387a}
+    image: ${MARU_IMAGE_NAME:-consensys/maru}:${MARU_TAG:-1.3.0-20260714-ced387a}
     hostname: maru
     container_name: maru
     profiles: [ "l2", "l2-bc", "debug" ]
@@ -59,7 +59,7 @@ services:
   sequencer:
     hostname: sequencer
     container_name: sequencer
-    image: consensys/linea-besu-package:${LINEA_BESU_PACKAGE_TAG:-2.1.1-20260811-0f74f55}
+    image: ${BESU_PACKAGE_IMAGE_NAME:-consensys/linea-besu-package}:${LINEA_BESU_PACKAGE_TAG:-2.1.1-20260811-0f74f55}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       l2-genesis-initialization:
@@ -147,7 +147,7 @@ services:
   l2-node-besu:
     hostname: l2-node-besu
     container_name: l2-node-besu
-    image: consensys/linea-besu-package:${LINEA_BESU_PACKAGE_TAG:-2.1.1-20260811-0f74f55}
+    image: ${BESU_PACKAGE_IMAGE_NAME:-consensys/linea-besu-package}:${LINEA_BESU_PACKAGE_TAG:-2.1.1-20260811-0f74f55}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       sequencer:
@@ -354,7 +354,7 @@ services:
   coordinator:
     hostname: coordinator
     container_name: coordinator
-    image: consensys/linea-coordinator:${LINEA_COORDINATOR_TAG:-1.1.0-20260728-703923b}
+    image: ${LINEA_COORDINATOR_IMAGE_NAME:-consensys/linea-coordinator}:${LINEA_COORDINATOR_TAG:-1.1.0-20260728-703923b}
     profiles: [ "l2", "debug" ]
     depends_on:
       l2-genesis-initialization:
@@ -685,7 +685,7 @@ services:
         ipv4_address: 10.10.10.205
 
   zkbesu-shomei-sr:
-    image: consensys/linea-besu-package:${LINEA_BESU_PACKAGE_TAG:-2.1.1-20260811-0f74f55}
+    image: ${BESU_PACKAGE_IMAGE_NAME:-consensys/linea-besu-package}:${LINEA_BESU_PACKAGE_TAG:-2.1.1-20260811-0f74f55}
     hostname: zkbesu-shomei-sr
     container_name: zkbesu-shomei-sr
     profiles: [ "staterecovery", "external-to-monorepo" ]

--- a/maru/app/Dockerfile
+++ b/maru/app/Dockerfile
@@ -5,6 +5,8 @@ WORKDIR /opt/consensys/maru
 
 COPY --from=libs ./** ./
 
+ENV LINETH_APP_JAR=/opt/consensys/maru/maru.jar
+
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
 ARG VCS_REF


### PR DESCRIPTION
- make coordinator and Maru images expose their launcher JAR through `LINETH_APP_JAR`
- make Compose consume the image-owned launcher path and canonical image repositories
- discover and load Docker artifacts from their manifests instead of service-specific filenames
- select E2E tags from one canonical image table, preserving explicit caller tags and falling back to `develop`
