### PR TITLE
chore(ci): add list-besu-profile shell script to reuse across enterpr…

### DIFF
--- a/.github/actions/run-git-cliff-commands/Makefile
+++ b/.github/actions/run-git-cliff-commands/Makefile
@@ -4,21 +4,23 @@
 # scripts/*.sh, and adds *-dry-run targets so you can preview a component's next
 # version and changelog locally before a release.
 #
+# scripts/components.sh is the single source of truth for each component's
+# SCOPES and INCLUDE_PATH (used by every git-cliff-backed workflow via the
+# component-info target/script). Add or change a component there — callers
+# only ever pass COMPONENT/component-name.
+#
 # Always run from the repository root (git-cliff --include-path patterns and the
 # template path are relative to it), pointing make at this file:
 #
 #   make -f .github/actions/run-git-cliff-commands/Makefile version-dry-run \
-#       COMPONENT=coordinator \
-#       INCLUDE_PATH='coordinator/**' \
-#       SCOPES=coordinator
+#       COMPONENT=coordinator
 #
 #   make -f .github/actions/run-git-cliff-commands/Makefile changelog-dry-run \
-#       COMPONENT=coordinator \
-#       INCLUDE_PATH='coordinator/**' \
-#       SCOPES=coordinator
+#       COMPONENT=coordinator
 #
-# INCLUDE_PATH may list several paths, one per line. Quote a multi-line value;
-# either a real newline-delimited string or bash/zsh $'a\nb' works, e.g.:
+# SCOPES/INCLUDE_PATH default to the COMPONENT's entry in scripts/components.sh
+# but can still be overridden explicitly, e.g. to preview a scope/path change
+# before committing it to components.sh:
 #
 #   make -f .github/actions/run-git-cliff-commands/Makefile prepend-dry-run \
 #       COMPONENT=linea-besu-package \
@@ -55,20 +57,21 @@ GENERATE_WITH_NEXT_TAG ?= true
 export INCLUDE_PATH SCOPES TEMPLATE COMPONENT RELEASE_TAG_SUFFIX
 export FOLDER_NAME GENERATE_WITH_NEXT_TAG
 
-.PHONY: help paths render version changelog prepend \
+.PHONY: help paths render version changelog prepend component-info \
         version-dry-run changelog-dry-run prepend-dry-run
 
 help:
 	@echo 'Targets:'
-	@echo '  paths            normalize INCLUDE_PATH -> include_paths'
-	@echo '  render           render cliff template with SCOPES -> config path'
-	@echo '  version          compute next version (needs CLIFF_CONFIG, INCLUDE_PATHS)'
-	@echo '  changelog        generate changelog (needs CLIFF_CONFIG, INCLUDE_PATHS)'
-	@echo '  prepend          prepend section into FOLDER_NAME/CHANGELOG.md'
-	@echo '  version-dry-run    preview next version (COMPONENT, INCLUDE_PATH, SCOPES)'
-	@echo '  changelog-dry-run  preview changelog    (COMPONENT, INCLUDE_PATH, SCOPES)'
+	@echo '  paths              normalize INCLUDE_PATH -> include_paths'
+	@echo '  render             render cliff template with SCOPES -> config path'
+	@echo '  version            compute next version (needs CLIFF_CONFIG, INCLUDE_PATHS)'
+	@echo '  changelog          generate changelog (needs CLIFF_CONFIG, INCLUDE_PATHS)'
+	@echo '  prepend            prepend section into FOLDER_NAME/CHANGELOG.md'
+	@echo '  component-info     look up a component'"'"'s default SCOPES/INCLUDE_PATH (needs COMPONENT)'
+	@echo '  version-dry-run    preview next version (COMPONENT, optionally INCLUDE_PATH/SCOPES to override)'
+	@echo '  changelog-dry-run  preview changelog    (COMPONENT, optionally INCLUDE_PATH/SCOPES to override)'
 	@echo '  prepend-dry-run    preview prepended CHANGELOG.md, file untouched'
-	@echo '                     (COMPONENT, INCLUDE_PATH, SCOPES, FOLDER_NAME)'
+	@echo '                     (COMPONENT, FOLDER_NAME, optionally INCLUDE_PATH/SCOPES to override)'
 
 # --- thin wrappers used by the composite action (env-driven) --------------
 
@@ -87,22 +90,35 @@ changelog:
 prepend:
 	@$(SCRIPTS_DIR)/prepend.sh
 
+# Single source of truth for a component's SCOPES/INCLUDE_PATH (scripts/components.sh).
+component-info:
+	@test -n "$$COMPONENT" || { echo 'COMPONENT is required (COMPONENT=...)' >&2; exit 1; }
+	@$(SCRIPTS_DIR)/component-info.sh
+
+# resolve-component-info COMPONENT [SCOPES] [INCLUDE_PATH] -> "scopes|include_path"
+# include_path lines are '\'-joined so the pair fits on one line for $(shell ...).
+define resolve_component_info
+info="$$(COMPONENT="$(1)" $(SCRIPTS_DIR)/component-info.sh)"; \
+scopes="$${SCOPES:-$$(printf '%s\n' "$$info" | sed -n 's/^scopes=//p')}"; \
+include_path="$${INCLUDE_PATH:-$$(printf '%s\n' "$$info" | sed '1d')}";
+endef
+
 # --- local dry-runs (no $GITHUB_OUTPUT; results go to your terminal) ------
+# SCOPES/INCLUDE_PATH default to COMPONENT's entry in scripts/components.sh;
+# set them explicitly to preview a value before committing it there.
 
 version-dry-run:
-	@test -n "$$COMPONENT"    || { echo 'COMPONENT is required (COMPONENT=...)'       >&2; exit 1; }
-	@test -n "$$INCLUDE_PATH" || { echo 'INCLUDE_PATH is required (INCLUDE_PATH=...)' >&2; exit 1; }
-	@test -n "$$SCOPES"       || { echo 'SCOPES is required (SCOPES=...)'             >&2; exit 1; }
-	@include_paths="$$($(SCRIPTS_DIR)/paths.sh)"; \
-	 config="$$($(SCRIPTS_DIR)/render.sh | sed 's/^config=//')"; \
+	@test -n "$$COMPONENT" || { echo 'COMPONENT is required (COMPONENT=...)' >&2; exit 1; }
+	@$(call resolve_component_info,$$COMPONENT) \
+	 include_paths="$$(INCLUDE_PATH="$$include_path" $(SCRIPTS_DIR)/paths.sh)"; \
+	 config="$$(SCOPES="$$scopes" $(SCRIPTS_DIR)/render.sh | sed 's/^config=//')"; \
 	 INCLUDE_PATHS="$$include_paths" CLIFF_CONFIG="$$config" $(SCRIPTS_DIR)/version.sh
 
 changelog-dry-run:
-	@test -n "$$COMPONENT"    || { echo 'COMPONENT is required (COMPONENT=...)'       >&2; exit 1; }
-	@test -n "$$INCLUDE_PATH" || { echo 'INCLUDE_PATH is required (INCLUDE_PATH=...)' >&2; exit 1; }
-	@test -n "$$SCOPES"       || { echo 'SCOPES is required (SCOPES=...)'             >&2; exit 1; }
-	@include_paths="$$($(SCRIPTS_DIR)/paths.sh)"; \
-	 config="$$($(SCRIPTS_DIR)/render.sh | sed 's/^config=//')"; \
+	@test -n "$$COMPONENT" || { echo 'COMPONENT is required (COMPONENT=...)' >&2; exit 1; }
+	@$(call resolve_component_info,$$COMPONENT) \
+	 include_paths="$$(INCLUDE_PATH="$$include_path" $(SCRIPTS_DIR)/paths.sh)"; \
+	 config="$$(SCOPES="$$scopes" $(SCRIPTS_DIR)/render.sh | sed 's/^config=//')"; \
 	 vout="$$(INCLUDE_PATHS="$$include_paths" CLIFF_CONFIG="$$config" $(SCRIPTS_DIR)/version.sh)"; \
 	 changed="$$(printf '%s\n' "$$vout" | sed -n 's/^changed=//p')"; \
 	 version="$$(printf '%s\n' "$$vout" | sed -n 's/^version=//p')"; \
@@ -116,12 +132,11 @@ changelog-dry-run:
 # Preview the CHANGELOG.md that `prepend` would produce, without writing the
 # file or touching the git remote.
 prepend-dry-run:
-	@test -n "$$COMPONENT"    || { echo 'COMPONENT is required (COMPONENT=...)'       >&2; exit 1; }
-	@test -n "$$INCLUDE_PATH" || { echo 'INCLUDE_PATH is required (INCLUDE_PATH=...)' >&2; exit 1; }
-	@test -n "$$SCOPES"       || { echo 'SCOPES is required (SCOPES=...)'             >&2; exit 1; }
-	@test -n "$$FOLDER_NAME"  || { echo 'FOLDER_NAME is required (FOLDER_NAME=...)'   >&2; exit 1; }
-	@include_paths="$$($(SCRIPTS_DIR)/paths.sh)"; \
-	 config="$$($(SCRIPTS_DIR)/render.sh | sed 's/^config=//')"; \
+	@test -n "$$COMPONENT"   || { echo 'COMPONENT is required (COMPONENT=...)'     >&2; exit 1; }
+	@test -n "$$FOLDER_NAME" || { echo 'FOLDER_NAME is required (FOLDER_NAME=...)' >&2; exit 1; }
+	@$(call resolve_component_info,$$COMPONENT) \
+	 include_paths="$$(INCLUDE_PATH="$$include_path" $(SCRIPTS_DIR)/paths.sh)"; \
+	 config="$$(SCOPES="$$scopes" $(SCRIPTS_DIR)/render.sh | sed 's/^config=//')"; \
 	 vout="$$(INCLUDE_PATHS="$$include_paths" CLIFF_CONFIG="$$config" $(SCRIPTS_DIR)/version.sh)"; \
 	 changed="$$(printf '%s\n' "$$vout" | sed -n 's/^changed=//p')"; \
 	 version="$$(printf '%s\n' "$$vout" | sed -n 's/^version=//p')"; \

--- a/.github/actions/run-git-cliff-commands/action.yml
+++ b/.github/actions/run-git-cliff-commands/action.yml
@@ -18,10 +18,18 @@ inputs:
           linea-besu/**
 
       Blank/whitespace-only lines are ignored; leading/trailing whitespace on each line is trimmed.
-    required: true
+      Optional — defaults to component-name's entry in scripts/components.sh (the single
+      source of truth); only pass this to override that default.
+    required: false
+    default: ''
   scopes:
-    description: "Regex alternation of conventional-commit scopes to gate on, injected into the shared template (e.g. 'coordinator' or 'linea-besu|tracer|sequencer|deps|misc')"
-    required: true
+    description: >
+      Regex alternation of conventional-commit scopes to gate on, injected into the shared
+      template (e.g. 'coordinator' or 'linea-besu|tracer|sequencer|deps|misc').
+      Optional — defaults to component-name's entry in scripts/components.sh (the single
+      source of truth); only pass this to override that default.
+    required: false
+    default: ''
   cliff-template:
     description: "Path to the shared git-cliff template containing the @@SCOPES@@ placeholder"
     required: false
@@ -57,28 +65,38 @@ runs:
   using: 'composite'
   steps:
     # The step bodies live in scripts/*.sh and are driven through the Makefile
-    # (targets: paths, render, version, changelog) so the same logic backs both
-    # this action and local `make *-dry-run` previews. See ./Makefile.
+    # (targets: component-info, paths, render, version, changelog) so the same
+    # logic backs both this action and local `make *-dry-run` previews. See ./Makefile.
     # Steps run from the repo root (GITHUB_WORKSPACE); the scripts append their
     # step outputs to $GITHUB_OUTPUT.
 
-    # Normalize inputs.include-path (newline-separated paths) into one
+    # Look up component-name's default scopes/include-path (scripts/components.sh)
+    # so callers only need to pass component-name. inputs.scopes/include-path,
+    # when given, override this default.
+    - name: Resolve component defaults
+      id: defaults
+      shell: bash
+      env:
+        COMPONENT: ${{ inputs.component-name }}
+      run: make -f "${{ github.action_path }}/Makefile" component-info
+
+    # Normalize the effective include-path (newline-separated paths) into one
     # trimmed, non-empty path per line so downstream steps can reconstruct a
     # bash array safely.
     - name: Build include-path list
       id: paths
       shell: bash
       env:
-        INCLUDE_PATH: ${{ inputs.include-path }}
+        INCLUDE_PATH: ${{ inputs.include-path != '' && inputs.include-path || steps.defaults.outputs.include_path }}
       run: make -f "${{ github.action_path }}/Makefile" paths
 
-    # Render the shared cliff template into a temp config with the caller's
+    # Render the shared cliff template into a temp config with the effective
     # scopes injected into the @@SCOPES@@ placeholder.
     - name: Render git-cliff config with injected scopes
       id: render
       shell: bash
       env:
-        SCOPES: ${{ inputs.scopes }}
+        SCOPES: ${{ inputs.scopes != '' && inputs.scopes || steps.defaults.outputs.scopes }}
         TEMPLATE: ${{ inputs.cliff-template }}
       run: make -f "${{ github.action_path }}/Makefile" render
 

--- a/.github/actions/run-git-cliff-commands/action.yml
+++ b/.github/actions/run-git-cliff-commands/action.yml
@@ -42,6 +42,16 @@ inputs:
     description: "Prepend the unreleased changelogs to the CHANGELOG.md"
     required: false
     default: "false"
+  target-ref:
+    description: >
+      Branch name to fast-forward before prepending, to dodge a race with a concurrent push
+      to that same branch. Only pass this when the caller will commit-and-push the result
+      afterward. Leave empty (default) otherwise — e.g. read-only CI previews must not pass
+      this, and must never derive it from `github.head_ref`/`github.ref_name` for a workflow
+      reachable by `pull_request`, since `github.head_ref` is attacker-controlled on fork PRs
+      (CodeQL actions/cache-poisoning).
+    required: false
+    default: ''
   generate-changelog-with-next-tag-version:
     description: "Generate the unreleased changelogs but replace the header with next-tag-version"
     required: false
@@ -134,5 +144,5 @@ runs:
         INCLUDE_PATHS: ${{ steps.paths.outputs.include_paths }}
         GENERATE_WITH_NEXT_TAG: ${{ inputs.generate-changelog-with-next-tag-version == 'true' }}
         NEXT_VERSION: ${{ steps.version.outputs.version }}
-        TARGET_REF: ${{ github.head_ref || github.ref_name }}
+        TARGET_REF: ${{ inputs.target-ref }}
       run: make -f "${{ github.action_path }}/Makefile" prepend

--- a/.github/actions/run-git-cliff-commands/scripts/component-info.sh
+++ b/.github/actions/run-git-cliff-commands/scripts/component-info.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Look up a component's default git-cliff SCOPES/INCLUDE_PATH from the single
+# source of truth in components.sh.
+#
+# Inputs (env):  COMPONENT
+# Output:        scopes, include_path  (multi-line)
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+# shellcheck source=components.sh
+. "${SCRIPT_DIR}/components.sh"
+
+: "${COMPONENT:?COMPONENT is required}"
+
+emit_kv scopes "$(component_scopes "$COMPONENT")"
+component_include_path "$COMPONENT" | emit_block include_path

--- a/.github/actions/run-git-cliff-commands/scripts/components.sh
+++ b/.github/actions/run-git-cliff-commands/scripts/components.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Single source of truth for each component's git-cliff SCOPES and
+# INCLUDE_PATH. Sourced by component-info.sh.
+#
+# To add/change a component's scopes or include-path, edit this file only —
+# every workflow that passes `component-name` to the run-git-cliff-commands
+# action (or a reusable workflow wrapping it) picks the values up automatically.
+
+# component_scopes NAME — regex alternation of conventional-commit scopes.
+component_scopes() {
+  case "$1" in
+    coordinator)         echo "coordinator|deps|misc" ;;
+    maru)                echo "maru|deps|misc" ;;
+    prover)               echo "prover|deps|misc" ;;
+    postman)              echo "postman|deps|misc" ;;
+    tx-exclusion-api)     echo "tx-exclusion-api|deps|misc" ;;
+    linea-besu-package)   echo "linea-besu|tracer|sequencer|deps|misc" ;;
+    linea)                echo "coordinator|linea-besu|tracer|sequencer|maru|prover|postman|tx-exclusion-api|deps|misc" ;;
+    *)
+      echo "components.sh: unknown component '$1'" >&2
+      return 1
+      ;;
+  esac
+}
+
+# component_include_path NAME — git-cliff --include-path filter, one path per line.
+component_include_path() {
+  case "$1" in
+    coordinator)       printf '%s\n' "coordinator/**" ;;
+    maru)              printf '%s\n' "maru/**" ;;
+    prover)            printf '%s\n' "prover/**" ;;
+    postman)           printf '%s\n' "postman/**" ;;
+    tx-exclusion-api)  printf '%s\n' "transaction-exclusion-api/**" ;;
+    linea-besu-package)
+      printf '%s\n' \
+        "tracer/**" \
+        "tracer-constraints/**" \
+        "linea-besu/plugins/linea-sequencer/**" \
+        "linea-besu/besu/**" \
+        "linea-besu/package/**" \
+        "gradle/libs.versions.toml"
+      ;;
+    linea)
+      printf '%s\n' \
+        "coordinator/**" \
+        "maru/**" \
+        "postman/**" \
+        "prover/**" \
+        "transaction-exclusion-api/**" \
+        "tracer/**" \
+        "tracer-constraints/**" \
+        "linea-besu/plugins/linea-sequencer/**" \
+        "linea-besu/besu/**" \
+        "linea-besu/package/**" \
+        "gradle/libs.versions.toml"
+      ;;
+    *)
+      echo "components.sh: unknown component '$1'" >&2
+      return 1
+      ;;
+  esac
+}

--- a/.github/actions/run-git-cliff-commands/scripts/prepend.sh
+++ b/.github/actions/run-git-cliff-commands/scripts/prepend.sh
@@ -6,7 +6,10 @@
 #                FOLDER_NAME (dir holding CHANGELOG.md),
 #                GENERATE_WITH_NEXT_TAG (true|false, default false),
 #                NEXT_VERSION (required when GENERATE_WITH_NEXT_TAG=true),
-#                TARGET_REF (branch to fast-forward before writing; CI only),
+#                TARGET_REF (optional; branch to fast-forward before writing, to dodge a
+#                            race with a concurrent push to that same branch. Only pass
+#                            this when the caller will push the result back — skipped
+#                            when empty),
 #                DRY_RUN (true|false, default false)
 #
 # With DRY_RUN=true it works on a throwaway copy and prints the resulting
@@ -35,10 +38,14 @@ if [ "${DRY_RUN}" = "true" ]; then
   trap 'rm -f "${target}"' EXIT
   cp "${CHANGELOG_FILE}" "${target}"
 else
-  # retrieve the latest changes of CHANGELOG.md first to avoid chances of
-  # rebase or merge conflicts later from other workflows
-  : "${TARGET_REF:?TARGET_REF is required}"
-  git pull --ff-only origin "refs/heads/${TARGET_REF}"
+  # When the caller is about to commit-and-push this file, retrieve the latest
+  # changes first to avoid rebase/merge conflicts with a concurrent push to the
+  # same branch. Skipped when TARGET_REF is unset — callers that don't push the
+  # result (e.g. a read-only CI preview) have nothing to race against, and must
+  # not pass an event-derived ref here (see action.yml).
+  if [ -n "${TARGET_REF:-}" ]; then
+    git pull --ff-only origin "refs/heads/${TARGET_REF}"
+  fi
   target="${CHANGELOG_FILE}"
 fi
 

--- a/.github/workflows/component-changelog-upload.yml
+++ b/.github/workflows/component-changelog-upload.yml
@@ -67,55 +67,25 @@ jobs:
       matrix:
         component: [ coordinator, maru, prover, postman, tx-exclusion-api, linea-besu-package, linea ]
         include:
-          # Scope-and-path gated: cliff-<component>.toml keeps only commits
-          # scoped to that component, AND include-path restricts to its paths.
+          # scopes/include-path per component are the single source of truth in
+          # .github/actions/run-git-cliff-commands/scripts/components.sh — the
+          # run-git-cliff-commands action resolves them from component-name.
           - component: coordinator
             folder-name: coordinator
-            scopes: coordinator|deps|misc
-            include-path: coordinator/**
           - component: maru
             folder-name: maru
-            scopes: maru|deps|misc
-            include-path: maru/**
           - component: prover
             folder-name: prover
-            scopes: prover|deps|misc
-            include-path: prover/**
           - component: postman
             folder-name: postman
-            scopes: postman|deps|misc
-            include-path: postman/**
           - component: tx-exclusion-api
             folder-name: transaction-exclusion-api
-            scopes: tx-exclusion-api|deps|misc
-            include-path: transaction-exclusion-api/**
           - component: linea-besu-package
             folder-name: linea-besu/package
             artifact-name: linea-besu-package
-            scopes: linea-besu|tracer|sequencer|deps|misc
-            include-path: |
-              tracer/**
-              tracer-constraints/**
-              linea-besu/plugins/linea-sequencer/**
-              linea-besu/besu/**
-              linea-besu/package/**
-              gradle/libs.versions.toml
           - component: linea
             folder-name: .
             artifact-name: linea
-            scopes: coordinator|linea-besu|tracer|sequencer|maru|prover|postman|tx-exclusion-api|deps|misc
-            include-path: |
-              coordinator/**
-              maru/**
-              postman/**
-              prover/**
-              transaction-exclusion-api/**
-              tracer/**
-              tracer-constraints/**
-              linea-besu/plugins/linea-sequencer/**
-              linea-besu/besu/**
-              linea-besu/package/**
-              gradle/libs.versions.toml
 
     name: Generate ${{ matrix.component }} [Unreleased] changelog
     steps:
@@ -143,8 +113,6 @@ jobs:
         with:
           component-name: ${{ matrix.component }}
           folder-name: ${{ matrix.folder-name }}
-          include-path: ${{ matrix.include-path }}
-          scopes: ${{ matrix.scopes }}
           prepend-changelog: 'true'
 
       - name: Upload CHANGELOG.md artifact

--- a/.github/workflows/coordinator-release.yml
+++ b/.github/workflows/coordinator-release.yml
@@ -35,10 +35,6 @@ jobs:
     with:
       component-name: coordinator
       folder-name: coordinator
-      # Scope-and-path gated: the shared cliff.template.toml (scope `coordinator`) keeps only `coordinator`-scoped
-      # commits, AND include-path restricts to the coordinator paths.
-      scopes: coordinator|deps|misc
-      include-path: coordinator/**
       image_tag_suffix: ${{ inputs.image_tag_suffix }}
       release_tag_suffix: ${{ inputs.release_tag_suffix }}
       draft_release: ${{ !inputs.pre_release }}

--- a/.github/workflows/linea-besu-release.yml
+++ b/.github/workflows/linea-besu-release.yml
@@ -51,17 +51,6 @@ jobs:
     with:
       # Release tag uses 'linea-besu-package' (e.g. releases/linea-besu-package/v1.2.3)
       component-name: linea-besu-package
-      # Scope-and-path gated: the shared cliff.template.toml (scopes `linea-besu|tracer|sequencer|deps|misc`)
-      # keeps only commits scoped to `linea-besu`, AND include-path restricts to the linea-besu package paths;
-      # a commit must satisfy both to drive the version bump and changelog.
-      scopes: linea-besu|tracer|sequencer|deps|misc
-      include-path: |
-        tracer/**
-        tracer-constraints/**
-        linea-besu/plugins/linea-sequencer/**
-        linea-besu/besu/**
-        linea-besu/package/**
-        gradle/libs.versions.toml
       release_tag_suffix: ${{ inputs.release_tag_suffix }}
 
   run-test-linea-sequencer:

--- a/.github/workflows/linea-milestone-release.yml
+++ b/.github/workflows/linea-milestone-release.yml
@@ -186,8 +186,6 @@ jobs:
     with:
       component-name: coordinator
       folder-name: coordinator
-      scopes: coordinator|deps|misc
-      include-path: coordinator/**
       image_tag_suffix: ${{ inputs.image_tag_suffix }}
       release_tag_suffix: ${{ inputs.release_tag_suffix }} # no release tag suffix should be allowed for milestone component release, only for dry run cases
       draft_release: ${{ !inputs.pre_release }}
@@ -206,8 +204,6 @@ jobs:
     with:
       component-name: prover
       folder-name: prover
-      scopes: prover|deps|misc
-      include-path: prover/**
       image_tag_suffix: ${{ inputs.image_tag_suffix }}
       release_tag_suffix: ${{ inputs.release_tag_suffix }} # no release tag suffix should be allowed for milestone component release, only for dry run cases
       draft_release: ${{ !inputs.pre_release }}
@@ -226,8 +222,6 @@ jobs:
     with:
       component-name: postman
       folder-name: postman
-      scopes: postman|deps|misc
-      include-path: postman/**
       image_tag_suffix: ${{ inputs.image_tag_suffix }}
       release_tag_suffix: ${{ inputs.release_tag_suffix }} # no release tag suffix should be allowed for milestone component release, only for dry run cases
       draft_release: ${{ !inputs.pre_release }}
@@ -246,8 +240,6 @@ jobs:
     with:
       component-name: tx-exclusion-api
       folder-name: transaction-exclusion-api
-      scopes: tx-exclusion-api|deps|misc
-      include-path: transaction-exclusion-api/**
       image_tag_suffix: ${{ inputs.image_tag_suffix }}
       release_tag_suffix: ${{ inputs.release_tag_suffix }} # non-empty release_tag_suffix can be only for non-main milestone release (e.g. dry run release)
       draft_release: ${{ !inputs.pre_release }}
@@ -266,8 +258,6 @@ jobs:
     with:
       component-name: maru
       folder-name: maru
-      scopes: maru|deps|misc
-      include-path: maru/**
       image_tag_suffix: ${{ inputs.image_tag_suffix }}
       release_tag_suffix: ${{ inputs.release_tag_suffix }} # no release tag suffix should be allowed for milestone component release, only for dry run cases
       draft_release: ${{ !inputs.pre_release }}

--- a/.github/workflows/maru-release.yml
+++ b/.github/workflows/maru-release.yml
@@ -35,10 +35,6 @@ jobs:
     with:
       component-name: maru
       folder-name: maru
-      # Scope-and-path gated: the shared cliff.template.toml (scope `maru`) keeps only `maru`-scoped commits,
-      # AND include-path restricts to the maru paths.
-      scopes: maru|deps|misc
-      include-path: maru/**
       image_tag_suffix: ${{ inputs.image_tag_suffix }}
       release_tag_suffix: ${{ inputs.release_tag_suffix }}
       draft_release: ${{ !inputs.pre_release }}

--- a/.github/workflows/postman-release.yml
+++ b/.github/workflows/postman-release.yml
@@ -35,10 +35,6 @@ jobs:
     with:
       component-name: postman
       folder-name: postman
-      # Scope-and-path gated: the shared cliff.template.toml (scope `postman`) keeps only `postman`-scoped
-      # commits, AND include-path restricts to the postman paths.
-      scopes: postman|deps|misc
-      include-path: postman/**
       image_tag_suffix: ${{ inputs.image_tag_suffix }}
       release_tag_suffix: ${{ inputs.release_tag_suffix }}
       draft_release: ${{ !inputs.pre_release }}

--- a/.github/workflows/prover-release.yml
+++ b/.github/workflows/prover-release.yml
@@ -36,10 +36,6 @@ jobs:
     with:
       component-name: prover
       folder-name: prover
-      # Scope-and-path gated: the shared cliff.template.toml (scope `prover`) keeps only `prover`-scoped
-      # commits, AND include-path restricts to the prover paths.
-      scopes: prover|deps|misc
-      include-path: prover/**
       image_tag_suffix: ${{ inputs.image_tag_suffix }}
       release_tag_suffix: ${{ inputs.release_tag_suffix }}
       draft_release: ${{ !inputs.pre_release }}

--- a/.github/workflows/reusable-component-gh-release.yml
+++ b/.github/workflows/reusable-component-gh-release.yml
@@ -18,13 +18,21 @@ on:
         required: true
         type: string
       include-path:
-        description: 'newline-separated string to represent the "git-cliff --include-path filter"'
-        required: true
+        description: >
+          newline-separated string to represent the "git-cliff --include-path filter".
+          Optional — defaults to component-name's entry in
+          .github/actions/run-git-cliff-commands/scripts/components.sh.
+        required: false
         type: string
+        default: ''
       scopes:
-        description: "Regex alternation of conventional-commit scopes to gate on (e.g. 'coordinator' or 'linea-besu|tracer|sequencer|deps|misc')"
-        required: true
+        description: >
+          Regex alternation of conventional-commit scopes to gate on (e.g. 'coordinator' or
+          'linea-besu|tracer|sequencer|deps|misc'). Optional — defaults to component-name's
+          entry in .github/actions/run-git-cliff-commands/scripts/components.sh.
+        required: false
         type: string
+        default: ''
       image_tag_suffix:
         description: 'Custom docker image tag suffix, i.e. docker image tag would be [semver]-[YYYYMMDD]-[commit]-[suffix], if not given, would be [semver]-[YYYYMMDD]-[commit]'
         required: false

--- a/.github/workflows/reusable-component-release-metadata.yml
+++ b/.github/workflows/reusable-component-release-metadata.yml
@@ -8,12 +8,21 @@ on:
         required: true
         type: string
       include-path:
-        description: 'newline-separated string to represent the "git-cliff --include-path filter"'
+        description: >
+          newline-separated string to represent the "git-cliff --include-path filter".
+          Optional — defaults to component-name's entry in
+          .github/actions/run-git-cliff-commands/scripts/components.sh.
+        required: false
         type: string
+        default: ''
       scopes:
-        description: "Regex alternation of conventional-commit scopes to gate on (e.g. 'coordinator' or 'linea-besu|tracer|sequencer|deps|misc')"
-        required: true
+        description: >
+          Regex alternation of conventional-commit scopes to gate on (e.g. 'coordinator' or
+          'linea-besu|tracer|sequencer|deps|misc'). Optional — defaults to component-name's
+          entry in .github/actions/run-git-cliff-commands/scripts/components.sh.
+        required: false
         type: string
+        default: ''
       release_tag_suffix:
         description: "Custom release tag suffix, i.e. release tag would be releases/[component]/v[semver]-[suffix]"
         required: false

--- a/.github/workflows/reusable-component-release-push-tag-changelog.yml
+++ b/.github/workflows/reusable-component-release-push-tag-changelog.yml
@@ -12,13 +12,21 @@ on:
         required: true
         type: string
       include-path:
-        description: 'newline-separated string to represent the "git-cliff --include-path filter"'
-        required: true
+        description: >
+          newline-separated string to represent the "git-cliff --include-path filter".
+          Optional — defaults to component-name's entry in
+          .github/actions/run-git-cliff-commands/scripts/components.sh.
+        required: false
         type: string
+        default: ''
       scopes:
-        description: "Regex alternation of conventional-commit scopes to gate on (e.g. 'coordinator' or 'linea-besu|tracer|sequencer|deps|misc')"
-        required: true
+        description: >
+          Regex alternation of conventional-commit scopes to gate on (e.g. 'coordinator' or
+          'linea-besu|tracer|sequencer|deps|misc'). Optional — defaults to component-name's
+          entry in .github/actions/run-git-cliff-commands/scripts/components.sh.
+        required: false
         type: string
+        default: ''
       release_tag_suffix:
         description: "Custom tag release tag suffix, i.e. releases/[component]/v[semver]-[suffix]"
         required: false

--- a/.github/workflows/reusable-component-release-push-tag-changelog.yml
+++ b/.github/workflows/reusable-component-release-push-tag-changelog.yml
@@ -129,6 +129,11 @@ jobs:
           scopes: ${{ inputs.scopes }}
           release_tag_suffix: ${{ inputs.release_tag_suffix }}
           prepend-changelog: 'true'
+          # This workflow commits and pushes CHANGELOG.md below, so fast-forward to the
+          # latest push on this branch first to dodge a race with a concurrent writer.
+          # Safe here: this workflow is only reachable via workflow_dispatch release
+          # pipelines, so github.head_ref is always empty (never a pull_request/fork ref).
+          target-ref: ${{ github.head_ref || github.ref_name }}
           generate-changelog-with-next-tag-version: 'true'
 
       - name: Commit and push ${{ inputs.component-name }}/CHANGELOG.md

--- a/.github/workflows/reusable-component-release.yml
+++ b/.github/workflows/reusable-component-release.yml
@@ -18,13 +18,21 @@ on:
         required: true
         type: string
       include-path:
-        description: 'newline-separated string to represent the "git-cliff --include-path filter"'
-        required: true
+        description: >
+          newline-separated string to represent the "git-cliff --include-path filter".
+          Optional — defaults to component-name's entry in
+          .github/actions/run-git-cliff-commands/scripts/components.sh.
+        required: false
         type: string
+        default: ''
       scopes:
-        description: "Regex alternation of conventional-commit scopes to gate on (e.g. 'coordinator' or 'linea-besu|tracer|sequencer|deps|misc')"
-        required: true
+        description: >
+          Regex alternation of conventional-commit scopes to gate on (e.g. 'coordinator' or
+          'linea-besu|tracer|sequencer|deps|misc'). Optional — defaults to component-name's
+          entry in .github/actions/run-git-cliff-commands/scripts/components.sh.
+        required: false
         type: string
+        default: ''
       image_tag_suffix:
         description: 'Custom docker image tag suffix, i.e. docker image tag would be [semver]-[YYYYMMDD]-[commit]-[suffix], if not given, would be [semver]-[YYYYMMDD]-[commit]'
         required: false

--- a/.github/workflows/reusable-linea-besu-package-gh-release.yml
+++ b/.github/workflows/reusable-linea-besu-package-gh-release.yml
@@ -60,16 +60,6 @@ jobs:
       # Release tag uses 'linea-besu-package' (e.g. releases/linea-besu-package/v1.2.3)
       component-name: linea-besu-package
       folder-name: linea-besu/package
-      # Scope-and-path gated: the shared cliff.template.toml (scopes `linea-besu|tracer|sequencer|deps|misc`) 
-      # keeps only commits scoped to `linea-besu`, AND include-path restricts to the linea-besu package paths.
-      scopes: linea-besu|tracer|sequencer|deps|misc
-      include-path: |
-        tracer/**
-        tracer-constraints/**
-        linea-besu/plugins/linea-sequencer/**
-        linea-besu/besu/**
-        linea-besu/package/**
-        gradle/libs.versions.toml
       release_tag_suffix: ${{ inputs.release_tag_suffix }}
       upload_changelog: ${{ inputs.upload_changelog }}
     secrets: inherit

--- a/.github/workflows/reusable-linea-besu-package-run-test.yml
+++ b/.github/workflows/reusable-linea-besu-package-run-test.yml
@@ -18,11 +18,7 @@ jobs:
 
       - name: Split and list profiles
         id: list-profiles
-        run: |
-          files=$(ls linea-besu/package/linea-besu/profiles/* | xargs -n 1 basename | sed 's/\.[^.]*$//')
-          files_json=$(echo "$files" | tr ' ' '\n' | jq -R -s -c 'split("\n") | map(select(length > 0))')
-          echo "files=$files_json" >> "$GITHUB_OUTPUT"
-          echo "Files: $files_json"
+        run: scripts/docker/list-besu-profiles.sh linea-besu/package/linea-besu/profiles
 
   test-profile:
     timeout-minutes: 4

--- a/.github/workflows/reusable-milestone-check-branch-and-compute-tag.yml
+++ b/.github/workflows/reusable-milestone-check-branch-and-compute-tag.yml
@@ -51,19 +51,6 @@ jobs:
         uses: ./.github/actions/run-git-cliff-commands
         with:
           component-name: linea
-          scopes: coordinator|linea-besu|tracer|sequencer|maru|prover|postman|tx-exclusion-api|deps|misc
-          include-path: |
-            coordinator/**
-            maru/**
-            postman/**
-            prover/**
-            transaction-exclusion-api/**
-            tracer/**
-            tracer-constraints/**
-            linea-besu/plugins/linea-sequencer/**
-            linea-besu/besu/**
-            linea-besu/package/**
-            gradle/libs.versions.toml
           release_tag_suffix: ${{ inputs.release_tag_suffix }}
 
       - name: Check if the next release tag already existed

--- a/.github/workflows/reusable-milestone-check-branch-and-compute-tag.yml
+++ b/.github/workflows/reusable-milestone-check-branch-and-compute-tag.yml
@@ -36,7 +36,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.head_ref || github.ref_name }}
+          # No ref override: defaults to github.sha, the immutable commit
+          # selected at dispatch time.
           fetch-depth: 0
           fetch-tags: true
           submodules: false

--- a/.github/workflows/reusable-milestone-component-release-metadata.yml
+++ b/.github/workflows/reusable-milestone-component-release-metadata.yml
@@ -49,7 +49,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.head_ref || github.ref_name }}
+          # No ref override: defaults to github.sha, the immutable commit
+          # selected at dispatch time.
           fetch-depth: 0
           fetch-tags: true
           submodules: false

--- a/.github/workflows/reusable-milestone-component-release-metadata.yml
+++ b/.github/workflows/reusable-milestone-component-release-metadata.yml
@@ -34,34 +34,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # scopes/include-path per component are the single source of truth in
+        # .github/actions/run-git-cliff-commands/scripts/components.sh — the
+        # run-git-cliff-commands action resolves them from component-name.
         component-name: [ coordinator, maru, prover, postman, tx-exclusion-api, linea-besu-package ]
-        include:
-          # Scope-and-path gated: cliff-<component>.toml keeps only commits
-          # scoped to that component, AND include-path restricts to its paths.
-          - component-name: coordinator
-            scopes: coordinator|deps|misc
-            include-path: coordinator/**
-          - component-name: maru
-            scopes: maru|deps|misc
-            include-path: maru/**
-          - component-name: prover
-            scopes: prover|deps|misc
-            include-path: prover/**
-          - component-name: postman
-            scopes: postman|deps|misc
-            include-path: postman/**
-          - component-name: tx-exclusion-api
-            scopes: tx-exclusion-api|deps|misc
-            include-path: transaction-exclusion-api/**
-          - component-name: linea-besu-package
-            scopes: linea-besu|tracer|sequencer|deps|misc
-            include-path: |
-              tracer/**
-              tracer-constraints/**
-              linea-besu/plugins/linea-sequencer/**
-              linea-besu/besu/**
-              linea-besu/package/**
-              gradle/libs.versions.toml
     outputs:
       coordinator: ${{ steps.changelog-outputs.outputs.coordinator }}
       maru: ${{ steps.changelog-outputs.outputs.maru }}
@@ -88,8 +64,6 @@ jobs:
         uses: ./.github/actions/run-git-cliff-commands
         with:
           component-name: ${{ matrix.component-name }}
-          include-path: ${{ matrix.include-path }}
-          scopes: ${{ matrix.scopes }}
           release_tag_suffix: ${{ inputs.release_tag_suffix }}
           generate-changelog-with-next-tag-version: 'true'
 

--- a/.github/workflows/reusable-milestone-release-push-tag-changelog.yml
+++ b/.github/workflows/reusable-milestone-release-push-tag-changelog.yml
@@ -133,16 +133,22 @@ jobs:
           # Every component is scope-and-path gated: <scopes> is injected into
           # the shared cliff.template.toml (keeping only commits carrying one of
           # those scopes) AND the include-paths restrict to that component's
-          # paths — a commit must satisfy both.
+          # paths — a commit must satisfy both. <scopes>/paths are looked up from
+          # the single source of truth in
+          # .github/actions/run-git-cliff-commands/scripts/components.sh
+          # (same component names) rather than duplicated here.
           TEMPLATE="cliff.template.toml"
-          components=(
-            "coordinator#${COORDINATOR_VERSION}#coordinator|deps|misc#[\"coordinator/**\"]"
-            "maru#${MARU_VERSION}#maru|deps|misc#[\"maru/**\"]"
-            "postman#${POSTMAN_VERSION}#postman|deps|misc#[\"postman/**\"]"
-            "prover#${PROVER_VERSION}#prover|deps|misc#[\"prover/**\"]"
-            "tx-exclusion-api#${TX_EXCLUSION_API_VERSION}#tx-exclusion-api|deps|misc#[\"transaction-exclusion-api/**\"]"
-            "linea-besu-package#${LINEA_BESU_VERSION}#linea-besu|tracer|sequencer|deps|misc#[\"tracer/**\",\"tracer-constraints/**\",\"linea-besu/plugins/linea-sequencer/**\",\"linea-besu/besu/**\",\"linea-besu/package/**\",\"gradle/libs.versions.toml\"]"
-          )
+          COMPONENT_MAKEFILE=".github/actions/run-git-cliff-commands/Makefile"
+          tags=(coordinator maru postman prover tx-exclusion-api linea-besu-package)
+          versions=("${COORDINATOR_VERSION}" "${MARU_VERSION}" "${POSTMAN_VERSION}" "${PROVER_VERSION}" "${TX_EXCLUSION_API_VERSION}" "${LINEA_BESU_VERSION}")
+          components=()
+          for i in "${!tags[@]}"; do
+            tag="${tags[i]}"
+            info="$(make -f "${COMPONENT_MAKEFILE}" component-info COMPONENT="${tag}")"
+            scopes="$(printf '%s\n' "${info}" | sed -n 's/^scopes=//p')"
+            paths_json="$(printf '%s\n' "${info}" | sed '1d' | jq -R -s -c 'split("\n") | map(select(length > 0))')"
+            components+=("${tag}#${versions[i]}#${scopes}#${paths_json}")
+          done
 
           for (( i=${#components[@]}-1; i>=0; i-- )); do
             entry="${components[i]}"

--- a/.github/workflows/tx-exclusion-api-release.yml
+++ b/.github/workflows/tx-exclusion-api-release.yml
@@ -35,11 +35,6 @@ jobs:
     with:
       component-name: tx-exclusion-api
       folder-name: transaction-exclusion-api
-      # Scope-and-path gated: the shared cliff.template.toml (scope `tx-exclusion-api`) keeps only
-      # `tx-exclusion-api`-scoped commits, AND include-path restricts to the
-      # transaction-exclusion-api paths.
-      scopes: tx-exclusion-api|deps|misc
-      include-path: transaction-exclusion-api/**
       image_tag_suffix: ${{ inputs.image_tag_suffix }}
       release_tag_suffix: ${{ inputs.release_tag_suffix }}
       draft_release: ${{ !inputs.pre_release }}

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Release tag of each component is in the format of `releases/[component]/v[semver
 
 The workflows do **not** keep a per-component `cliff.toml`. A single [`cliff.template.toml`](cliff.template.toml) is rendered at run time by substituting the component's conventional-commit scopes into its `@@SCOPES@@` placeholder, then git-cliff is run with that component's `--include-path` filter. A commit therefore counts only when it is **both** in-scope **and** touches a component path (scope-and-path gating).
 
+Each component's scopes and include-path are declared in exactly one place — [`scripts/components.sh`](.github/actions/run-git-cliff-commands/scripts/components.sh) — and every workflow/action looks them up from there by `component-name`, rather than hardcoding them. To add a component or change its scopes/paths, edit `components.sh` only.
+
 You can reproduce exactly what a workflow computes using the dry-run targets in the [`run-git-cliff-commands`](.github/actions/run-git-cliff-commands/action.yml) action's `Makefile` — these drive the very same scripts CI runs, so the rendering, scope injection, and gating all match. Prerequisites: install git-cliff (`brew install git-cliff` or `cargo install git-cliff`), have GNU `make`, and fetch tags (`git fetch --tags`). Run everything **from the repo root**:
 
 ```bash
@@ -62,28 +64,21 @@ MK=.github/actions/run-git-cliff-commands/Makefile
 
 # Preview the NEXT bumped version + tag for a component
 # (prints tag=/version=/changed=; logs "nothing to bump" if no release is due).
-make -f "$MK" version-dry-run \
-  COMPONENT=coordinator \
-  SCOPES='coordinator|deps|misc' \
-  INCLUDE_PATH='coordinator/**'
+# SCOPES/INCLUDE_PATH default to COMPONENT's entry in scripts/components.sh.
+make -f "$MK" version-dry-run COMPONENT=coordinator
 
 # Preview the component's changelog for the next release.
-make -f "$MK" changelog-dry-run \
-  COMPONENT=coordinator \
-  SCOPES='coordinator|deps|misc' \
-  INCLUDE_PATH='coordinator/**'
+make -f "$MK" changelog-dry-run COMPONENT=coordinator
 
 # Preview the CHANGELOG.md exactly as a release would rewrite it — WITHOUT
 # writing the file or touching the remote (needs FOLDER_NAME, the directory
 # that holds the component's CHANGELOG.md).
 make -f "$MK" prepend-dry-run \
   COMPONENT=coordinator \
-  SCOPES='coordinator|deps|misc' \
-  INCLUDE_PATH='coordinator/**' \
   FOLDER_NAME=coordinator
 ```
 
-`INCLUDE_PATH` is one path per line, so for a component with several paths pass a multi-line value — bash/zsh `$'a\nb'` or a real newline-quoted string both work:
+Pass `SCOPES`/`INCLUDE_PATH` explicitly to preview a value *before* committing it to `components.sh` (`INCLUDE_PATH` is one path per line, so for several paths use a multi-line value — bash/zsh `$'a\nb'` or a real newline-quoted string both work):
 
 ```bash
 make -f "$MK" changelog-dry-run \
@@ -92,24 +87,25 @@ make -f "$MK" changelog-dry-run \
   INCLUDE_PATH=$'tracer/**\ntracer-constraints/**\nlinea-besu/plugins/linea-sequencer/**\nlinea-besu/besu/**\nlinea-besu/package/**\ngradle/libs.versions.toml'
 ```
 
-Fill the arguments per component (`COMPONENT` is also the release tag-pattern component; `FOLDER_NAME` is only needed for `prepend-dry-run`):
+`COMPONENT` is also the release tag-pattern component; `FOLDER_NAME` (only needed for `prepend-dry-run`) per component:
 
-| `COMPONENT` | `SCOPES` | `INCLUDE_PATH` (one per line) | `FOLDER_NAME` |
-|---|---|---|---|
-| `coordinator` | `coordinator\|deps\|misc` | `coordinator/**` | `coordinator` |
-| `maru` | `maru\|deps\|misc` | `maru/**` | `maru` |
-| `postman` | `postman\|deps\|misc` | `postman/**` | `postman` |
-| `prover` | `prover\|deps\|misc` | `prover/**` | `prover` |
-| `tx-exclusion-api` | `tx-exclusion-api\|deps\|misc` | `transaction-exclusion-api/**` | `transaction-exclusion-api` |
-| `linea-besu-package` | `linea-besu\|tracer\|sequencer\|deps\|misc` | `tracer/**`, `tracer-constraints/**`, `linea-besu/plugins/linea-sequencer/**`, `linea-besu/besu/**`, `linea-besu/package/**`, `gradle/libs.versions.toml` | `linea-besu/package` |
-| `linea` (milestone) | `coordinator\|linea-besu\|tracer\|sequencer\|maru\|prover\|postman\|tx-exclusion-api\|deps\|misc` | the union of every component path above | `.` |
+| `COMPONENT` | `FOLDER_NAME` |
+|---|---|
+| `coordinator` | `coordinator` |
+| `maru` | `maru` |
+| `postman` | `postman` |
+| `prover` | `prover` |
+| `tx-exclusion-api` | `transaction-exclusion-api` |
+| `linea-besu-package` | `linea-besu/package` |
+| `linea` (milestone) | `.` |
 
 Notes:
 
 - The dry-run targets are read-only: they never modify tracked files or the git remote. `prepend-dry-run` renders on a throwaway copy of `CHANGELOG.md` and prints the result to stdout; the real file is left untouched.
+- Run `make -f "$MK" component-info COMPONENT=<name>` to print a component's resolved `scopes`/`include_path` without running git-cliff.
 - If a component has no qualifying commits, git-cliff reports "There is nothing to bump" and `changed=false` — meaning no release would be cut. This is the scope-and-path gating in action: a commit counts only when it is **both** in-scope **and** touches a component path.
 - The changelog/prepend previews render under the computed next-version header by default (`GENERATE_WITH_NEXT_TAG=true`); pass `GENERATE_WITH_NEXT_TAG=false` to preview under an `[unreleased]` header instead.
-- These are the same `scopes` and `include-path` values the workflows pass to the action, and the Makefile runs the same scripts, so the local result matches CI. Run `make -f "$MK" help` to list every target.
+- The Makefile runs the same scripts (and the same `components.sh` lookup) the workflows use, so the local result matches CI. Run `make -f "$MK" help` to list every target.
 
 ### Per-component release
 

--- a/scripts/docker/list-besu-profiles.sh
+++ b/scripts/docker/list-besu-profiles.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Lists Besu profile names (one per *.toml file) under a profiles directory, as a JSON array
+# suitable for a GitHub Actions matrix. Shared by:
+#   - lineth-monorepo/.github/workflows/reusable-linea-besu-package-run-test.yml
+#   - lineth-enterprise/.github/workflows/e-besu-package-run-test.yml (via the mirrored
+#     scripts/docker/ copy — see .github/actions/e-checkout-and-setup-lineth-monorepo)
+#
+# Usage: list-besu-profiles.sh <profiles-dir>
+# When $GITHUB_OUTPUT is set, writes `files=<json>`; otherwise prints the JSON to stdout.
+
+set -euo pipefail
+
+profiles_dir="${1:?Usage: list-besu-profiles.sh <profiles-dir>}"
+
+files_json="$(
+  find "${profiles_dir}" -maxdepth 1 -type f -name '*.toml' -exec basename {} .toml \; |
+    sort |
+    jq -R -s -c 'split("\n") | map(select(length > 0))'
+)"
+
+echo "Profiles: ${files_json}" >&2
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "files=${files_json}" >> "${GITHUB_OUTPUT}"
+else
+  echo "${files_json}"
+fi


### PR DESCRIPTION
…ise and oss ci

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release/changelog automation and git ref handling; behavior should match prior matrices if `components.sh` is correct, but mistakes would affect version bumps and CHANGELOG prepends across all components.
> 
> **Overview**
> **Centralizes** per-component git-cliff `SCOPES` and `INCLUDE_PATH` in `scripts/components.sh`, with lookup via `component-info` in the `run-git-cliff-commands` action and Makefile dry-runs. Release and changelog workflows now pass **`component-name` only** (optional overrides remain); milestone changelog assembly calls `make component-info` instead of duplicating scope/path strings.
> 
> **Security / behavior:** adds optional **`target-ref`** on the composite action so `prepend` only `git pull --ff-only` when a caller will push—read-only jobs (e.g. component changelog upload) no longer derive branch from `github.head_ref`. Release push workflows set `target-ref` explicitly. Some milestone metadata checkouts drop mutable `head_ref` in favor of the dispatch commit (`github.sha`).
> 
> **Also:** extracts **`scripts/docker/list-besu-profiles.sh`** for the Besu profile test matrix (shared with enterprise CI) and updates **README** local preview docs to match the new defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4601ee54da9b39821609392bb71fc9e167552fe7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->