### PR TITLE
feat(coordinator): add ConflationTriggerCalculatorByCoinbase

### DIFF
--- a/coordinator/core-interfaces/src/main/kotlin/linea/domain/Conflation.kt
+++ b/coordinator/core-interfaces/src/main/kotlin/linea/domain/Conflation.kt
@@ -47,11 +47,12 @@ enum class ConflationTrigger(val triggerPriority: Int) {
   // as it is used as conflation, blob and aggregation boundary.
   TARGET_BLOCK_NUMBER(1),
   FORCED_TRANSACTION(2),
-  HARD_FORK(3),
-  DATA_LIMIT(4),
-  TRACES_LIMIT(5),
-  TIME_LIMIT(6),
-  BLOCKS_LIMIT(7),
+  COINBASE_CHANGE(3),
+  HARD_FORK(4),
+  DATA_LIMIT(5),
+  TRACES_LIMIT(6),
+  TIME_LIMIT(7),
+  BLOCKS_LIMIT(8),
 }
 
 data class ConflationCalculationResult(

--- a/coordinator/core/src/main/kotlin/lineth/conflation/calculators/ConflationTriggerCalculatorByCoinbase.kt
+++ b/coordinator/core/src/main/kotlin/lineth/conflation/calculators/ConflationTriggerCalculatorByCoinbase.kt
@@ -1,0 +1,41 @@
+package lineth.conflation.calculators
+
+import linea.domain.BlockCounters
+import linea.domain.ConflationTrigger
+
+/**
+ * Triggers conflation when the block coinbase (miner address) changes.
+ *
+ * The RISC-V execution proof uses the first block's miner as the coinbase for the
+ * entire conflation, so all blocks in a batch must share the same coinbase.
+ */
+class ConflationTriggerCalculatorByCoinbase : ConflationTriggerCalculator {
+  override val id: String = ConflationTrigger.COINBASE_CHANGE.name
+  private var currentBatchCoinbase: String? = null
+
+  override fun checkOverflow(blockCounters: BlockCounters): ConflationTriggerCalculator.OverflowTrigger? {
+    val batchCoinbase = currentBatchCoinbase ?: return null
+    return if (blockCounters.coinbase != batchCoinbase) {
+      ConflationTriggerCalculator.OverflowTrigger(ConflationTrigger.COINBASE_CHANGE, false)
+    } else {
+      null
+    }
+  }
+
+  override fun appendBlock(blockCounters: BlockCounters) {
+    if (currentBatchCoinbase == null) {
+      currentBatchCoinbase = blockCounters.coinbase
+    } else if (blockCounters.coinbase != currentBatchCoinbase) {
+      throw IllegalStateException(
+        "Block ${blockCounters.blockNumber} coinbase=${blockCounters.coinbase} " +
+          "differs from batch coinbase=$currentBatchCoinbase",
+      )
+    }
+  }
+
+  override fun reset() {
+    currentBatchCoinbase = null
+  }
+
+  override fun copyCountersTo(counters: ConflationCounters) = Unit
+}

--- a/coordinator/core/src/test/kotlin/lineth/conflation/calculators/ConflationTriggerCalculatorByCoinbaseTest.kt
+++ b/coordinator/core/src/test/kotlin/lineth/conflation/calculators/ConflationTriggerCalculatorByCoinbaseTest.kt
@@ -1,0 +1,77 @@
+package lineth.conflation.calculators
+
+import linea.domain.BlockCounters
+import linea.domain.ConflationTrigger
+import net.consensys.linea.traces.TracesCountersV2
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.time.Instant
+
+class ConflationTriggerCalculatorByCoinbaseTest {
+  private lateinit var calculator: ConflationTriggerCalculatorByCoinbase
+
+  private val coinbaseA = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  private val coinbaseB = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+  @BeforeEach
+  fun beforeEach() {
+    calculator = ConflationTriggerCalculatorByCoinbase()
+  }
+
+  @Test
+  fun `checkOverflow should return null when batch is empty`() {
+    assertThat(calculator.checkOverflow(blockCounters(1, coinbaseA))).isNull()
+  }
+
+  @Test
+  fun `checkOverflow should return null when coinbase matches the batch`() {
+    calculator.appendBlock(blockCounters(1, coinbaseA))
+    assertThat(calculator.checkOverflow(blockCounters(2, coinbaseA))).isNull()
+  }
+
+  @Test
+  fun `checkOverflow should trigger when coinbase changes`() {
+    calculator.appendBlock(blockCounters(1, coinbaseA))
+    assertThat(calculator.checkOverflow(blockCounters(2, coinbaseB)))
+      .isEqualTo(ConflationTriggerCalculator.OverflowTrigger(ConflationTrigger.COINBASE_CHANGE, false))
+  }
+
+  @Test
+  fun `appendBlock should throw when coinbase differs from batch coinbase`() {
+    calculator.appendBlock(blockCounters(1, coinbaseA))
+    assertThatThrownBy { calculator.appendBlock(blockCounters(2, coinbaseB)) }
+      .isInstanceOf(IllegalStateException::class.java)
+      .hasMessageContaining("coinbase")
+  }
+
+  @Test
+  fun `reset should clear batch coinbase so next block starts a fresh batch`() {
+    calculator.appendBlock(blockCounters(1, coinbaseA))
+    calculator.reset()
+    assertThat(calculator.checkOverflow(blockCounters(2, coinbaseB))).isNull()
+    calculator.appendBlock(blockCounters(2, coinbaseB))
+    assertThat(calculator.checkOverflow(blockCounters(3, coinbaseA)))
+      .isEqualTo(ConflationTriggerCalculator.OverflowTrigger(ConflationTrigger.COINBASE_CHANGE, false))
+  }
+
+  @Test
+  fun `should accumulate multiple blocks with the same coinbase without triggering`() {
+    repeat(10) { i ->
+      assertThat(calculator.checkOverflow(blockCounters(i + 1, coinbaseA))).isNull()
+      calculator.appendBlock(blockCounters(i + 1, coinbaseA))
+    }
+    assertThat(calculator.checkOverflow(blockCounters(11, coinbaseB)))
+      .isEqualTo(ConflationTriggerCalculator.OverflowTrigger(ConflationTrigger.COINBASE_CHANGE, false))
+  }
+
+  private fun blockCounters(blockNumber: Int, coinbase: String): BlockCounters =
+    BlockCounters(
+      blockNumber = blockNumber.toULong(),
+      blockTimestamp = Instant.parse("2021-01-01T00:00:00.000Z"),
+      tracesCounters = TracesCountersV2.EMPTY_TRACES_COUNT,
+      blockRLPEncoded = ByteArray(0),
+      coinbase = coinbase,
+    )
+}


### PR DESCRIPTION
## Summary

- Adds `COINBASE_CHANGE(3)` to `ConflationTrigger` enum, between `FORCED_TRANSACTION(2)` and `HARD_FORK(4)`
- Implements `ConflationTriggerCalculatorByCoinbase`: triggers conflation whenever the miner address changes between blocks within a batch
- The RISC-V `L2ExecutionRequestBuilder` uses `conflation.blocks.first().miner` as the coinbase for the whole batch, so all blocks in one conflation must share the same coinbase — this calculator enforces that invariant

## Design notes

- On restart the calculator correctly initialises from `null`: the `BlockCreationMonitor` always replays from the start of the first un-proven batch, so the first block fed to the calculator is always the first block of its batch, and the coinbase is set correctly without any explicit seeding
- `appendBlock` throws `IllegalStateException` if called with a mismatched coinbase, serving as a defence-in-depth guard against the `GlobalBlockConflationCalculator` feeding a block that should have triggered an overflow

## Test plan

- [ ] `ConflationTriggerCalculatorByCoinbaseTest` — 6 unit tests covering: empty-batch returns null, same-coinbase returns null, coinbase change triggers `COINBASE_CHANGE`, mismatched `appendBlock` throws, `reset` clears state, multi-block accumulation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes conflation trigger ordering and batch-splitting rules for coordinator proving; incorrect wiring or priority could produce invalid multi-miner batches until integrated.
> 
> **Overview**
> Adds a **coinbase-change** conflation boundary so batches never mix blocks with different miner addresses, matching how RISC-V execution proofs treat the first block’s miner as the batch coinbase.
> 
> Introduces `ConflationTrigger.COINBASE_CHANGE` at priority **3** (above hard fork and limit triggers) and `ConflationTriggerCalculatorByCoinbase`, which sets the batch coinbase on the first appended block, returns `COINBASE_CHANGE` on `checkOverflow` when the next block’s `coinbase` differs, and throws on mismatched `appendBlock` as a guard. Unit tests cover empty batch, matching coinbase, change detection, reset, and multi-block accumulation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b76f91bc75787195c20ece81fcdba6d46be5a9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->