### PR TITLE
feat(prover-ray): update prover-ray to ZkC version v1.2.31

### DIFF
--- a/prover-ray/backend/backend_test.go
+++ b/prover-ray/backend/backend_test.go
@@ -87,7 +87,7 @@ func compileZKCBin(t *testing.T, srcPath string) string {
 	zkcField := field.KOALABEAR_16
 	zkcCfg := codegen.DEFAULT_CONFIG
 
-	macroProgram, _, errs := compiler.Compile(zkcField, *src)
+	macroProgram, _, errs := compiler.Compile(zkcField, codegen.DEFAULT_MAX_STATIC_HEIGHT, *src)
 	if len(errs) > 0 {
 		t.Fatalf("zkc macro compile %q: %v", srcPath, errs)
 	}
@@ -96,7 +96,7 @@ func compileZKCBin(t *testing.T, srcPath string) string {
 		t.Fatalf("zkc ast compile %q: %v", srcPath, errs)
 	}
 
-	binF := constraints.NewBinaryFile[koalabear.Element](nil, nil, zkcField, zkcCfg.GetMaxStaticHeight(), ir)
+	binF := constraints.NewBinaryFile[koalabear.Element](nil, nil, ir)
 	binBytes, err := binF.MarshalBinary()
 	require.NoError(t, err)
 

--- a/prover-ray/backend/core.go
+++ b/prover-ray/backend/core.go
@@ -11,6 +11,7 @@ import (
 	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/wiop"
 	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/zkcdriver"
 	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/zkcdriver/risc5"
+	"github.com/sirupsen/logrus"
 )
 
 // ErrNotImplemented is returned by stubs that are not yet wired up.
@@ -139,8 +140,13 @@ func (c *Core) runProve(
 ) (wiop.Proof, wiop.PublicInput, error) {
 	_ = ctx // cancellation not yet propagated into the prover internals
 
+	traces := c.driver.TraceZkcInputs(preRead)
+	if len(traces) > 1 {
+		logrus.Fatalf("the test case is expected to only use a single public inputs")
+	}
+
 	proof, pub := c.sys.Prove(func(rt *wiop.Runtime) {
-		c.driver.AssignWithPreRead(rt, preRead, field.Octuplet{})
+		c.driver.AssignTraceShard(rt, traces[0], field.Octuplet{})
 	})
 
 	if err := c.sys.Verify(proof, pub); err != nil {

--- a/prover-ray/go.mod
+++ b/prover-ray/go.mod
@@ -3,7 +3,7 @@ module github.com/LFDT-Lineth/lineth-monorepo/prover-ray
 go 1.25.7
 
 require (
-	github.com/LFDT-Lineth/zkc v1.2.27
+	github.com/LFDT-Lineth/zkc v1.2.31
 	github.com/consensys/gnark v0.14.1-0.20260219004710-bbfb2f70a565
 	github.com/consensys/gnark-crypto v0.20.2-0.20260807171631-a71790dd0fe3
 	github.com/ethereum/go-ethereum v1.17.0

--- a/prover-ray/go.sum
+++ b/prover-ray/go.sum
@@ -1,5 +1,9 @@
 github.com/LFDT-Lineth/zkc v1.2.27 h1:QQYJa/jE66LqyAFOQlFtrEGzDHXWNyfndwpnXvNF5TM=
 github.com/LFDT-Lineth/zkc v1.2.27/go.mod h1:sBRNMvovYHKzGBhayuSA5m5HMadXWmI/rX8nNsaMidE=
+github.com/LFDT-Lineth/zkc v1.2.31-0.20260829130202-f3d43522975d h1:IueEK4h1hV5xyR9gvW+P0tSWSHDalhEgpJC23bKfdc4=
+github.com/LFDT-Lineth/zkc v1.2.31-0.20260829130202-f3d43522975d/go.mod h1:sBRNMvovYHKzGBhayuSA5m5HMadXWmI/rX8nNsaMidE=
+github.com/LFDT-Lineth/zkc v1.2.31 h1:ptNsFn3Tal9+VwuP9tehUdsriLKTok8HEWRu4s1B4vk=
+github.com/LFDT-Lineth/zkc v1.2.31/go.mod h1:sBRNMvovYHKzGBhayuSA5m5HMadXWmI/rX8nNsaMidE=
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6 h1:1zYrtlhrZ6/b6SAjLSfKzWtdgqK0U+HtH/VcBWh1BaU=
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=

--- a/prover-ray/zkcdriver/assignment.go
+++ b/prover-ray/zkcdriver/assignment.go
@@ -19,11 +19,10 @@ import (
 var _ [1]uint32 = koalabear.Element{}
 var _ [1]uint32 = field.Element{}
 
-// ReadExpandedTraces parses the provided trace file, expands it and returns the
-// corset object holding the expanded traces.
-func AssignFromTrace(
+// AssignFromTraceShard expands and assigns the trace to the given runtime.
+func AssignFromTraceShard(
 	run *wiop.Runtime,
-	traces trace.Trace[koalabear.Element],
+	shard trace.Shard[koalabear.Element],
 	schema air.Schema[koalabear.Element],
 	sharedRandomness field.Octuplet,
 ) {
@@ -37,70 +36,68 @@ func AssignFromTrace(
 	}
 
 	eg := &errgroup.Group{}
-	// FIXME: @djp this clearly is not working correctly, since it is putting
-	// all shards into the same assignment.
-	for _, shard := range traces {
-		// Parallelize across modules
-		for modID := range shard.Width() {
-			eg.Go(func() error {
 
-				trMod := shard.Module(modID)
-				scMod := schema.Module(modID)
+	// Parallelize across modules
+	for modID := range shard.Width() {
+		eg.Go(func() error {
 
-				if scMod.IsStatic() {
-					// @alex: the current version of corset flags modules as being
-					// static or not static. But it may be the case, that a module
-					// has static size, some its column have static content but some
-					// do not have static content.
-					return nil
-				}
+			trMod := shard.Module(modID)
+			scMod := schema.Module(modID)
 
-				// Iterate each column in module
-				parallel.Execute(int(trMod.Width()), func(start, stop int) {
-					for id := start; id < stop; id++ {
-
-						var (
-							sys         = run.System
-							columnIDMap = sys.Annotations[corsetColumnMapAnnotationKey].(map[string]wiop.ObjectID)
-							col         = trMod.Column(uint(id))
-							moduleName  = trMod.Name()
-							name        = qualifiedCorsetName(moduleName, trMod.Descriptor().Columns[id].Name)
-							pad         koalabear.Element
-						)
-
-						if _, ok := columnIDMap[name]; !ok {
-							logrus.Debugf("zkcdriver: AssignFromTrace: skipping unknown column %q", name)
-							continue
-						}
-
-						var (
-							wCol    = sys.LookupColumn(columnIDMap[name])
-							padding field.Element
-						)
-
-						// Use unsafe cast to avoid per-element Bytes()/SetBytes()
-						// round-trip.
-						plain := make([]field.Element, col.Len())
-						for i := range plain {
-							v := col.Get(uint(i))
-							plain[i] = *(*field.Element)(unsafe.Pointer(&v))
-						}
-
-						// FIXME: @djp use of a padding value here does not make
-						// sense to me, since ZkC is in charge of padding.
-						padding = *(*field.Element)(unsafe.Pointer(&pad))
-
-						// Done
-						run.AssignColumn(
-							wCol,
-							&wiop.ConcreteVector{Plain: field.VecFromBase(plain), Padding: padding},
-						)
-					}
-				})
+			if scMod.IsStatic() {
+				// @alex: the current version of corset flags modules as being
+				// static or not static. But it may be the case, that a module
+				// has static size, some its column have static content but some
+				// do not have static content.
 				return nil
+			}
+
+			// Iterate each column in module
+			parallel.Execute(int(trMod.Width()), func(start, stop int) {
+				for id := start; id < stop; id++ {
+
+					var (
+						sys         = run.System
+						columnIDMap = sys.Annotations[corsetColumnMapAnnotationKey].(map[string]wiop.ObjectID)
+						col         = trMod.Column(uint(id))
+						moduleName  = trMod.Name()
+						name        = qualifiedCorsetName(moduleName, trMod.Descriptor().Columns[id].Name)
+						pad         koalabear.Element
+					)
+
+					if _, ok := columnIDMap[name]; !ok {
+						logrus.Debugf("zkcdriver: AssignFromTrace: skipping unknown column %q", name)
+						continue
+					}
+
+					var (
+						wCol    = sys.LookupColumn(columnIDMap[name])
+						padding field.Element
+					)
+
+					// Use unsafe cast to avoid per-element Bytes()/SetBytes()
+					// round-trip.
+					plain := make([]field.Element, col.Len())
+					for i := range plain {
+						v := col.Get(uint(i))
+						plain[i] = *(*field.Element)(unsafe.Pointer(&v))
+					}
+
+					// FIXME: @djp use of a padding value here does not make
+					// sense to me, since ZkC is in charge of padding.
+					padding = *(*field.Element)(unsafe.Pointer(&pad))
+
+					// Done
+					run.AssignColumn(
+						wCol,
+						&wiop.ConcreteVector{Plain: field.VecFromBase(plain), Padding: padding},
+					)
+				}
 			})
-		}
+			return nil
+		})
 	}
+
 	if err := eg.Wait(); err != nil {
 		logrus.Panicf("zkcdriver: AssignFromTrace failed: %v", err)
 	}

--- a/prover-ray/zkcdriver/assignment.go
+++ b/prover-ray/zkcdriver/assignment.go
@@ -83,8 +83,6 @@ func AssignFromTraceShard(
 						plain[i] = *(*field.Element)(unsafe.Pointer(&v))
 					}
 
-					// FIXME: @djp use of a padding value here does not make
-					// sense to me, since ZkC is in charge of padding.
 					padding = *(*field.Element)(unsafe.Pointer(&pad))
 
 					// Done

--- a/prover-ray/zkcdriver/assignment.go
+++ b/prover-ray/zkcdriver/assignment.go
@@ -36,66 +36,70 @@ func AssignFromTrace(
 		messagebus.AssignSharedRandomnessSeed(run, sharedRandomness)
 	}
 
-	// Parallelize across modules
 	eg := &errgroup.Group{}
-	for modID := range traces.Width() {
-		eg.Go(func() error {
+	// FIXME: @djp this clearly is not working correctly, since it is putting
+	// all shards into the same assignment.
+	for _, shard := range traces {
+		// Parallelize across modules
+		for modID := range shard.Width() {
+			eg.Go(func() error {
 
-			trMod := traces.Module(modID)
-			scMod := schema.Module(modID)
+				trMod := shard.Module(modID)
+				scMod := schema.Module(modID)
 
-			if scMod.IsStatic() {
-				// @alex: the current version of corset flags modules as being
-				// static or not static. But it may be the case, that a module
-				// has static size, some its column have static content but some
-				// do not have static content.
-				return nil
-			}
-
-			// Iterate each column in module
-			parallel.Execute(int(trMod.Width()), func(start, stop int) {
-				for id := start; id < stop; id++ {
-
-					var (
-						sys         = run.System
-						columnIDMap = sys.Annotations[corsetColumnMapAnnotationKey].(map[string]wiop.ObjectID)
-						col         = trMod.Column(uint(id))
-						moduleName  = trMod.Name().String()
-						name        = qualifiedCorsetName(moduleName, col.Name())
-					)
-
-					if _, ok := columnIDMap[name]; !ok {
-						logrus.Debugf("zkcdriver: AssignFromTrace: skipping unknown column %q", name)
-						continue
-					}
-
-					var (
-						wCol    = sys.LookupColumn(columnIDMap[name])
-						padding field.Element
-						data    = col.Data()
-					)
-
-					// Use unsafe cast to avoid per-element Bytes()/SetBytes()
-					// round-trip.
-					plain := make([]field.Element, data.Len())
-					for i := range plain {
-						v := data.Get(uint(i))
-						plain[i] = *(*field.Element)(unsafe.Pointer(&v))
-					}
-
-					// Configure padding value
-					pad := col.Padding()
-					padding = *(*field.Element)(unsafe.Pointer(&pad))
-
-					// Done
-					run.AssignColumn(
-						wCol,
-						&wiop.ConcreteVector{Plain: field.VecFromBase(plain), Padding: padding},
-					)
+				if scMod.IsStatic() {
+					// @alex: the current version of corset flags modules as being
+					// static or not static. But it may be the case, that a module
+					// has static size, some its column have static content but some
+					// do not have static content.
+					return nil
 				}
+
+				// Iterate each column in module
+				parallel.Execute(int(trMod.Width()), func(start, stop int) {
+					for id := start; id < stop; id++ {
+
+						var (
+							sys         = run.System
+							columnIDMap = sys.Annotations[corsetColumnMapAnnotationKey].(map[string]wiop.ObjectID)
+							col         = trMod.Column(uint(id))
+							moduleName  = trMod.Name()
+							name        = qualifiedCorsetName(moduleName, trMod.Descriptor().Columns[id].Name)
+							pad         koalabear.Element
+						)
+
+						if _, ok := columnIDMap[name]; !ok {
+							logrus.Debugf("zkcdriver: AssignFromTrace: skipping unknown column %q", name)
+							continue
+						}
+
+						var (
+							wCol    = sys.LookupColumn(columnIDMap[name])
+							padding field.Element
+						)
+
+						// Use unsafe cast to avoid per-element Bytes()/SetBytes()
+						// round-trip.
+						plain := make([]field.Element, col.Len())
+						for i := range plain {
+							v := col.Get(uint(i))
+							plain[i] = *(*field.Element)(unsafe.Pointer(&v))
+						}
+
+						// FIXME: @djp use of a padding value here does not make
+						// sense to me, since ZkC is in charge of padding.
+						padding = *(*field.Element)(unsafe.Pointer(&pad))
+
+						// Done
+						run.AssignColumn(
+							wCol,
+							&wiop.ConcreteVector{Plain: field.VecFromBase(plain), Padding: padding},
+						)
+					}
+				})
+				return nil
 			})
-			return nil
-		})
+		}
 	}
 	if err := eg.Wait(); err != nil {
 		logrus.Panicf("zkcdriver: AssignFromTrace failed: %v", err)

--- a/prover-ray/zkcdriver/definition.go
+++ b/prover-ray/zkcdriver/definition.go
@@ -422,7 +422,7 @@ func (s *schemaScanner) addConstraintInComp(name string, corsetCS schema.Constra
 				table.Columns[i] = s.compColumnByCorsetID(sendPort.Module, sendPort.Registers[i]).View()
 			}
 
-			s.Sys.NewMessageBusReceive(s.Sys.Context.Childf("bus-%v", name), "0", name, table)
+			s.Sys.NewMessageBusSend(s.Sys.Context.Childf("bus-%v", name), "0", name, table)
 		}
 
 	case air.LookupConstraint[koalabear.Element]:

--- a/prover-ray/zkcdriver/definition.go
+++ b/prover-ray/zkcdriver/definition.go
@@ -390,23 +390,40 @@ func (s *schemaScanner) addConstraintInComp(name string, corsetCS schema.Constra
 	switch cs := corsetCS.(type) {
 
 	case air.BusConstraint[koalabear.Element]:
-		// FIXME: @djp this needs to be implemented.  The layout of bus
-		// constraints is very similar to that for lookups.
-		//
-		// var bc = cs.Unwrap()
-		// // Iterate receive ports, each of which identifies a set of columns in a
-		// // given module (including a selector) which determine the message being
-		// // reveived.
-		// for _, recvPort := range bc.Receives {
-		//
-		// }
-		// // Iterate send ports, each of which identifies a set of columns in a
-		// // given module (including a selector) which determine the message being
-		// // sent.
-		// for _, sendPort := range bc.Receives {
-		//
-		// }
-		panic("support translation of bus constraints")
+
+		var bc = cs.Unwrap()
+		// Iterate receive ports, each of which identifies a set of columns in a
+		// given module (including a selector) which determine the message being
+		// reveived.
+		for _, recvPort := range bc.Receives {
+
+			table := wiop.Table{
+				Columns:  make([]*wiop.ColumnView, len(recvPort.Registers)),
+				Selector: s.compColumnByCorsetID(recvPort.Module, recvPort.Selector).View(),
+			}
+
+			for i := range table.Columns {
+				table.Columns[i] = s.compColumnByCorsetID(recvPort.Module, recvPort.Registers[i]).View()
+			}
+
+			s.Sys.NewMessageBusReceive(s.Sys.Context.Childf("bus-%v", name), "0", name, table)
+		}
+
+		// Iterate send ports, each of which identifies a set of columns in a
+		// given module (including a selector) which determine the message being
+		// sent.
+		for _, sendPort := range bc.Sends {
+			table := wiop.Table{
+				Columns:  make([]*wiop.ColumnView, len(sendPort.Registers)),
+				Selector: s.compColumnByCorsetID(sendPort.Module, sendPort.Selector).View(),
+			}
+
+			for i := range table.Columns {
+				table.Columns[i] = s.compColumnByCorsetID(sendPort.Module, sendPort.Registers[i]).View()
+			}
+
+			s.Sys.NewMessageBusReceive(s.Sys.Context.Childf("bus-%v", name), "0", name, table)
+		}
 
 	case air.LookupConstraint[koalabear.Element]:
 

--- a/prover-ray/zkcdriver/definition.go
+++ b/prover-ray/zkcdriver/definition.go
@@ -69,7 +69,7 @@ func Define(sys *wiop.System, schema *air.Schema[koalabear.Element]) {
 	// Collect modules and sort them by name to ensure deterministic processing order
 	modules := schema.Modules().Collect()
 	sort.Slice(modules, func(i, j int) bool {
-		return modules[i].Name().String() < modules[j].Name().String()
+		return modules[i].Name() < modules[j].Name()
 	})
 
 	scanner := &schemaScanner{
@@ -102,7 +102,7 @@ func (s *schemaScanner) collectPublicOutputs() PublicOutput {
 			continue
 		}
 
-		moduleName := modDecl.Name().String()
+		moduleName := modDecl.Name()
 
 		// Only one public output is supported, so a slot already claimed by an
 		// earlier module is refused rather than silently resolved.
@@ -163,7 +163,7 @@ func (s *schemaScanner) scanColumns() {
 	// Use the pre-sorted modules from the scanner to ensure deterministic ordering
 	// Iterate each declared module
 	for _, modDecl := range s.Modules {
-		moduleName := modDecl.Name().String()
+		moduleName := modDecl.Name()
 
 		// Skip non-native modules whose every column is dangling to avoid creating empty
 		// wiop modules whose dynamic size would never be set.
@@ -292,7 +292,7 @@ func (s *schemaScanner) collectReferencedColumns() map[string]struct{} {
 		case air.RangeConstraint[koalabear.Element]:
 			rc := cs.Unwrap()
 			for i := range rc.Bitwidths {
-				s.addColRef(rc.Context, rc.Sources[i].Register(), referenced)
+				s.addColRef(rc.Context, rc.Sources[i], referenced)
 			}
 		}
 	}
@@ -334,7 +334,7 @@ func (s *schemaScanner) collectFromTerm(
 func (s *schemaScanner) addColRef(modID schema.ModuleId, regID register.Id, out map[string]struct{}) {
 	ref := register.NewRef(modID, regID)
 	cCol := s.Schema.Register(ref)
-	moduleName := s.Schema.Module(modID).Name().String()
+	moduleName := s.Schema.Module(modID).Name()
 	out[qualifiedCorsetName(moduleName, cCol.Name())] = struct{}{}
 }
 
@@ -388,6 +388,25 @@ func (s *schemaScanner) scanConstraints() {
 func (s *schemaScanner) addConstraintInComp(name string, corsetCS schema.Constraint[koalabear.Element]) {
 
 	switch cs := corsetCS.(type) {
+
+	case air.BusConstraint[koalabear.Element]:
+		// FIXME: @djp this needs to be implemented.  The layout of bus
+		// constraints is very similar to that for lookups.
+		//
+		// var bc = cs.Unwrap()
+		// // Iterate receive ports, each of which identifies a set of columns in a
+		// // given module (including a selector) which determine the message being
+		// // reveived.
+		// for _, recvPort := range bc.Receives {
+		//
+		// }
+		// // Iterate send ports, each of which identifies a set of columns in a
+		// // given module (including a selector) which determine the message being
+		// // sent.
+		// for _, sendPort := range bc.Receives {
+		//
+		// }
+		panic("support translation of bus constraints")
 
 	case air.LookupConstraint[koalabear.Element]:
 
@@ -493,7 +512,7 @@ func (s *schemaScanner) addConstraintInComp(name string, corsetCS schema.Constra
 		for i, bitwidth := range rc.Bitwidths {
 			// Determine bound for this range constraint
 			bound := 1 << bitwidth
-			col := s.compColumnByCorsetID(rc.Context, rc.Sources[i].Register())
+			col := s.compColumnByCorsetID(rc.Context, rc.Sources[i])
 			col.Module.NewRangeCheck(col.Context.Childf("range-%v", name), col, bound)
 		}
 
@@ -588,7 +607,7 @@ func (s *schemaScanner) compColumnByCorsetID(
 		// construct register reference which uniquely identifies the column
 		ref        = register.NewRef(modID, regID)
 		cCol       = s.Schema.Register(ref)
-		moduleName = s.Schema.Module(modID).Name().String()
+		moduleName = s.Schema.Module(modID).Name()
 		columnName = qualifiedCorsetName(moduleName, cCol.Name())
 	)
 

--- a/prover-ray/zkcdriver/guest_output_test.go
+++ b/prover-ray/zkcdriver/guest_output_test.go
@@ -62,9 +62,14 @@ func TestGuestPublicOutputs(t *testing.T) {
 	assert.NotNil(t, sys.LookupColumn(output.Address), "the address column must resolve")
 	assert.NotNil(t, sys.LookupColumn(output.Data), "the data column must resolve")
 
+	traces := driver.TraceZkcInputs(inputs)
+	if len(traces) > 1 {
+		t.Fatalf("the test fixture is expected to only use a single public inputs")
+	}
+
 	var got []koalafield.Element
 	proof, pub := sys.Prove(func(rt *wiop.Runtime) {
-		driver.AssignWithPreRead(rt, inputs, koalafield.Octuplet{})
+		driver.AssignTraceShard(rt, traces[0], koalafield.Octuplet{})
 		got = risc5.GetGuestPublicOutputs(rt)
 	}, wiop.ProveOptions{CheckUnreducedQueries: true})
 
@@ -94,29 +99,34 @@ func TestGuestPublicOutputsWrongLength(t *testing.T) {
 	t.Run("the length constraints reject the proof", func(t *testing.T) {
 		sys, driver, inputs, _ := newGuestOutputSystem(t, zkcPath, inputHex)
 
-		assert.False(t, provesAndVerifies(t, sys, driver, inputs),
+		assert.False(t, provesAndVerifiesFirstShardOnly(t, sys, driver, inputs),
 			"a guest output whose length disagrees with the memory must not verify")
 	})
 
 	t.Run("the prover reports the mismatch", func(t *testing.T) {
 		sys, driver, inputs, _ := newGuestOutputSystem(t, zkcPath, inputHex)
 
+		traces := driver.TraceZkcInputs(inputs)
+		if len(traces) > 1 {
+			t.Fatalf("the test fixture is expected to only use a single public inputs")
+		}
+
 		assert.PanicsWithValue(t,
 			"risc5: GetGuestPublicOutputs: the guest wrote 9 outputs but the expected output size is 8",
 			func() {
 				sys.Prove(func(rt *wiop.Runtime) {
-					driver.AssignWithPreRead(rt, inputs, koalafield.Octuplet{})
+					driver.AssignTraceShard(rt, traces[0], koalafield.Octuplet{})
 					risc5.GetGuestPublicOutputs(rt)
 				})
 			})
 	})
 }
 
-// provesAndVerifies reports whether sys produces a proof that verifies. A
+// provesAndVerifiesFirstShardOnly reports whether sys produces a proof that verifies. A
 // violated constraint can surface either as a verification error or as a panic
 // from the prover, so both count as a failure; the reason is logged so that a
 // rejection for an unrelated reason does not pass for the one under test.
-func provesAndVerifies(
+func provesAndVerifiesFirstShardOnly(
 	t *testing.T, sys *wiop.System, driver *zkcdriver.ZkCDriver, inputs *zkcdriver.PreReadInputs,
 ) (ok bool) {
 
@@ -129,8 +139,13 @@ func provesAndVerifies(
 		}
 	}()
 
+	traces := driver.TraceZkcInputs(inputs)
+	if len(traces) > 1 {
+		t.Fatalf("the test fixture is expected to only use a single public inputs")
+	}
+
 	proof, pub := sys.Prove(func(rt *wiop.Runtime) {
-		driver.AssignWithPreRead(rt, inputs, koalafield.Octuplet{})
+		driver.AssignTraceShard(rt, traces[0], koalafield.Octuplet{})
 	}, wiop.ProveOptions{CheckUnreducedQueries: true})
 
 	if err := sys.Verify(proof, pub); err != nil {

--- a/prover-ray/zkcdriver/native_modules.go
+++ b/prover-ray/zkcdriver/native_modules.go
@@ -28,7 +28,7 @@ const (
 )
 
 func (s *schemaScanner) defineNativeModule(mod schema.Module[koalabear.Element]) error {
-	modName := mod.Name().String()
+	modName := mod.Name()
 	if after, found := strings.CutPrefix(modName, nativeMulmod); found {
 		if err := s.defineNativeMulmod(mod, after); err != nil {
 			return fmt.Errorf("native mulmod %s: %w", modName, err)
@@ -47,7 +47,7 @@ func (s *schemaScanner) defineNativeModule(mod schema.Module[koalabear.Element])
 // native module without adding any constraint, leaving the module genuinely
 // unconstrained while still giving callers a valid column to reference.
 func (s *schemaScanner) defineNativeExpUnconstrained(mod schema.Module[koalabear.Element]) {
-	modName := mod.Name().String()
+	modName := mod.Name()
 
 	moduleWIOP := s.Sys.NewDynamicModule(
 		s.Sys.Context.Childf("module-native-%s", modName),
@@ -85,7 +85,7 @@ func (s *schemaScanner) defineNativeMulmod(mod schema.Module[koalabear.Element],
 		return fmt.Errorf("invalid number of bits %d: must be positive", nbBits)
 	}
 
-	modName := mod.Name().String()
+	modName := mod.Name()
 
 	// nbBitsPerLimb is the bitwidth of one limb register, as declared by the
 	// schema. All limb registers of a mulmod module share the same width.

--- a/prover-ray/zkcdriver/r5_benchmark_test.go
+++ b/prover-ray/zkcdriver/r5_benchmark_test.go
@@ -25,8 +25,8 @@ const (
 
 var (
 	r5TraceSink trace.Trace[koalabear.Element]
-	r5ProofSink wiop.Proof
-	r5PubSink   wiop.PublicInput
+	r5ProofSink []wiop.Proof
+	r5PubSink   []wiop.PublicInput
 )
 
 type r5BenchmarkFixture struct {
@@ -187,14 +187,16 @@ func BenchmarkR5AssignFromExpandedTrace(b *testing.B) {
 	b.ResetTimer()
 
 	for b.Loop() {
-		rt := wiop.NewRuntime(fixture.system)
-		zkcdriver.AssignFromTrace(
-			rt,
-			fixture.expandedShards,
-			fixture.binFile.AirConstraints(),
-			koalafield.Octuplet{},
-		)
+		for _, shard := range fixture.expandedShards {
+			zkcdriver.AssignFromTraceShard(
+				wiop.NewRuntime(fixture.system),
+				shard,
+				fixture.binFile.AirConstraints(),
+				koalafield.Octuplet{},
+			)
+		}
 	}
+
 	reportR5Work(b, fixture)
 }
 
@@ -208,9 +210,18 @@ func BenchmarkR5TraceAndAssign(b *testing.B) {
 	b.ResetTimer()
 
 	for b.Loop() {
-		rt := wiop.NewRuntime(fixture.system)
-		fixture.driver.AssignWithPreRead(rt, inputs, koalafield.Octuplet{})
+		traces := fixture.driver.TraceZkcInputs(inputs)
+		fixture.expandedShards = traces
+		for _, shard := range traces {
+			zkcdriver.AssignFromTraceShard(
+				wiop.NewRuntime(fixture.system),
+				shard,
+				fixture.binFile.AirConstraints(),
+				koalafield.Octuplet{},
+			)
+		}
 	}
+
 	reportR5Work(b, fixture)
 }
 
@@ -242,30 +253,37 @@ func BenchmarkR5ZKCCompile(b *testing.B) {
 // BenchmarkR5Prove measures one warm proof on a precompiled immutable system.
 // It includes trace generation and column assignment, as production Prove does,
 // but excludes ZKC and WIOP compilation and excludes verification.
+//
+// The scope of the benchmark is a single (the first) shard
 func BenchmarkR5Prove(b *testing.B) {
 	fixture := loadR5BenchmarkFixture(b)
 	fixture.ensureSystem(b)
 	inputs := &zkcdriver.PreReadInputs{Inputs: fixture.inputs}
+	traces := fixture.driver.TraceZkcInputs(inputs)
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for b.Loop() {
 		proof, pub := fixture.system.Prove(func(rt *wiop.Runtime) {
-			fixture.driver.AssignWithPreRead(rt, inputs, koalafield.Octuplet{})
+			fixture.driver.AssignTraceShard(rt, traces[0], koalafield.Octuplet{})
 		})
-		r5ProofSink, r5PubSink = proof, pub
+		r5ProofSink, r5PubSink = []wiop.Proof{proof}, []wiop.PublicInput{pub}
 	}
 	reportR5Work(b, fixture)
 }
 
 // BenchmarkR5Verify measures verification of one proof produced before the
-// timer starts. The immutable proof and public input are reused.
+// timer starts. The immutable proof and public input are reused
+//
+// The scope of the benchmark is a single (the first) shard
 func BenchmarkR5Verify(b *testing.B) {
 	fixture := loadR5BenchmarkFixture(b)
 	fixture.ensureSystem(b)
 	inputs := &zkcdriver.PreReadInputs{Inputs: fixture.inputs}
+	traces := fixture.driver.TraceZkcInputs(inputs)
+
 	proof, pub := fixture.system.Prove(func(rt *wiop.Runtime) {
-		fixture.driver.AssignWithPreRead(rt, inputs, koalafield.Octuplet{})
+		fixture.driver.AssignTraceShard(rt, traces[0], koalafield.Octuplet{})
 	})
 	if err := fixture.system.Verify(proof, pub); err != nil {
 		b.Fatalf("verifying setup proof: %v", err)
@@ -298,14 +316,28 @@ func BenchmarkR5ColdEndToEnd(b *testing.B) {
 		if err != nil {
 			b.Fatalf("serializing R5 constraints: %v", err)
 		}
-		system, driver := compileR5BenchmarkSystem(b, serialized)
-		proof, pub := system.Prove(func(rt *wiop.Runtime) {
-			driver.AssignWithPreRead(rt, &zkcdriver.PreReadInputs{Inputs: fixture.inputs}, koalafield.Octuplet{})
-		})
-		if err := system.Verify(proof, pub); err != nil {
-			b.Fatalf("verifying R5 proof: %v", err)
+
+		var (
+			system, driver = compileR5BenchmarkSystem(b, serialized)
+			inputs         = &zkcdriver.PreReadInputs{Inputs: fixture.inputs}
+			traces         = fixture.driver.TraceZkcInputs(inputs)
+			proofs         = make([]wiop.Proof, len(traces))
+			pubs           = make([]wiop.PublicInput, len(traces))
+		)
+
+		for i, shard := range traces {
+			proofs[i], pubs[i] = system.Prove(func(rt *wiop.Runtime) {
+				driver.AssignTraceShard(rt, shard, koalafield.Octuplet{})
+			})
 		}
-		r5ProofSink, r5PubSink = proof, pub
+
+		for i := range proofs {
+			if err := system.Verify(proofs[i], pubs[i]); err != nil {
+				b.Fatalf("verifying R5 proof: %v", err)
+			}
+		}
+
+		r5ProofSink, r5PubSink = proofs, pubs
 	}
 	reportR5Work(b, fixture)
 }

--- a/prover-ray/zkcdriver/r5_benchmark_test.go
+++ b/prover-ray/zkcdriver/r5_benchmark_test.go
@@ -41,6 +41,9 @@ type r5BenchmarkFixture struct {
 }
 
 func loadR5BenchmarkFixture(b *testing.B) *r5BenchmarkFixture {
+
+	b.Helper()
+
 	var (
 		// NOTE: the "sharding strategy" controls how sharding operators, and is
 		// fairly simplistic (at this stage).  In essence, the strategy below

--- a/prover-ray/zkcdriver/r5_benchmark_test.go
+++ b/prover-ray/zkcdriver/r5_benchmark_test.go
@@ -3,6 +3,7 @@ package zkcdriver_test
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"runtime"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"github.com/LFDT-Lineth/zkc/pkg/trace"
 	"github.com/LFDT-Lineth/zkc/pkg/util/field/koalabear"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/constraints"
+	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm"
 )
 
 const (
@@ -28,17 +30,35 @@ var (
 )
 
 type r5BenchmarkFixture struct {
-	binFile       *constraints.BinaryFile[koalabear.Element]
-	inputs        map[string][]byte
-	expandedTrace trace.Trace[koalabear.Element]
-	serialized    []byte
-	system        *wiop.System
-	driver        *zkcdriver.ZkCDriver
-	traceRows     uint64
-	traceCells    uint64
+	binFile        *constraints.BinaryFile[koalabear.Element]
+	inputs         map[string][]byte
+	expandedShards []trace.Shard[koalabear.Element]
+	serialized     []byte
+	system         *wiop.System
+	driver         *zkcdriver.ZkCDriver
+	traceRows      []uint64
+	traceCells     []uint64
 }
 
 func loadR5BenchmarkFixture(b *testing.B) *r5BenchmarkFixture {
+	var (
+		// NOTE: the "sharding strategy" controls how sharding operators, and is
+		// fairly simplistic (at this stage).  In essence, the strategy below
+		// indicates that each shard will contain 500K invocations of the
+		// "interpreter()" function.  Since this function is involved once per
+		// RISC-V instruction, this indicates that each shard contains 500K
+		// RISC-V instruction executions.  Note, for example, that the first
+		// shard is expected to be bigger under this simplistic strategy, since
+		// it will also include the initialisation phase of the interpreter
+		// (i.e. loading inputs into RAM).
+		shardingStrategy = vm.NewShardingStrategy("interpreter", 500000)
+		// Specificy tracing options
+		tracingConfig = vm.DEFAULT_TRACE_CONFIG.WithSharding(shardingStrategy).
+			// Indicate shards should be traced in parallel after an initial
+			// "fast mode" execution run to create checkpoints (i.e. as
+			// determined by the sharding strategy).
+			WithParallelism(true)
+	)
 	b.Helper()
 
 	verifierELF, err := os.ReadFile(r5VerifierPath)
@@ -53,7 +73,7 @@ func loadR5BenchmarkFixture(b *testing.B) *r5BenchmarkFixture {
 	if err != nil {
 		b.Fatalf("compiling R5 ZKC program: %v", err)
 	}
-	_, _, expandedTrace, errs := binFile.Trace(inputs, constraints.DEFAULT_TRACE_CONFIG)
+	_, expandedTrace, errs := binFile.Trace(inputs, tracingConfig)
 	if len(errs) > 0 {
 		b.Fatalf("tracing R5 fixture: %v", errors.Join(errs...))
 	}
@@ -62,15 +82,21 @@ func loadR5BenchmarkFixture(b *testing.B) *r5BenchmarkFixture {
 		b.Fatalf("serializing R5 constraints: %v", err)
 	}
 	fixture := &r5BenchmarkFixture{
-		binFile:       binFile,
-		inputs:        inputs,
-		expandedTrace: expandedTrace,
-		serialized:    serialized,
+		binFile:        binFile,
+		inputs:         inputs,
+		expandedShards: expandedTrace,
+		serialized:     serialized,
 	}
-	for moduleID := range expandedTrace.Width() {
-		module := expandedTrace.Module(moduleID)
-		fixture.traceRows += uint64(module.Height())
-		fixture.traceCells += uint64(module.Height()) * uint64(module.Width())
+	// Initialise traceRows/traceCells
+	fixture.traceRows = make([]uint64, len(expandedTrace))
+	fixture.traceCells = make([]uint64, len(expandedTrace))
+	// Collect per-shard metrics
+	for i, shard := range expandedTrace {
+		for moduleID := range shard.Width() {
+			module := shard.Module(moduleID)
+			fixture.traceRows[i] += uint64(module.Height())
+			fixture.traceCells[i] += uint64(module.Height()) * uint64(module.Width())
+		}
 	}
 
 	return fixture
@@ -99,9 +125,11 @@ func compileR5BenchmarkSystem(b *testing.B, serialized []byte) (*wiop.System, *z
 
 func reportR5Work(b *testing.B, fixture *r5BenchmarkFixture) {
 	b.Helper()
-	b.ReportMetric(float64(fixture.traceRows), "trace-rows/op")
-	b.ReportMetric(float64(fixture.traceCells), "trace-cells/op")
-	b.ReportMetric(float64(runtime.GOMAXPROCS(0)), "gomaxprocs")
+	for i := range fixture.traceCells {
+		b.ReportMetric(float64(fixture.traceRows[i]), fmt.Sprintf("shard_%d/trace-rows/op", i))
+		b.ReportMetric(float64(fixture.traceCells[i]), fmt.Sprintf("shard_%d/trace-cells/op", i))
+		b.ReportMetric(float64(runtime.GOMAXPROCS(0)), "gomaxprocs")
+	}
 }
 
 // BenchmarkR5Trace measures RISC-V execution and AIR trace expansion. It does
@@ -112,9 +140,9 @@ func BenchmarkR5Trace(b *testing.B) {
 	b.ResetTimer()
 
 	for b.Loop() {
-		_, _, expandedTrace, errs := fixture.binFile.Trace(
+		_, expandedTrace, errs := fixture.binFile.Trace(
 			fixture.inputs,
-			constraints.DEFAULT_TRACE_CONFIG,
+			vm.DEFAULT_TRACE_CONFIG,
 		)
 		if len(errs) > 0 {
 			b.Fatalf("tracing R5 program: %v", errors.Join(errs...))
@@ -132,16 +160,16 @@ func BenchmarkR5TraceAndCheck(b *testing.B) {
 	b.ResetTimer()
 
 	for b.Loop() {
-		_, _, expandedTrace, errs := fixture.binFile.Trace(
+		_, expandedTrace, errs := fixture.binFile.Trace(
 			fixture.inputs,
-			constraints.DEFAULT_TRACE_CONFIG,
+			vm.DEFAULT_TRACE_CONFIG,
 		)
 		if len(errs) > 0 {
 			b.Fatalf("tracing R5 program: %v", errors.Join(errs...))
 		}
 		if failures := fixture.binFile.Check(
+			vm.DEFAULT_TRACE_CONFIG,
 			expandedTrace,
-			constraints.DEFAULT_TRACE_CONFIG,
 		); len(failures) > 0 {
 			b.Fatalf("checking R5 trace: %s", failures[0].Message())
 		}
@@ -162,7 +190,7 @@ func BenchmarkR5AssignFromExpandedTrace(b *testing.B) {
 		rt := wiop.NewRuntime(fixture.system)
 		zkcdriver.AssignFromTrace(
 			rt,
-			fixture.expandedTrace,
+			fixture.expandedShards,
 			fixture.binFile.AirConstraints(),
 			koalafield.Octuplet{},
 		)

--- a/prover-ray/zkcdriver/r5_test.go
+++ b/prover-ray/zkcdriver/r5_test.go
@@ -6,7 +6,7 @@ import (
 
 	zkc_r5 "github.com/LFDT-Lineth/lineth-monorepo/prover-ray/backend/zkc-r5"
 	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/zkcdriver"
-	"github.com/LFDT-Lineth/zkc/pkg/zkc/constraints"
+	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm"
 )
 
 // This is a benchmark for the RISC-V arithmetization and not a test so that we
@@ -31,7 +31,7 @@ func BenchmarkRisc5Arithmetization(b *testing.B) {
 		b.Fatalf("failed to compile zkc source: %v", err)
 	}
 	b.Logf("tracing zkc")
-	outputs, err := traceZkc(binf, constraints.DEFAULT_TRACE_CONFIG, inputsMap, false)
+	outputs, err := traceZkc(binf, vm.DEFAULT_TRACE_CONFIG, inputsMap, false)
 	if err != nil {
 		b.Fatalf("failed to parse test case: %v", err)
 	}

--- a/prover-ray/zkcdriver/sync_test.go
+++ b/prover-ray/zkcdriver/sync_test.go
@@ -75,7 +75,6 @@ func TestZkcIntegrationTestSynced(t *testing.T) {
 			basePath := strings.TrimSuffix(f, zkcExtension)
 			acceptPath := basePath + acceptExtension
 			if files.CheckFilePath(acceptPath) != nil {
-				fatalIfNotKnown(t, failures, baseName, -1, failReasonNoTestData, "accept file %s does not exist for test-case %s", acceptPath, f)
 				return
 			}
 			binF, err := compileBinaryConstraints(f)

--- a/prover-ray/zkcdriver/zkcdriver.go
+++ b/prover-ray/zkcdriver/zkcdriver.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/maths/koalabear/field"
 	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/wiop"
+	"github.com/LFDT-Lineth/zkc/pkg/trace"
 	"github.com/LFDT-Lineth/zkc/pkg/util/collection/typed"
 	"github.com/LFDT-Lineth/zkc/pkg/util/field/koalabear"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/constraints"
@@ -69,20 +70,6 @@ func NewZkCDriver(sys *wiop.System, settings Settings, bin io.Reader) *ZkCDriver
 	}
 }
 
-// Assign the arithmetization related columns. Namely, it will open the file
-// specified in the witness object, call corset and assign the prover runtime
-// columns. As part of the assignment process, the original trace is expanded
-// according to the given schema.  The expansion process is about filling in
-// computed columns with concrete values, such for determining multiplicative
-// inverses, etc.
-func (a *ZkCDriver) Assign(
-	run *wiop.Runtime,
-	inputsFile string,
-	sharedRandomness field.Octuplet,
-) {
-	a.AssignWithPreRead(run, ReadZkcInputs(inputsFile), sharedRandomness)
-}
-
 // PreReadInputs holds the result of pre-reading a trace file.
 type PreReadInputs struct {
 	// Inputs as required for the zkc program.  Each input corresponds with a
@@ -96,9 +83,9 @@ type PreReadInputs struct {
 	InputsFile string
 }
 
-// ReadZkcInputs reads and parses a zkc inputs file, returning the "pre-read"
+// PreReadZkcInputs reads and parses a zkc inputs file, returning the "pre-read"
 // input data. This can be called early to overlap I/O with other work.
-func ReadZkcInputs(inputsFile string) *PreReadInputs {
+func PreReadZkcInputs(inputsFile string) *PreReadInputs {
 	traceF, err := ReadMaybeCompressedFile(inputsFile)
 	if err != nil {
 		return &PreReadInputs{Err: err, InputsFile: inputsFile}
@@ -107,12 +94,10 @@ func ReadZkcInputs(inputsFile string) *PreReadInputs {
 	return &PreReadInputs{Inputs: inputs, Err: err, InputsFile: inputsFile}
 }
 
-// AssignWithPreRead assigns arithmetization columns using a pre-read trace.
-func (a *ZkCDriver) AssignWithPreRead(
-	run *wiop.Runtime,
-	preRead *PreReadInputs,
-	sharedRandomness field.Octuplet,
-) {
+// TraceZkcInputs reads and expands a trace file, returning the pre-read trace
+// data laid out on multiple shards. The function panics on errors.
+func (a *ZkCDriver) TraceZkcInputs(preRead *PreReadInputs) trace.Trace[koalabear.Element] {
+
 	assignStart := time.Now()
 	var (
 		errs []error
@@ -145,8 +130,17 @@ func (a *ZkCDriver) AssignWithPreRead(
 	}
 	logrus.Infof("[bootstrapper] tracing: %v", time.Since(tracingStart))
 
+	return expandedTrace
+}
+
+// AssignTraceShard assigns arithmetization columns using a pre-read trace.
+func (a *ZkCDriver) AssignTraceShard(
+	run *wiop.Runtime,
+	expandedShard trace.Shard[koalabear.Element],
+	sharedRandomness field.Octuplet,
+) {
+
 	copyStart := time.Now()
-	AssignFromTrace(run, expandedTrace, a.BinaryFile.AirConstraints(), sharedRandomness)
+	AssignFromTraceShard(run, expandedShard, a.BinaryFile.AirConstraints(), sharedRandomness)
 	logrus.Infof("[bootstrapper] column assignment: %v", time.Since(copyStart))
-	logrus.Infof("[bootstrapper] total Arithmetization.Assign: %v", time.Since(assignStart))
 }

--- a/prover-ray/zkcdriver/zkcdriver.go
+++ b/prover-ray/zkcdriver/zkcdriver.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/maths/koalabear/field"
+	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/utils"
 	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/wiop"
 	"github.com/LFDT-Lineth/zkc/pkg/trace"
 	"github.com/LFDT-Lineth/zkc/pkg/util/collection/typed"
@@ -88,6 +89,7 @@ type PreReadInputs struct {
 func PreReadZkcInputs(inputsFile string) *PreReadInputs {
 	traceF, err := ReadMaybeCompressedFile(inputsFile)
 	if err != nil {
+		utils.Panic("boom: %v", err)
 		return &PreReadInputs{Err: err, InputsFile: inputsFile}
 	}
 	inputs, err := ReadZkcInputFile(traceF)

--- a/prover-ray/zkcdriver/zkcdriver.go
+++ b/prover-ray/zkcdriver/zkcdriver.go
@@ -41,7 +41,7 @@ type ZkCDriver struct {
 	// Configuration options for tracing (e.g. whether or not to use
 	// parallelisation, what batch size to use, etc).  Generally speaking this
 	// should be left to the provided defaults.
-	TracingConfig constraints.TraceConfig `serde:"omit"`
+	TracingConfig vm.TraceConfig `serde:"omit"`
 	// Metadata embedded in the zkevm.bin file, as needed to check
 	// compatibility.  Guaranteed non-nil.
 	Metadata typed.Map `serde:"omit"`
@@ -63,7 +63,7 @@ func NewZkCDriver(sys *wiop.System, settings Settings, bin io.Reader) *ZkCDriver
 	// Construct the driver
 	return &ZkCDriver{
 		BinaryFile:    binf,
-		TracingConfig: constraints.DEFAULT_TRACE_CONFIG,
+		TracingConfig: vm.DEFAULT_TRACE_CONFIG,
 		Settings:      &settings,
 		Metadata:      metadata,
 	}
@@ -118,8 +118,8 @@ func (a *ZkCDriver) AssignWithPreRead(
 		errs []error
 		// filter the inputs so that we only pass the inputs that are actually
 		// used by the zkc program.
-		inputs = vm.FilterInputs(a.BinaryFile.Program(), preRead.Inputs)
-		errT   = preRead.Err
+		inputs, _ = vm.FilterInputs(a.BinaryFile.TracingProgram(), preRead.Inputs)
+		errT      = preRead.Err
 	)
 	logrus.Infof("[bootstrapper] trace available (pre-read): %v", time.Since(assignStart))
 
@@ -138,7 +138,7 @@ func (a *ZkCDriver) AssignWithPreRead(
 	// Attempt to trace the ZkC program using the provided inputs, generating a
 	// fully expanded AIR-compatible trace.
 	tracingStart := time.Now()
-	_, _, expandedTrace, errs := a.BinaryFile.Trace(inputs, a.TracingConfig)
+	_, expandedTrace, errs := a.BinaryFile.Trace(inputs, a.TracingConfig)
 
 	if len(errs) > 0 {
 		logrus.Panicf("tracing failed: %v", errors.Join(errs...).Error())

--- a/prover-ray/zkcdriver/zkcdriver_test.go
+++ b/prover-ray/zkcdriver/zkcdriver_test.go
@@ -182,10 +182,9 @@ func runProveVerify(inputs *zkcdriver.PreReadInputs, binFile *constraints.Binary
 	proverCompilePipeline(sys)
 
 	var (
-		preRead = zkcdriver.PreReadZkcInputs(inputs.InputsFile)
-		traces  = driver.TraceZkcInputs(preRead)
-		proofs  = make([]wiop.Proof, len(traces))
-		pubs    = make([]wiop.PublicInput, len(traces))
+		traces = driver.TraceZkcInputs(inputs)
+		proofs = make([]wiop.Proof, len(traces))
+		pubs   = make([]wiop.PublicInput, len(traces))
 	)
 
 	for i, shard := range traces {

--- a/prover-ray/zkcdriver/zkcdriver_test.go
+++ b/prover-ray/zkcdriver/zkcdriver_test.go
@@ -48,7 +48,7 @@ func compileBinaryConstraints(srcPath string) (binfile *constraints.BinaryFile[k
 		return nil, fmt.Errorf("failed to read zkc source file: %w", err)
 	}
 	src := source.NewSourceFile(srcPath, srcZkc)
-	macroProgram, _, errs := compiler.Compile(zkcField, *src)
+	macroProgram, _, errs := compiler.Compile(zkcField, codegen.DEFAULT_MAX_STATIC_HEIGHT, *src)
 	if len(errs) > 0 {
 		for i := range errs {
 			fmt.Printf("zkc compile error: %s\n", errs[i].Error())
@@ -62,7 +62,7 @@ func compileBinaryConstraints(srcPath string) (binfile *constraints.BinaryFile[k
 		}
 		return nil, fmt.Errorf("failed to compile zkc source")
 	}
-	binfile = constraints.NewBinaryFile[koalabear.Element](nil, nil, zkcField, zkcCfg.GetMaxStaticHeight(), ir)
+	binfile = constraints.NewBinaryFile[koalabear.Element](nil, nil, ir)
 	return binfile, nil
 }
 
@@ -87,10 +87,10 @@ func parseTestCase(
 	// the input file also has outputs what the zkc program produces. Lets
 	// filter them out for tracing purposes, so that we can sanity-check the
 	// inputs of the test-case.
-	filteredInputs := vm.FilterInputs(binF.Program(), inputs.Inputs)
+	filteredInputs, _ := vm.FilterInputs(binF.TracingProgram(), inputs.Inputs)
 
 	// This sanity-checks the corset inputs of the test-case
-	outputs, err = traceZkc(binF, constraints.DEFAULT_TRACE_CONFIG, filteredInputs, withTraceCheck)
+	outputs, err = traceZkc(binF, vm.DEFAULT_TRACE_CONFIG, filteredInputs, withTraceCheck)
 	if err != nil {
 		return nil, nil, fmt.Errorf("constraint check failed: %w", err)
 	}
@@ -100,7 +100,7 @@ func parseTestCase(
 
 func traceZkc(
 	binFile *constraints.BinaryFile[koalabear.Element],
-	tracingCfg constraints.TraceConfig,
+	tracingCfg vm.TraceConfig,
 	input map[string][]byte,
 	withCheck bool,
 ) (outputs map[string][]byte, err error) {
@@ -112,14 +112,14 @@ func traceZkc(
 	}()
 
 	// trace program with given input
-	outputs, _, tr, errs := binFile.Trace(input, tracingCfg)
+	outputs, tr, errs := binFile.Trace(input, tracingCfg)
 	if len(errs) > 0 {
 		return nil, fmt.Errorf("could not trace the binary file: %w", errors.Join(errs...))
 	}
 
 	if withCheck {
 		// check the traces work
-		if errsSchema := binFile.Check(tr, tracingCfg); len(errsSchema) > 0 {
+		if errsSchema := binFile.Check(tracingCfg, tr); len(errsSchema) > 0 {
 			errs := make([]error, len(errsSchema))
 			for i, e := range errsSchema {
 				errs[i] = errors.New(e.Message())

--- a/prover-ray/zkcdriver/zkcdriver_test.go
+++ b/prover-ray/zkcdriver/zkcdriver_test.go
@@ -181,14 +181,26 @@ func runProveVerify(inputs *zkcdriver.PreReadInputs, binFile *constraints.Binary
 	// Run the prover compile pipeline, which will compile the system and prepare it for proof generation
 	proverCompilePipeline(sys)
 
-	// Run the ZkC driver to produce a proof and public inputs
-	proof, pub := sys.Prove(
-		func(rt *wiop.Runtime) { driver.AssignWithPreRead(rt, inputs, koalafield.Octuplet{}) },
-		wiop.ProveOptions{CheckUnreducedQueries: true})
+	var (
+		preRead = zkcdriver.PreReadZkcInputs(inputs.InputsFile)
+		traces  = driver.TraceZkcInputs(preRead)
+		proofs  = make([]wiop.Proof, len(traces))
+		pubs    = make([]wiop.PublicInput, len(traces))
+	)
 
-	// Verify the proof and public inputs
-	if err := sys.Verify(proof, pub); err != nil {
-		return fmt.Errorf("verification failed: %w", err)
+	for i, shard := range traces {
+
+		proofs[i], pubs[i] = sys.Prove(
+			func(rt *wiop.Runtime) { driver.AssignTraceShard(rt, shard, koalafield.Octuplet{}) },
+			wiop.ProveOptions{CheckUnreducedQueries: true})
 	}
+
+	for i := range proofs {
+
+		if err := sys.Verify(proofs[i], pubs[i]); err != nil {
+			return fmt.Errorf("verification failed: %w", err)
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
This updates prover-ray to utilise ZkC version v1.2.31 which provides trace sharding, and also places global functions onto a bus.  As such, this initial set of changes is incomplete because it requires modifications to the prover tests to support sharding.  This also requires support for translating bus constraints (whose structure is very similar to the existing lookup constraints).
