### PR TITLE
feat(misc): canonical SSZ wire format for the l2-execution guest I/O

### DIFF
--- a/rollup_spec/src/rollup_spec/l2_execution_ssz.py
+++ b/rollup_spec/src/rollup_spec/l2_execution_ssz.py
@@ -1,0 +1,419 @@
+"""
+Canonical SSZ wire format for the l2-execution guest program.
+
+Remerkleable SSZ containers that mirror the logical dataclasses in
+`l2_execution.py` / `block.py`, plus the framing and bounds needed to
+serialize them unambiguously. As the base guest of the proof pipeline it
+also hosts the framing machinery the sibling guest wire modules import. The
+vanilla per-block payload wire (schema id 0x0001) lives in
+`stateless_input.py`.
+
+Framing: every message is `schema_id (2 bytes, big-endian) || SSZ bytes`.
+Two schema ids are defined here:
+
+  - `L2_EXECUTION_INPUT_SCHEMA_ID`  (0x0002) — extended l2-execution guest input
+  - `L2_EXECUTION_OUTPUT_SCHEMA_ID` (0x0003) — extended l2-execution guest output
+
+The guest output wire is hash-only: the 0x0003 body is exactly
+`keccak256(ssz(public_inputs))` — 32 bytes, nothing else (34 bytes framed).
+The remaining `L2ExecutionProof` fields (`start_block_number` and the
+`l2_l1_messages`/`tx_froms`/`filtered_addresses` preimages) are off-chain
+data, never part of this wire format, and `proof` is attached by the prover
+layer above the guest. The hash is irreversible, so the output decoder
+returns the public-inputs hash rather than reconstructing a dataclass;
+`encode_l2_execution_public_inputs_bytes` exposes the fixed 368-byte
+preimage tuple.
+
+Each payload's `stateless_input_ssz` is carried opaquely — an already
+0x0001-framed vanilla stateless-input byte slice, byte-identical to what a
+vanilla guest accepts, decoded on its own one level up — so this codec never
+looks inside it.
+
+Besides the input wire, this module carries the SSZ containers for an
+already-proven l2-execution proof (`SszVerifiableL2ExecutionProof` and its
+parts): they are not a guest message of their own but are embedded in the
+rollup guest's input, which recursively verifies them.
+
+List/vector bounds are conservative powers of two: capacity ceilings for the
+wire format, not the guest's or coordinator's own (tighter) operational
+limits. Each constant below carries a one-line rationale.
+"""
+
+from typing import Any, TypeAlias
+
+from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.state import Address
+from ethereum_types.numeric import U64
+from remerkleable.basic import uint8, uint64
+from remerkleable.byte_arrays import ByteList, ByteVector, Bytes32 as SszBytes32
+from remerkleable.complex import Container, List
+
+from .block import (
+    ChainConfig,
+    ForcedTransactionAcceptance,
+    ForcedTransactionWitness,
+    LinethPayloadInput,
+    LinethRollupExtension,
+)
+from .l2_execution import (
+    L2ExecutionProof,
+    L2ExecutionProofPrivateInput,
+    L2ExecutionProofPublicInput,
+    VerifiableL2ExecutionProof,
+)
+from .stateless_input import InvalidSsz
+
+# ── Framing ──────────────────────────────────────────────────────────────────
+L2_EXECUTION_INPUT_SCHEMA_ID = 0x0002
+L2_EXECUTION_OUTPUT_SCHEMA_ID = 0x0003
+SCHEMA_ID_SIZE = 2
+
+# ── SSZ list/vector bounds ───────────────────────────────────────────────────
+MAX_PAYLOADS = 2**16                           # blocks (one payload each) in one l2-execution proof range
+MAX_FTX_PER_PAYLOAD = 2**16                    # forced transactions declared for a single payload
+MAX_STATELESS_INPUT_BYTES = 2**30              # 1 GiB: one opaque, already-framed vanilla stateless input
+MAX_TX_BYTES = 2**30                           # matches the consensus-layer Transaction ByteList limit
+MAX_PROOF_BYTES = 2**24                        # 16 MiB: generous ceiling on a recursively-verified proof blob
+MAX_L2_L1_MESSAGES_PER_EXEC_PROOF = 2**16      # L2->L1 message hashes emitted by one l2-execution proof
+MAX_TX_FROMS_PER_EXEC_PROOF = 2**16            # recovered tx senders emitted by one l2-execution proof
+MAX_FILTERED_ADDRESSES_PER_EXEC_PROOF = 2**16  # sanction-list addresses emitted by one l2-execution proof
+
+SszAddress: TypeAlias = ByteVector[20]
+
+# ── Framing helpers ──────────────────────────────────────────────────────────
+
+
+def _frame(schema_id: int, raw: bytes) -> bytes:
+    return schema_id.to_bytes(SCHEMA_ID_SIZE, "big") + raw
+
+
+def _strip_frame(data: bytes, schema_id: int, ctx: str) -> bytes:
+    payload = bytes(data)
+    if len(payload) < SCHEMA_ID_SIZE:
+        raise InvalidSsz(f"{ctx}: input shorter than the {SCHEMA_ID_SIZE}-byte schema id")
+    got = int.from_bytes(payload[:SCHEMA_ID_SIZE], "big")
+    if got != schema_id:
+        raise InvalidSsz(f"{ctx}: expected schema id 0x{schema_id:04x}, got 0x{got:04x}")
+    return payload[SCHEMA_ID_SIZE:]
+
+
+def _strict_decode(data: bytes, container: type) -> Any:
+    """
+    Decode `data` as `container`, rejecting anything that is not its canonical
+    SSZ encoding. `remerkleable.decode_bytes` is lax about length (it ignores or
+    absorbs trailing bytes), so we re-encode and require equality — SSZ encoding
+    is bijective.
+    """
+    try:
+        view = container.decode_bytes(data)
+    except Exception as exc:  # remerkleable raises a variety of decode errors
+        raise InvalidSsz(f"{container.__name__}: {exc}") from exc
+    if view.encode_bytes() != data:
+        raise InvalidSsz(f"{container.__name__}: input is not the canonical SSZ encoding")
+    return view
+
+
+# ── SSZ wire schema: extended guest input ────────────────────────────────────
+
+
+class SszChainConfig(Container):
+    # Field order matches `block.py::ChainConfig`.
+    l2_message_service_address: SszAddress
+    coinbase: SszAddress
+    chain_id: uint64
+
+
+class SszForcedTransactionWitness(Container):
+    # Field order matches `block.py::ForcedTransactionWitness`; `acceptance`
+    # carries the `ForcedTransactionAcceptance` enum value (0..4).
+    number: uint64
+    signed_tx_rlp: ByteList[MAX_TX_BYTES]
+    acceptance: uint8
+    deadline: uint64
+
+
+class SszLinethPayloadInput(Container):
+    # `stateless_input_ssz` is the opaque, already 0x0001-framed vanilla
+    # stateless-input byte slice.
+    stateless_input_ssz: ByteList[MAX_STATELESS_INPUT_BYTES]
+    forced_transactions: List[SszForcedTransactionWitness, MAX_FTX_PER_PAYLOAD]
+
+
+class SszL2ExecutionProofPrivateInput(Container):
+    # Wire order: `chain_config` before `payloads` (see module docstring).
+    parent_ftx_rolling_hash: SszBytes32
+    parent_last_processed_ftx_number: uint64
+    chain_config: SszChainConfig
+    payloads: List[SszLinethPayloadInput, MAX_PAYLOADS]
+
+
+# ── SSZ wire schema: embedded proof containers ───────────────────────────────
+
+
+class SszL2ExecutionProofPublicInput(Container):
+    # 16-field l2-execution public input tuple (Readme.md §2.1), field order
+    # matches `l2_execution.py::L2ExecutionProofPublicInput`.
+    parent_block_hash: SszBytes32
+    end_block_hash: SszBytes32
+    end_block_number: uint64
+    end_block_timestamp: uint64
+    l2_l1_messages_hash: SszBytes32
+    parent_l1_l2_bridge_rolling_hash: SszBytes32
+    parent_l1_l2_bridge_rolling_hash_message_number: uint64
+    end_l1_l2_bridge_rolling_hash: SszBytes32
+    end_l1_l2_bridge_rolling_hash_message_number: uint64
+    dynamic_chain_config_hash: SszBytes32
+    parent_ftx_rolling_hash: SszBytes32
+    parent_ftx_number: uint64
+    end_ftx_rolling_hash: SszBytes32
+    end_processed_ftx_number: uint64
+    filtered_addresses_hash: SszBytes32
+    tx_froms_hash: SszBytes32
+
+
+class SszL2ExecutionProof(Container):
+    # An already-proven l2-execution proof, as recursively verified by the
+    # rollup guest: carries its own `proof` bytes (a guest's own output never
+    # carries `proof` — the prover layer attaches it).
+    public_inputs: SszL2ExecutionProofPublicInput
+    start_block_number: uint64
+    proof: ByteList[MAX_PROOF_BYTES]
+    l2_l1_messages: List[SszBytes32, MAX_L2_L1_MESSAGES_PER_EXEC_PROOF]
+    tx_froms: List[SszAddress, MAX_TX_FROMS_PER_EXEC_PROOF]
+    filtered_addresses: List[SszAddress, MAX_FILTERED_ADDRESSES_PER_EXEC_PROOF]
+
+
+class SszVerifiableL2ExecutionProof(Container):
+    proof: SszL2ExecutionProof
+    program_vk: SszBytes32
+
+
+# ── Logical dataclass -> SSZ view converters ─────────────────────────────────
+
+
+def _ssz_chain_config(config: ChainConfig) -> SszChainConfig:
+    return SszChainConfig(
+        l2_message_service_address=bytes(config.l2_message_service_address),
+        coinbase=bytes(config.coinbase),
+        chain_id=int(config.chain_id),
+    )
+
+
+def _ssz_forced_transaction_witness(ftx: ForcedTransactionWitness) -> SszForcedTransactionWitness:
+    return SszForcedTransactionWitness(
+        number=int(ftx.number),
+        signed_tx_rlp=bytes(ftx.signed_tx_rlp),
+        acceptance=int(ftx.acceptance.value),
+        deadline=int(ftx.deadline),
+    )
+
+
+def _ssz_lineth_payload_input(payload: LinethPayloadInput) -> SszLinethPayloadInput:
+    return SszLinethPayloadInput(
+        stateless_input_ssz=bytes(payload.stateless_input_ssz),
+        forced_transactions=[
+            _ssz_forced_transaction_witness(ftx)
+            for ftx in payload.rollup_extension.forced_transactions
+        ],
+    )
+
+
+def _ssz_l2_execution_input(private_input: L2ExecutionProofPrivateInput) -> SszL2ExecutionProofPrivateInput:
+    return SszL2ExecutionProofPrivateInput(
+        parent_ftx_rolling_hash=bytes(private_input.parent_ftx_rolling_hash),
+        parent_last_processed_ftx_number=int(private_input.parent_last_processed_ftx_number),
+        chain_config=_ssz_chain_config(private_input.chain_config),
+        payloads=[_ssz_lineth_payload_input(p) for p in private_input.payloads],
+    )
+
+
+def _ssz_l2_execution_public_input(pi: L2ExecutionProofPublicInput) -> SszL2ExecutionProofPublicInput:
+    return SszL2ExecutionProofPublicInput(
+        parent_block_hash=bytes(pi.parent_block_hash),
+        end_block_hash=bytes(pi.end_block_hash),
+        end_block_number=int(pi.end_block_number),
+        end_block_timestamp=int(pi.end_block_timestamp),
+        l2_l1_messages_hash=bytes(pi.l2_l1_messages_hash),
+        parent_l1_l2_bridge_rolling_hash=bytes(pi.parent_l1_l2_bridge_rolling_hash),
+        parent_l1_l2_bridge_rolling_hash_message_number=int(
+            pi.parent_l1_l2_bridge_rolling_hash_message_number
+        ),
+        end_l1_l2_bridge_rolling_hash=bytes(pi.end_l1_l2_bridge_rolling_hash),
+        end_l1_l2_bridge_rolling_hash_message_number=int(
+            pi.end_l1_l2_bridge_rolling_hash_message_number
+        ),
+        dynamic_chain_config_hash=bytes(pi.dynamic_chain_config_hash),
+        parent_ftx_rolling_hash=bytes(pi.parent_ftx_rolling_hash),
+        parent_ftx_number=int(pi.parent_ftx_number),
+        end_ftx_rolling_hash=bytes(pi.end_ftx_rolling_hash),
+        end_processed_ftx_number=int(pi.end_processed_ftx_number),
+        filtered_addresses_hash=bytes(pi.filtered_addresses_hash),
+        tx_froms_hash=bytes(pi.tx_froms_hash),
+    )
+
+
+def _ssz_l2_execution_proof(proof: L2ExecutionProof) -> SszL2ExecutionProof:
+    return SszL2ExecutionProof(
+        public_inputs=_ssz_l2_execution_public_input(proof.public_inputs),
+        start_block_number=int(proof.start_block_number),
+        proof=bytes(proof.proof),
+        l2_l1_messages=[bytes(h) for h in proof.l2_l1_messages],
+        tx_froms=[bytes(a) for a in proof.tx_froms],
+        filtered_addresses=[bytes(a) for a in proof.filtered_addresses],
+    )
+
+
+def _ssz_verifiable_l2_execution_proof(
+    verifiable: VerifiableL2ExecutionProof,
+) -> SszVerifiableL2ExecutionProof:
+    return SszVerifiableL2ExecutionProof(
+        proof=_ssz_l2_execution_proof(verifiable.proof),
+        program_vk=bytes(verifiable.program_vk),
+    )
+
+
+# ── SSZ view -> logical dataclass converters ─────────────────────────────────
+
+
+def _chain_config_from_view(view: Any) -> ChainConfig:
+    return ChainConfig(
+        l2_message_service_address=Address(bytes(view.l2_message_service_address)),
+        coinbase=Address(bytes(view.coinbase)),
+        chain_id=U64(int(view.chain_id)),
+    )
+
+
+def _forced_transaction_witness_from_view(view: Any) -> ForcedTransactionWitness:
+    return ForcedTransactionWitness(
+        number=U64(int(view.number)),
+        signed_tx_rlp=bytes(view.signed_tx_rlp),
+        acceptance=ForcedTransactionAcceptance(int(view.acceptance)),
+        deadline=U64(int(view.deadline)),
+    )
+
+
+def _lineth_payload_input_from_view(view: Any) -> LinethPayloadInput:
+    return LinethPayloadInput(
+        stateless_input_ssz=bytes(view.stateless_input_ssz),
+        rollup_extension=LinethRollupExtension(
+            forced_transactions=[
+                _forced_transaction_witness_from_view(ftx) for ftx in view.forced_transactions
+            ],
+        ),
+    )
+
+
+def _l2_execution_input_from_view(view: Any) -> L2ExecutionProofPrivateInput:
+    return L2ExecutionProofPrivateInput(
+        parent_ftx_rolling_hash=Hash32(bytes(view.parent_ftx_rolling_hash)),
+        parent_last_processed_ftx_number=U64(int(view.parent_last_processed_ftx_number)),
+        payloads=[_lineth_payload_input_from_view(p) for p in view.payloads],
+        chain_config=_chain_config_from_view(view.chain_config),
+    )
+
+
+def _l2_execution_public_input_from_view(view: Any) -> L2ExecutionProofPublicInput:
+    return L2ExecutionProofPublicInput(
+        parent_block_hash=Hash32(bytes(view.parent_block_hash)),
+        end_block_hash=Hash32(bytes(view.end_block_hash)),
+        end_block_number=U64(int(view.end_block_number)),
+        end_block_timestamp=U64(int(view.end_block_timestamp)),
+        l2_l1_messages_hash=Hash32(bytes(view.l2_l1_messages_hash)),
+        parent_l1_l2_bridge_rolling_hash=Hash32(bytes(view.parent_l1_l2_bridge_rolling_hash)),
+        parent_l1_l2_bridge_rolling_hash_message_number=U64(
+            int(view.parent_l1_l2_bridge_rolling_hash_message_number)
+        ),
+        end_l1_l2_bridge_rolling_hash=Hash32(bytes(view.end_l1_l2_bridge_rolling_hash)),
+        end_l1_l2_bridge_rolling_hash_message_number=U64(
+            int(view.end_l1_l2_bridge_rolling_hash_message_number)
+        ),
+        dynamic_chain_config_hash=Hash32(bytes(view.dynamic_chain_config_hash)),
+        parent_ftx_rolling_hash=Hash32(bytes(view.parent_ftx_rolling_hash)),
+        parent_ftx_number=U64(int(view.parent_ftx_number)),
+        end_ftx_rolling_hash=Hash32(bytes(view.end_ftx_rolling_hash)),
+        end_processed_ftx_number=U64(int(view.end_processed_ftx_number)),
+        filtered_addresses_hash=Hash32(bytes(view.filtered_addresses_hash)),
+        tx_froms_hash=Hash32(bytes(view.tx_froms_hash)),
+    )
+
+
+def _l2_execution_proof_from_view(view: Any) -> L2ExecutionProof:
+    return L2ExecutionProof(
+        public_inputs=_l2_execution_public_input_from_view(view.public_inputs),
+        start_block_number=U64(int(view.start_block_number)),
+        proof=bytes(view.proof),
+        l2_l1_messages=[Hash32(bytes(h)) for h in view.l2_l1_messages],
+        tx_froms=[Address(bytes(a)) for a in view.tx_froms],
+        filtered_addresses=[Address(bytes(a)) for a in view.filtered_addresses],
+    )
+
+
+def _verifiable_l2_execution_proof_from_view(view: Any) -> VerifiableL2ExecutionProof:
+    return VerifiableL2ExecutionProof(
+        proof=_l2_execution_proof_from_view(view.proof),
+        program_vk=Hash32(bytes(view.program_vk)),
+    )
+
+
+# ── Extended guest input: dataclass <-> framed SSZ bytes ─────────────────────
+
+
+def encode_l2_execution_input(private_input: L2ExecutionProofPrivateInput) -> bytes:
+    """Encode an `L2ExecutionProofPrivateInput` into framed SSZ bytes (0x0002 schema id)."""
+    return _frame(
+        L2_EXECUTION_INPUT_SCHEMA_ID,
+        _ssz_l2_execution_input(private_input).encode_bytes(),
+    )
+
+
+def decode_l2_execution_input_ssz(data: bytes) -> L2ExecutionProofPrivateInput:
+    """
+    Decode framed SSZ bytes into an `L2ExecutionProofPrivateInput`. Strict:
+    rejects a wrong schema id, truncated bytes, trailing bytes, or
+    non-canonical SSZ.
+    """
+    payload = _strip_frame(data, L2_EXECUTION_INPUT_SCHEMA_ID, "l2-execution input")
+    return _l2_execution_input_from_view(_strict_decode(payload, SszL2ExecutionProofPrivateInput))
+
+
+# ── Extended guest output: hash-only framed wire ─────────────────────────────
+
+# The 0x0003 body is exactly one keccak256 hash.
+_OUTPUT_BODY_SIZE = 32
+
+
+def encode_l2_execution_public_inputs_bytes(pi: L2ExecutionProofPublicInput) -> bytes:
+    """
+    SSZ-encode the plain 16-field public-input tuple to its fixed 368-byte
+    wire representation — the preimage of the hash the 0x0003 output frame
+    carries, exposed for verifiers/provers and off-chain inspection.
+    """
+    return _ssz_l2_execution_public_input(pi).encode_bytes()
+
+
+def encode_l2_execution_output(proof: L2ExecutionProof) -> bytes:
+    """
+    Encode the extended l2-execution guest's own output into its framed wire
+    bytes (0x0003 schema id): `schema_id || keccak256(ssz(public_inputs))`,
+    34 bytes total. Every `proof` field other than `public_inputs` is
+    off-chain data with no place on this wire (see module docstring).
+    """
+    return _frame(
+        L2_EXECUTION_OUTPUT_SCHEMA_ID,
+        keccak256(encode_l2_execution_public_inputs_bytes(proof.public_inputs)),
+    )
+
+
+def decode_l2_execution_output_ssz(data: bytes) -> Hash32:
+    """
+    Decode a framed l2-execution output into the public-inputs hash it
+    carries. The body is `keccak256` of the SSZ-encoded public-input tuple —
+    irreversible, so no dataclass is reconstructed. Strict: rejects a wrong
+    schema id, a truncated body, or trailing bytes.
+    """
+    payload = _strip_frame(data, L2_EXECUTION_OUTPUT_SCHEMA_ID, "l2-execution output")
+    if len(payload) != _OUTPUT_BODY_SIZE:
+        raise InvalidSsz(
+            f"l2-execution output: body must be exactly {_OUTPUT_BODY_SIZE} bytes, got {len(payload)}"
+        )
+    return Hash32(payload)

--- a/rollup_spec/src/rollup_spec/l2_execution_ssz.py
+++ b/rollup_spec/src/rollup_spec/l2_execution_ssz.py
@@ -284,10 +284,16 @@ def _chain_config_from_view(view: Any) -> ChainConfig:
 
 
 def _forced_transaction_witness_from_view(view: Any) -> ForcedTransactionWitness:
+    try:
+        acceptance = ForcedTransactionAcceptance(int(view.acceptance))
+    except ValueError as exc:
+        raise InvalidSsz(
+            f"SszForcedTransactionWitness.acceptance: invalid ForcedTransactionAcceptance value {int(view.acceptance)}"
+        ) from exc
     return ForcedTransactionWitness(
         number=U64(int(view.number)),
         signed_tx_rlp=bytes(view.signed_tx_rlp),
-        acceptance=ForcedTransactionAcceptance(int(view.acceptance)),
+        acceptance=acceptance,
         deadline=U64(int(view.deadline)),
     )
 

--- a/rollup_spec/src/rollup_spec/rollup_aggregation_ssz.py
+++ b/rollup_spec/src/rollup_spec/rollup_aggregation_ssz.py
@@ -1,0 +1,196 @@
+"""
+Canonical SSZ wire format for the rollup-aggregation guest program.
+
+This module is the contract a Zig guest decoder and a future Go encoder are
+written against: remerkleable SSZ containers that mirror the logical
+dataclasses in `rollup_aggregation.py` / `l1_rollup.py` / `rollup.py`, plus
+the framing and bounds needed to serialize them unambiguously. This Python
+spec is the source of truth for the wire format. The framing helpers are imported from
+the sibling `l2_execution_ssz.py`, and the shared `SszRollupPublicInput` container plus common bounds
+are imported from the sibling `rollup_ssz.py`.
+
+Framing: exactly like `stateless_input.py::STATELESS_INPUT_SCHEMA_ID`, every
+message is `schema_id (2 bytes, big-endian) || SSZ bytes`. Two schema ids are
+defined, one per guest-facing message:
+
+  - `ROLLUP_AGGREGATION_INPUT_SCHEMA_ID`  (0x1002) — rollup-aggregation guest input
+  - `ROLLUP_AGGREGATION_OUTPUT_SCHEMA_ID` (0x1802) — rollup-aggregation guest output
+
+The guest output container omits the `proof` field the logical
+`FinalizationSubmission` dataclass carries: a guest cannot attest its own
+proof, so `proof` is attached by the prover layer above and is never part of
+the guest-emitted bytes. Decoding an output frame reconstructs the dataclass
+with `proof=b""`, matching the placeholder `run_rollup_aggregation_guest`
+already emits.
+
+List/vector bounds are conservative powers of two: capacity ceilings for the
+wire format, not the guest's or coordinator's own (tighter) operational
+limits. Each constant below carries a one-line rationale.
+"""
+
+from typing import Any
+
+from ethereum.crypto.hash import Hash32
+from ethereum.state import Address
+from ethereum_types.numeric import U64
+from remerkleable.basic import uint64
+from remerkleable.byte_arrays import ByteList, Bytes32 as SszBytes32
+from remerkleable.complex import Container, List
+
+from .l1_rollup import FinalizationSubmission
+from .rollup import RollupProof, VerifiableRollupProof
+from .rollup_aggregation import RollupAggregationProofPrivateInput
+from .l2_execution_ssz import (
+    MAX_PROOF_BYTES,
+    SszAddress,
+    _frame,
+    _strict_decode,
+    _strip_frame,
+)
+from .rollup_ssz import (
+    MAX_FILTERED_ADDRESSES,
+    MAX_L2_L1_ROOTS,
+    SszRollupPublicInput,
+    _rollup_public_input_from_view,
+    _ssz_rollup_public_input,
+)
+
+# ── Framing ──────────────────────────────────────────────────────────────────
+ROLLUP_AGGREGATION_INPUT_SCHEMA_ID = 0x1002
+ROLLUP_AGGREGATION_OUTPUT_SCHEMA_ID = 0x1802
+
+# ── SSZ list/vector bounds ───────────────────────────────────────────────────
+MAX_L2_MESSAGING_BLOCKS_OFFSETS = 2**16        # L1 calldata offsets carried by the aggregation output
+MAX_ROLLUP_PROOFS_PER_AGGREGATION = 2**10      # rollup proofs recursively verified by one aggregation proof
+
+# ── SSZ wire schema (remerkleable) ───────────────────────────────────────────
+
+
+class SszRollupProof(Container):
+    # An already-proven rollup proof, as recursively verified by the
+    # rollup-aggregation guest: carries its own `proof` bytes.
+    public_inputs: SszRollupPublicInput
+    start_block_number: uint64
+    proof: ByteList[MAX_PROOF_BYTES]
+    l2_l1_roots: List[SszBytes32, MAX_L2_L1_ROOTS]
+    filtered_addresses: List[SszAddress, MAX_FILTERED_ADDRESSES]
+
+
+class SszVerifiableRollupProof(Container):
+    proof: SszRollupProof
+    program_vk: SszBytes32
+
+
+class SszRollupAggregationProofPrivateInput(Container):
+    # Field order matches `rollup_aggregation.py::RollupAggregationProofPrivateInput`.
+    rollup_proofs: List[SszVerifiableRollupProof, MAX_ROLLUP_PROOFS_PER_AGGREGATION]
+
+
+class SszRollupAggregationOutput(Container):
+    # The rollup-aggregation guest's own output: `FinalizationSubmission` with
+    # `proof` omitted. Field order matches the remaining fields of
+    # `l1_rollup.py::FinalizationSubmission`.
+    public_inputs: SszRollupPublicInput
+    l2_l1_roots: List[SszBytes32, MAX_L2_L1_ROOTS]
+    filtered_addresses: List[SszAddress, MAX_FILTERED_ADDRESSES]
+    l2_messaging_blocks_offsets: List[uint64, MAX_L2_MESSAGING_BLOCKS_OFFSETS]
+
+
+# ── Logical dataclass -> SSZ view converters ─────────────────────────────────
+
+
+def _ssz_rollup_proof(proof: RollupProof) -> SszRollupProof:
+    return SszRollupProof(
+        public_inputs=_ssz_rollup_public_input(proof.public_inputs),
+        start_block_number=int(proof.start_block_number),
+        proof=bytes(proof.proof),
+        l2_l1_roots=[bytes(r) for r in proof.l2_l1_roots],
+        filtered_addresses=[bytes(a) for a in proof.filtered_addresses],
+    )
+
+
+def _ssz_verifiable_rollup_proof(verifiable: VerifiableRollupProof) -> SszVerifiableRollupProof:
+    return SszVerifiableRollupProof(
+        proof=_ssz_rollup_proof(verifiable.proof),
+        program_vk=bytes(verifiable.program_vk),
+    )
+
+
+# ── SSZ view -> logical dataclass converters ─────────────────────────────────
+
+
+def _rollup_proof_from_view(view: Any) -> RollupProof:
+    return RollupProof(
+        public_inputs=_rollup_public_input_from_view(view.public_inputs),
+        start_block_number=U64(int(view.start_block_number)),
+        proof=bytes(view.proof),
+        l2_l1_roots=[Hash32(bytes(r)) for r in view.l2_l1_roots],
+        filtered_addresses=[Address(bytes(a)) for a in view.filtered_addresses],
+    )
+
+
+def _verifiable_rollup_proof_from_view(view: Any) -> VerifiableRollupProof:
+    return VerifiableRollupProof(
+        proof=_rollup_proof_from_view(view.proof),
+        program_vk=Hash32(bytes(view.program_vk)),
+    )
+
+
+# ── Rollup-aggregation input: dataclass <-> framed SSZ bytes ─────────────────
+
+
+def encode_aggregation_input(agg_input: RollupAggregationProofPrivateInput) -> bytes:
+    """Encode a `RollupAggregationProofPrivateInput` into framed SSZ bytes (0x1002 schema id)."""
+    ssz_input = SszRollupAggregationProofPrivateInput(
+        rollup_proofs=[_ssz_verifiable_rollup_proof(p) for p in agg_input.rollup_proofs],
+    )
+    return _frame(ROLLUP_AGGREGATION_INPUT_SCHEMA_ID, ssz_input.encode_bytes())
+
+
+def decode_aggregation_input_ssz(data: bytes) -> RollupAggregationProofPrivateInput:
+    """
+    Decode framed SSZ bytes into a `RollupAggregationProofPrivateInput`. Strict:
+    rejects a wrong schema id, truncated bytes, trailing bytes, or non-canonical SSZ.
+    """
+    payload = _strip_frame(data, ROLLUP_AGGREGATION_INPUT_SCHEMA_ID, "rollup-aggregation input")
+    view = _strict_decode(payload, SszRollupAggregationProofPrivateInput)
+    return RollupAggregationProofPrivateInput(
+        rollup_proofs=[_verifiable_rollup_proof_from_view(p) for p in view.rollup_proofs],
+    )
+
+
+# ── Rollup-aggregation output: dataclass <-> framed SSZ bytes ────────────────
+
+
+def encode_aggregation_output(submission: FinalizationSubmission) -> bytes:
+    """
+    Encode the rollup-aggregation guest's own output into framed SSZ bytes
+    (0x1802 schema id). `submission.proof` is deliberately dropped — it is a
+    prover-attached placeholder in `FinalizationSubmission`, never part of the
+    guest-emitted bytes.
+    """
+    ssz_output = SszRollupAggregationOutput(
+        public_inputs=_ssz_rollup_public_input(submission.public_inputs),
+        l2_l1_roots=[bytes(r) for r in submission.l2_l1_roots],
+        filtered_addresses=[bytes(a) for a in submission.filtered_addresses],
+        l2_messaging_blocks_offsets=[int(o) for o in submission.l2_messaging_blocks_offsets],
+    )
+    return _frame(ROLLUP_AGGREGATION_OUTPUT_SCHEMA_ID, ssz_output.encode_bytes())
+
+
+def decode_aggregation_output_ssz(data: bytes) -> FinalizationSubmission:
+    """
+    Decode framed SSZ bytes into a `FinalizationSubmission` with `proof=b""`
+    (the guest never emits proof bytes; the prover layer attaches them
+    separately). Strict: rejects a wrong schema id, truncated bytes, trailing
+    bytes, or non-canonical SSZ.
+    """
+    payload = _strip_frame(data, ROLLUP_AGGREGATION_OUTPUT_SCHEMA_ID, "rollup-aggregation output")
+    view = _strict_decode(payload, SszRollupAggregationOutput)
+    return FinalizationSubmission(
+        public_inputs=_rollup_public_input_from_view(view.public_inputs),
+        proof=b"",
+        l2_l1_roots=[Hash32(bytes(r)) for r in view.l2_l1_roots],
+        filtered_addresses=[Address(bytes(a)) for a in view.filtered_addresses],
+        l2_messaging_blocks_offsets=[int(o) for o in view.l2_messaging_blocks_offsets],
+    )

--- a/rollup_spec/src/rollup_spec/rollup_ssz.py
+++ b/rollup_spec/src/rollup_spec/rollup_ssz.py
@@ -1,0 +1,293 @@
+"""
+Canonical SSZ wire format for the rollup guest program.
+
+Remerkleable SSZ containers that mirror the logical dataclasses in
+`rollup.py`, plus the framing and bounds needed to serialize them
+unambiguously. The framing machinery and the embedded l2-execution proof
+containers (`SszVerifiableL2ExecutionProof` and its parts) come from the
+sibling `l2_execution_ssz.py`, mirroring the proof pipeline itself.
+
+Framing: every message is `schema_id (2 bytes, big-endian) || SSZ bytes`.
+Two schema ids are defined, one per guest-facing message:
+
+  - `ROLLUP_INPUT_SCHEMA_ID`  (0x1001) — rollup guest input
+  - `ROLLUP_OUTPUT_SCHEMA_ID` (0x1801) — rollup guest output
+
+The guest output container omits the `proof` field the logical `RollupProof`
+dataclass carries: a guest cannot attest its own proof, so `proof` is attached
+by the prover layer above and is never part of the guest-emitted bytes.
+Decoding an output frame reconstructs the dataclass with `proof=b""`, matching
+the placeholder `run_rollup_guest` already emits.
+
+Optional modelling: `RollupProofPrivateInput.boundary_prev_data_rolling_hash`
+is the one Optional field in this wire format (required only for a mid-chunk
+start, `start_offset > 0`). It is modelled as `List[Bytes32, 1]` — an
+SSZ list capped at length 1 — exactly as `stateless_input.py` models its
+optional fork-activation values. Absent is the empty list; present is a
+single-element list. This keeps every field a plain SSZ list/container type
+with no bespoke union/optional primitive.
+
+List/vector bounds are conservative powers of two: capacity ceilings for the
+wire format, not the guest's or coordinator's own (tighter) operational
+limits. Each constant below carries a one-line rationale.
+"""
+
+from typing import Any, Optional
+
+from ethereum.crypto.hash import Hash32
+from ethereum.state import Address
+from ethereum_types.numeric import U64
+from remerkleable.basic import uint64
+from remerkleable.byte_arrays import ByteList, Bytes32 as SszBytes32
+from remerkleable.complex import Container, List
+
+from .l2_execution_ssz import (
+    SszAddress,
+    SszVerifiableL2ExecutionProof,
+    _frame,
+    _ssz_verifiable_l2_execution_proof,
+    _strict_decode,
+    _strip_frame,
+    _verifiable_l2_execution_proof_from_view,
+)
+from .rollup import (
+    BLOB_BYTES_LENGTH,
+    ConflationWitness,
+    RollupProof,
+    RollupProofPrivateInput,
+    RollupPublicInput,
+)
+
+# ── Framing ──────────────────────────────────────────────────────────────────
+ROLLUP_INPUT_SCHEMA_ID = 0x1001
+ROLLUP_OUTPUT_SCHEMA_ID = 0x1801
+
+# ── SSZ list/vector bounds ───────────────────────────────────────────────────
+MAX_CONFLATIONS_PER_ROLLUP = 2**10             # conflations one rollup proof recursively verifies
+MAX_L2_EXECUTION_PROOFS_PER_ROLLUP = 2**10     # paired 1:1 with conflations (rollup.py::run_rollup_guest)
+MAX_CHUNKS_PER_ROLLUP = 2**12                  # chunks touched by one rollup proof's dataRollingHash fold
+MAX_BLOCK_RLPS_PER_CONFLATION = 2**12          # full block RLPs (one per block) in a single conflation
+MAX_BYTES_PER_BLOCK_RLP = 2**24                # 16 MiB: a full canonical block RLP including all tx bodies
+MAX_PROGRAM_VKS = 2**10                        # distinct guest program VKs bubbled into one program_vks set
+MAX_L2_L1_ROOTS = 2**16                        # per-chunk L2->L1 message-tree roots merged into one proof
+MAX_FILTERED_ADDRESSES = 2**16                 # sanction-list addresses merged at the rollup layer
+# `opaque_prefix_bytes`/`opaque_suffix_bytes` are each bounded by one chunk
+# (`_verify_and_fold_chunks` in rollup.py). Their exact lengths are constrained
+# by `start_offset`/`end_offset`, so `BLOB_BYTES_LENGTH` is a safe SSZ bound.
+
+# ── SSZ wire schema (remerkleable) ───────────────────────────────────────────
+
+
+class SszConflationWitness(Container):
+    block_rlps: List[ByteList[MAX_BYTES_PER_BLOCK_RLP], MAX_BLOCK_RLPS_PER_CONFLATION]
+
+
+class SszRollupPublicInput(Container):
+    # 20-field rollup public input tuple (Readme.md §2.4), field order matches
+    # `rollup.py::RollupPublicInput`.
+    end_block_number: uint64
+    end_block_timestamp: uint64
+    l2_l1_bridge_transaction_tree: SszBytes32
+    parent_l1_l2_bridge_rolling_hash: SszBytes32
+    parent_l1_l2_bridge_rolling_hash_message_number: uint64
+    end_l1_l2_bridge_rolling_hash: SszBytes32
+    end_l1_l2_bridge_rolling_hash_message_number: uint64
+    dynamic_chain_config_hash: SszBytes32
+    parent_ftx_rolling_hash: SszBytes32
+    parent_ftx_number: uint64
+    end_ftx_rolling_hash: SszBytes32
+    end_processed_ftx_number: uint64
+    filtered_addresses_hash: SszBytes32
+    parent_data_rolling_hash: SszBytes32
+    end_data_rolling_hash: SszBytes32
+    parent_block_hash: SszBytes32
+    end_block_hash: SszBytes32
+    start_offset: uint64
+    end_offset: uint64
+    program_vks: List[SszBytes32, MAX_PROGRAM_VKS]
+
+
+class SszRollupProofPrivateInput(Container):
+    # Field order matches `rollup.py::RollupProofPrivateInput`.
+    parent_data_rolling_hash: SszBytes32
+    start_offset: uint64
+    chain_id: uint64
+    conflations: List[SszConflationWitness, MAX_CONFLATIONS_PER_ROLLUP]
+    chunks: List[SszBytes32, MAX_CHUNKS_PER_ROLLUP]
+    l2_execution_proofs: List[SszVerifiableL2ExecutionProof, MAX_L2_EXECUTION_PROOFS_PER_ROLLUP]
+    opaque_prefix_bytes: ByteList[BLOB_BYTES_LENGTH]
+    opaque_suffix_bytes: ByteList[BLOB_BYTES_LENGTH]
+    # Optional[Hash32]: empty list means absent, single-element list means
+    # present (see module docstring).
+    boundary_prev_data_rolling_hash: List[SszBytes32, 1]
+
+
+class SszRollupOutput(Container):
+    # The rollup guest's own output: `RollupProof` with `proof` omitted (the
+    # prover layer attaches it). Field order matches the remaining fields of
+    # `rollup.py::RollupProof`.
+    public_inputs: SszRollupPublicInput
+    start_block_number: uint64
+    l2_l1_roots: List[SszBytes32, MAX_L2_L1_ROOTS]
+    filtered_addresses: List[SszAddress, MAX_FILTERED_ADDRESSES]
+
+
+# ── Logical dataclass -> SSZ view converters ─────────────────────────────────
+
+
+def _ssz_conflation_witness(witness: ConflationWitness) -> SszConflationWitness:
+    return SszConflationWitness(block_rlps=[bytes(r) for r in witness.block_rlps])
+
+
+def _ssz_rollup_public_input(pi: RollupPublicInput) -> SszRollupPublicInput:
+    return SszRollupPublicInput(
+        end_block_number=int(pi.end_block_number),
+        end_block_timestamp=int(pi.end_block_timestamp),
+        l2_l1_bridge_transaction_tree=bytes(pi.l2_l1_bridge_transaction_tree),
+        parent_l1_l2_bridge_rolling_hash=bytes(pi.parent_l1_l2_bridge_rolling_hash),
+        parent_l1_l2_bridge_rolling_hash_message_number=int(
+            pi.parent_l1_l2_bridge_rolling_hash_message_number
+        ),
+        end_l1_l2_bridge_rolling_hash=bytes(pi.end_l1_l2_bridge_rolling_hash),
+        end_l1_l2_bridge_rolling_hash_message_number=int(
+            pi.end_l1_l2_bridge_rolling_hash_message_number
+        ),
+        dynamic_chain_config_hash=bytes(pi.dynamic_chain_config_hash),
+        parent_ftx_rolling_hash=bytes(pi.parent_ftx_rolling_hash),
+        parent_ftx_number=int(pi.parent_ftx_number),
+        end_ftx_rolling_hash=bytes(pi.end_ftx_rolling_hash),
+        end_processed_ftx_number=int(pi.end_processed_ftx_number),
+        filtered_addresses_hash=bytes(pi.filtered_addresses_hash),
+        parent_data_rolling_hash=bytes(pi.parent_data_rolling_hash),
+        end_data_rolling_hash=bytes(pi.end_data_rolling_hash),
+        parent_block_hash=bytes(pi.parent_block_hash),
+        end_block_hash=bytes(pi.end_block_hash),
+        start_offset=int(pi.start_offset),
+        end_offset=int(pi.end_offset),
+        program_vks=[bytes(v) for v in pi.program_vks],
+    )
+
+
+def _ssz_rollup_input(private_input: RollupProofPrivateInput) -> SszRollupProofPrivateInput:
+    boundary = private_input.boundary_prev_data_rolling_hash
+    return SszRollupProofPrivateInput(
+        parent_data_rolling_hash=bytes(private_input.parent_data_rolling_hash),
+        start_offset=int(private_input.start_offset),
+        chain_id=int(private_input.chain_id),
+        conflations=[_ssz_conflation_witness(c) for c in private_input.conflations],
+        chunks=[bytes(c) for c in private_input.chunks],
+        l2_execution_proofs=[
+            _ssz_verifiable_l2_execution_proof(p) for p in private_input.l2_execution_proofs
+        ],
+        opaque_prefix_bytes=bytes(private_input.opaque_prefix_bytes),
+        opaque_suffix_bytes=bytes(private_input.opaque_suffix_bytes),
+        boundary_prev_data_rolling_hash=[bytes(boundary)] if boundary is not None else [],
+    )
+
+
+# ── SSZ view -> logical dataclass converters ─────────────────────────────────
+
+
+def _conflation_witness_from_view(view: Any) -> ConflationWitness:
+    return ConflationWitness(block_rlps=[bytes(r) for r in view.block_rlps])
+
+
+def _rollup_public_input_from_view(view: Any) -> RollupPublicInput:
+    return RollupPublicInput(
+        end_block_number=U64(int(view.end_block_number)),
+        end_block_timestamp=U64(int(view.end_block_timestamp)),
+        l2_l1_bridge_transaction_tree=Hash32(bytes(view.l2_l1_bridge_transaction_tree)),
+        parent_l1_l2_bridge_rolling_hash=Hash32(bytes(view.parent_l1_l2_bridge_rolling_hash)),
+        parent_l1_l2_bridge_rolling_hash_message_number=U64(
+            int(view.parent_l1_l2_bridge_rolling_hash_message_number)
+        ),
+        end_l1_l2_bridge_rolling_hash=Hash32(bytes(view.end_l1_l2_bridge_rolling_hash)),
+        end_l1_l2_bridge_rolling_hash_message_number=U64(
+            int(view.end_l1_l2_bridge_rolling_hash_message_number)
+        ),
+        dynamic_chain_config_hash=Hash32(bytes(view.dynamic_chain_config_hash)),
+        parent_ftx_rolling_hash=Hash32(bytes(view.parent_ftx_rolling_hash)),
+        parent_ftx_number=U64(int(view.parent_ftx_number)),
+        end_ftx_rolling_hash=Hash32(bytes(view.end_ftx_rolling_hash)),
+        end_processed_ftx_number=U64(int(view.end_processed_ftx_number)),
+        filtered_addresses_hash=Hash32(bytes(view.filtered_addresses_hash)),
+        parent_data_rolling_hash=Hash32(bytes(view.parent_data_rolling_hash)),
+        end_data_rolling_hash=Hash32(bytes(view.end_data_rolling_hash)),
+        parent_block_hash=Hash32(bytes(view.parent_block_hash)),
+        end_block_hash=Hash32(bytes(view.end_block_hash)),
+        start_offset=int(view.start_offset),
+        end_offset=int(view.end_offset),
+        program_vks=[Hash32(bytes(v)) for v in view.program_vks],
+    )
+
+
+def _rollup_input_from_view(view: Any) -> RollupProofPrivateInput:
+    boundary_list = view.boundary_prev_data_rolling_hash
+    boundary: Optional[Hash32] = (
+        Hash32(bytes(boundary_list[0])) if len(boundary_list) == 1 else None
+    )
+    return RollupProofPrivateInput(
+        parent_data_rolling_hash=Hash32(bytes(view.parent_data_rolling_hash)),
+        start_offset=int(view.start_offset),
+        chain_id=U64(int(view.chain_id)),
+        conflations=[_conflation_witness_from_view(c) for c in view.conflations],
+        chunks=[Hash32(bytes(c)) for c in view.chunks],
+        l2_execution_proofs=[
+            _verifiable_l2_execution_proof_from_view(p) for p in view.l2_execution_proofs
+        ],
+        opaque_prefix_bytes=bytes(view.opaque_prefix_bytes),
+        opaque_suffix_bytes=bytes(view.opaque_suffix_bytes),
+        boundary_prev_data_rolling_hash=boundary,
+    )
+
+
+# ── Rollup input: dataclass <-> framed SSZ bytes ─────────────────────────────
+
+
+def encode_rollup_input(private_input: RollupProofPrivateInput) -> bytes:
+    """Encode a `RollupProofPrivateInput` into framed SSZ bytes (0x1001 schema id)."""
+    return _frame(ROLLUP_INPUT_SCHEMA_ID, _ssz_rollup_input(private_input).encode_bytes())
+
+
+def decode_rollup_input_ssz(data: bytes) -> RollupProofPrivateInput:
+    """
+    Decode framed SSZ bytes into a `RollupProofPrivateInput`. Strict: rejects a
+    wrong schema id, truncated bytes, trailing bytes, or non-canonical SSZ.
+    """
+    payload = _strip_frame(data, ROLLUP_INPUT_SCHEMA_ID, "rollup input")
+    return _rollup_input_from_view(_strict_decode(payload, SszRollupProofPrivateInput))
+
+
+# ── Rollup output: dataclass <-> framed SSZ bytes ────────────────────────────
+
+
+def encode_rollup_output(proof: RollupProof) -> bytes:
+    """
+    Encode the rollup guest's own output into framed SSZ bytes (0x1801 schema
+    id). `proof.proof` is deliberately dropped — it is a prover-attached
+    placeholder in `RollupProof`, never part of the guest-emitted bytes.
+    """
+    ssz_output = SszRollupOutput(
+        public_inputs=_ssz_rollup_public_input(proof.public_inputs),
+        start_block_number=int(proof.start_block_number),
+        l2_l1_roots=[bytes(r) for r in proof.l2_l1_roots],
+        filtered_addresses=[bytes(a) for a in proof.filtered_addresses],
+    )
+    return _frame(ROLLUP_OUTPUT_SCHEMA_ID, ssz_output.encode_bytes())
+
+
+def decode_rollup_output_ssz(data: bytes) -> RollupProof:
+    """
+    Decode framed SSZ bytes into a `RollupProof` with `proof=b""` (the guest
+    never emits proof bytes; the prover layer attaches them separately).
+    Strict: rejects a wrong schema id, truncated bytes, trailing bytes, or
+    non-canonical SSZ.
+    """
+    payload = _strip_frame(data, ROLLUP_OUTPUT_SCHEMA_ID, "rollup output")
+    view = _strict_decode(payload, SszRollupOutput)
+    return RollupProof(
+        public_inputs=_rollup_public_input_from_view(view.public_inputs),
+        start_block_number=U64(int(view.start_block_number)),
+        l2_l1_roots=[Hash32(bytes(r)) for r in view.l2_l1_roots],
+        filtered_addresses=[Address(bytes(a)) for a in view.filtered_addresses],
+    )

--- a/rollup_spec/tests/test_l2_execution_ssz.py
+++ b/rollup_spec/tests/test_l2_execution_ssz.py
@@ -1,0 +1,183 @@
+"""
+Tests for the l2-execution SSZ wire format (`l2_execution_ssz.py`).
+
+These cover the properties this codec is responsible for:
+  - round-trip fidelity: the SSZ codec preserves every field of the logical
+    guest-input dataclass, including the nested payloads, forced-transaction
+    witnesses, and the opaque per-payload stateless-input byte slices;
+  - output framing: the 0x0003 frame carries exactly the keccak256 of the
+    fixed 368-byte SSZ public-input tuple and nothing else;
+  - strict decoding: a wrong schema id, truncated bytes, or trailing bytes are
+    all rejected rather than silently accepted or truncated.
+
+Run from the rollup_spec/ directory:  python -m pytest
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import rollup_spec
+from ethereum.crypto.hash import keccak256
+from ethereum_types.numeric import U64
+
+from rollup_spec.l2_execution import L2ExecutionProof
+from rollup_spec.l2_execution_ssz import (
+    decode_l2_execution_input_ssz,
+    decode_l2_execution_output_ssz,
+    encode_l2_execution_input,
+    encode_l2_execution_output,
+    encode_l2_execution_public_inputs_bytes,
+)
+from rollup_spec.proof_io_v1 import _decode_l2_execution_public_input, decode_request
+from rollup_spec.stateless_input import InvalidSsz
+
+_TESTDATA_DIR = Path(rollup_spec.__file__).resolve().parent / "prover_io" / "testdata"
+
+
+def _fixture(name: str) -> Path:
+    """Resolve `<name>`, allowing an optional `<startBlock>-<endBlock>-` prefix."""
+    matches = sorted(_TESTDATA_DIR.glob(f"*{name}"))
+    assert matches, f"no fixture matching *{name} in {_TESTDATA_DIR}"
+    assert len(matches) == 1, f"multiple fixtures matching *{name}: {matches}"
+    return matches[0]
+
+
+def _load_json(name: str) -> dict:
+    return json.loads(_fixture(name).read_text())
+
+
+def _l2_execution_input():
+    return decode_request(_load_json("getZkL2ExecutionProofV1.request.json"))
+
+
+def _l2_execution_proof() -> L2ExecutionProof:
+    """The guest output implied by the response fixture (the preimage lists
+    are irrelevant here: only `public_inputs` reaches the 0x0003 wire)."""
+    response = _load_json("getZkL2ExecutionProofV1.response.json")
+    return L2ExecutionProof(
+        public_inputs=_decode_l2_execution_public_input(response["publicInputs"], "publicInputs."),
+        start_block_number=U64(response["startBlockNumber"]),
+    )
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Round-trip: JSON fixture -> dataclass -> SSZ -> dataclass
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_l2_execution_input_round_trips_through_ssz() -> None:
+    original = _l2_execution_input()
+    recovered = decode_l2_execution_input_ssz(encode_l2_execution_input(original))
+    assert recovered == original
+
+
+def test_l2_execution_input_fixture_exercises_nested_fields() -> None:
+    # Guard the round-trip test's coverage: the fixture must exercise the
+    # nested payload list and the opaque stateless-input slices, or the
+    # round-trip would vacuously pass on empty containers.
+    original = _l2_execution_input()
+    assert len(original.payloads) > 0
+    assert all(len(p.stateless_input_ssz) > 0 for p in original.payloads)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Output: hash-only 0x0003 frame
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_l2_execution_output_is_a_34_byte_hash_frame() -> None:
+    encoded = encode_l2_execution_output(_l2_execution_proof())
+    assert len(encoded) == 34
+    assert encoded[:2] == (0x0003).to_bytes(2, "big")
+
+
+def test_l2_execution_output_hash_is_keccak_of_the_public_input_tuple() -> None:
+    proof = _l2_execution_proof()
+    encoded = encode_l2_execution_output(proof)
+    expected = keccak256(encode_l2_execution_public_inputs_bytes(proof.public_inputs))
+    assert encoded[2:] == expected
+    assert decode_l2_execution_output_ssz(encoded) == expected
+
+
+def test_l2_execution_public_input_tuple_encodes_to_exactly_368_bytes() -> None:
+    # Pins the fixed tuple layout (16 fields: 10 x Bytes32 + 6 x uint64) the
+    # guest hashes; any field addition/reorder/retype changes this size.
+    proof = _l2_execution_proof()
+    assert len(encode_l2_execution_public_inputs_bytes(proof.public_inputs)) == 368
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Strict decode rejections
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# Exercised on bytes this module's own encoder just produced from the JSON
+# fixtures — no checked-in SSZ fixture needed.
+
+
+def _l2_execution_input_bytes() -> bytes:
+    return encode_l2_execution_input(_l2_execution_input())
+
+
+def _l2_execution_output_bytes() -> bytes:
+    return encode_l2_execution_output(_l2_execution_proof())
+
+
+_DECODE_CASES = [
+    pytest.param(
+        decode_l2_execution_input_ssz, _l2_execution_input_bytes, 0x0002, id="l2_execution_input"
+    ),
+    pytest.param(
+        decode_l2_execution_output_ssz, _l2_execution_output_bytes, 0x0003, id="l2_execution_output"
+    ),
+]
+
+
+@pytest.mark.parametrize("decode_fn, encode_bytes, schema_id", _DECODE_CASES)
+def test_decode_rejects_wrong_schema_id(decode_fn, encode_bytes, schema_id) -> None:
+    encoded = bytearray(encode_bytes())
+    # Flip the schema id to a value that is not any schema id defined across
+    # the guest wire modules.
+    wrong_id = (schema_id ^ 0xFFFF).to_bytes(2, "big")
+    encoded[0:2] = wrong_id
+    with pytest.raises(InvalidSsz, match="schema id"):
+        decode_fn(bytes(encoded))
+
+
+@pytest.mark.parametrize("decode_fn, encode_bytes, schema_id", _DECODE_CASES)
+def test_decode_rejects_truncated_bytes(decode_fn, encode_bytes, schema_id) -> None:
+    encoded = encode_bytes()
+    with pytest.raises(InvalidSsz):
+        decode_fn(encoded[: len(encoded) - 1])
+
+
+@pytest.mark.parametrize("decode_fn, encode_bytes, schema_id", _DECODE_CASES)
+def test_decode_rejects_missing_schema_id(decode_fn, encode_bytes, schema_id) -> None:
+    encoded = encode_bytes()
+    with pytest.raises(InvalidSsz, match="schema id"):
+        decode_fn(encoded[:1])
+
+
+def test_input_decode_never_silently_absorbs_a_trailing_byte() -> None:
+    # SSZ encoding is bijective, so a trailing byte yields either invalid SSZ
+    # or the canonical encoding of a DIFFERENT value. The input container ends
+    # in a nested byte list, so the appended byte lands inside the last
+    # payload's final `signed_tx_rlp` — a changed value, hence the second
+    # branch: the decode must never hand back the original value as if the
+    # byte were ignorable framing slack.
+    encoded = _l2_execution_input_bytes()
+    original = decode_l2_execution_input_ssz(encoded)
+    try:
+        mutated = decode_l2_execution_input_ssz(encoded + b"\x00")
+    except InvalidSsz:
+        return
+    assert mutated != original
+
+
+def test_output_decode_rejects_trailing_garbage() -> None:
+    # The output body is fixed-size (one 32-byte hash), so trailing bytes are
+    # always detectable and must be rejected outright.
+    encoded = _l2_execution_output_bytes()
+    with pytest.raises(InvalidSsz):
+        decode_l2_execution_output_ssz(encoded + b"\x00")

--- a/rollup_spec/tests/test_rollup_aggregation_ssz.py
+++ b/rollup_spec/tests/test_rollup_aggregation_ssz.py
@@ -1,0 +1,163 @@
+"""
+Tests for the rollup-aggregation SSZ wire format (`rollup_aggregation_ssz.py`).
+
+These cover the two properties this codec is responsible for:
+  - round-trip fidelity: the SSZ codec preserves every field of the logical
+    request/output dataclasses, and (for outputs) the JSON the coordinator
+    would see back out;
+  - strict decoding: a wrong schema id, truncated bytes, or trailing bytes are
+    all rejected rather than silently accepted or truncated.
+
+There is no golden-vector byte-stability check here: nothing outside this
+package's own encoder consumes its exact byte output (the riscv-guests Zig
+guests define and test their own wire format independently — see
+`riscv-guests/rollup-aggregation/test/support.zig`), so pinning this
+encoder's bytes against a checked-in fixture would only be checking it
+against itself.
+
+Run from the rollup_spec/ directory:  python -m pytest
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import rollup_spec
+from ethereum.crypto.hash import Hash32
+from ethereum.state import Address
+
+from rollup_spec.l1_rollup import FinalizationSubmission
+from rollup_spec.proof_io_v1 import (
+    _decode_rollup_public_input,
+    decode_aggregation_request,
+    encode_aggregation_response,
+)
+from rollup_spec.rollup_aggregation_ssz import (
+    decode_aggregation_input_ssz,
+    decode_aggregation_output_ssz,
+    encode_aggregation_input,
+    encode_aggregation_output,
+)
+from rollup_spec.stateless_input import InvalidSsz
+
+_TESTDATA_DIR = Path(rollup_spec.__file__).resolve().parent / "prover_io" / "testdata"
+_PROVER_VERSION = "4.0.0-riscv"
+
+
+def _fixture(name: str) -> Path:
+    """Resolve `<name>`, allowing an optional `<startBlock>-<endBlock>-` prefix."""
+    matches = sorted(_TESTDATA_DIR.glob(f"*{name}"))
+    assert matches, f"no fixture matching *{name} in {_TESTDATA_DIR}"
+    assert len(matches) == 1, f"multiple fixtures matching *{name}: {matches}"
+    return matches[0]
+
+
+def _load_json(name: str) -> dict:
+    return json.loads(_fixture(name).read_text())
+
+
+def _hexbytes(value: str) -> bytes:
+    return bytes.fromhex(value[2:] if value[:2] in ("0x", "0X") else value)
+
+
+def _aggregation_output_from_response(resp: dict) -> FinalizationSubmission:
+    """The rollup-aggregation guest's own output implied by a response fixture:
+    the same guest-emitted fields, with `proverVersion`/`proof` dropped."""
+    pi = _decode_rollup_public_input(resp["publicInputs"], "publicInputs.")
+    return FinalizationSubmission(
+        public_inputs=pi,
+        proof=b"",
+        l2_l1_roots=[Hash32(_hexbytes(h)) for h in resp["l2L1Roots"]],
+        filtered_addresses=[Address(_hexbytes(a)) for a in resp["filteredAddresses"]],
+        l2_messaging_blocks_offsets=list(resp["l2MessagingBlocksOffsets"]),
+    )
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Round-trip: JSON fixture -> dataclass -> SSZ -> dataclass (-> JSON)
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_aggregation_input_round_trips_through_ssz() -> None:
+    original = decode_aggregation_request(
+        _load_json("getZkRollupAggregationProofV1.request.json")
+    )
+    recovered = decode_aggregation_input_ssz(encode_aggregation_input(original))
+    assert recovered == original
+
+
+def test_aggregation_output_round_trips_through_ssz_and_back_to_json() -> None:
+    response = _load_json("getZkRollupAggregationProofV1.response.json")
+    original_output = _aggregation_output_from_response(response)
+
+    recovered_output = decode_aggregation_output_ssz(encode_aggregation_output(original_output))
+    assert recovered_output == original_output
+
+    rebuilt_response = encode_aggregation_response(
+        recovered_output,
+        prover_version=_PROVER_VERSION,
+        start_block_number=response["startBlockNumber"],
+    )
+    assert rebuilt_response == {**response, "proof": "0x"}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Strict decode rejections
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# Exercised once per decode function, corrupting bytes this module's own encoder just produced
+# from the JSON fixtures — no checked-in SSZ fixture needed.
+
+def _aggregation_input_bytes() -> bytes:
+    return encode_aggregation_input(
+        decode_aggregation_request(_load_json("getZkRollupAggregationProofV1.request.json"))
+    )
+
+
+def _aggregation_output_bytes() -> bytes:
+    return encode_aggregation_output(
+        _aggregation_output_from_response(_load_json("getZkRollupAggregationProofV1.response.json"))
+    )
+
+
+_DECODE_CASES = [
+    pytest.param(decode_aggregation_input_ssz, _aggregation_input_bytes, 0x1002, id="aggregation_input"),
+    pytest.param(decode_aggregation_output_ssz, _aggregation_output_bytes, 0x1802, id="aggregation_output"),
+]
+
+
+@pytest.mark.parametrize("decode_fn, encode_bytes, schema_id", _DECODE_CASES)
+def test_decode_rejects_wrong_schema_id(decode_fn, encode_bytes, schema_id) -> None:
+    encoded = bytearray(encode_bytes())
+    # Flip the schema id to a value that is neither the expected id nor any of
+    # the other schema ids in the rollup/rollup-aggregation wire format.
+    wrong_id = (schema_id ^ 0xFFFF).to_bytes(2, "big")
+    encoded[0:2] = wrong_id
+    with pytest.raises(InvalidSsz, match="schema id"):
+        decode_fn(bytes(encoded))
+
+
+@pytest.mark.parametrize("decode_fn, encode_bytes, schema_id", _DECODE_CASES)
+def test_decode_rejects_truncated_bytes(decode_fn, encode_bytes, schema_id) -> None:
+    encoded = encode_bytes()
+    with pytest.raises(InvalidSsz):
+        decode_fn(encoded[: len(encoded) - 1])
+
+
+@pytest.mark.parametrize("decode_fn, encode_bytes, schema_id", _DECODE_CASES)
+def test_decode_rejects_missing_schema_id(decode_fn, encode_bytes, schema_id) -> None:
+    encoded = encode_bytes()
+    with pytest.raises(InvalidSsz, match="schema id"):
+        decode_fn(encoded[:1])
+
+
+@pytest.mark.parametrize("decode_fn, encode_bytes, schema_id", _DECODE_CASES)
+def test_decode_rejects_trailing_garbage(decode_fn, encode_bytes, schema_id) -> None:
+    # A trailing byte either breaks the outer container's own offset/length
+    # bookkeeping (remerkleable raises directly) or decodes as if absorbed and
+    # is then caught by the canonical-encoding re-check — either way it must
+    # surface as InvalidSsz, not succeed silently.
+    encoded = encode_bytes()
+    with pytest.raises(InvalidSsz):
+        decode_fn(encoded + b"\x00")

--- a/rollup_spec/tests/test_rollup_ssz.py
+++ b/rollup_spec/tests/test_rollup_ssz.py
@@ -1,0 +1,158 @@
+"""
+Tests for the rollup SSZ wire format (`rollup_ssz.py`).
+
+These cover the two properties this codec is responsible for:
+  - round-trip fidelity: the SSZ codec preserves every field of the logical
+    request/output dataclasses, and (for outputs) the JSON the coordinator
+    would see back out;
+  - strict decoding: a wrong schema id, truncated bytes, or trailing bytes are
+    all rejected rather than silently accepted or truncated.
+
+There is no golden-vector byte-stability check here: pinning this encoder's
+bytes against a fixture the same encoder produced would only be checking it
+against itself. Implementations conform to this codec by round-tripping
+against it directly.
+
+Run from the rollup_spec/ directory:  python -m pytest
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import rollup_spec
+from ethereum.crypto.hash import Hash32
+from ethereum.state import Address
+from ethereum_types.numeric import U64
+
+from rollup_spec.rollup import RollupProof
+from rollup_spec.proof_io_v1 import (
+    _decode_rollup_public_input,
+    decode_rollup_request,
+    encode_rollup_response,
+)
+from rollup_spec.rollup_ssz import (
+    decode_rollup_input_ssz,
+    decode_rollup_output_ssz,
+    encode_rollup_input,
+    encode_rollup_output,
+)
+from rollup_spec.stateless_input import InvalidSsz
+
+_TESTDATA_DIR = Path(rollup_spec.__file__).resolve().parent / "prover_io" / "testdata"
+_PROVER_VERSION = "4.0.0-riscv"
+
+
+def _fixture(name: str) -> Path:
+    """Resolve `<name>`, allowing an optional `<startBlock>-<endBlock>-` prefix."""
+    matches = sorted(_TESTDATA_DIR.glob(f"*{name}"))
+    assert matches, f"no fixture matching *{name} in {_TESTDATA_DIR}"
+    assert len(matches) == 1, f"multiple fixtures matching *{name}: {matches}"
+    return matches[0]
+
+
+def _load_json(name: str) -> dict:
+    return json.loads(_fixture(name).read_text())
+
+
+def _hexbytes(value: str) -> bytes:
+    return bytes.fromhex(value[2:] if value[:2] in ("0x", "0X") else value)
+
+
+def _rollup_output_from_response(resp: dict) -> RollupProof:
+    """The rollup guest's own output implied by a response fixture: the same
+    guest-emitted fields, with `proverVersion`/`proof` dropped."""
+    pi = _decode_rollup_public_input(resp["publicInputs"], "publicInputs.")
+    return RollupProof(
+        public_inputs=pi,
+        start_block_number=U64(resp["startBlockNumber"]),
+        l2_l1_roots=[Hash32(_hexbytes(h)) for h in resp["l2L1Roots"]],
+        filtered_addresses=[Address(_hexbytes(a)) for a in resp["filteredAddresses"]],
+    )
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Round-trip: JSON fixture -> dataclass -> SSZ -> dataclass (-> JSON)
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_rollup_input_round_trips_through_ssz() -> None:
+    original = decode_rollup_request(_load_json("getZkRollupProofV1.request.json"))
+    recovered = decode_rollup_input_ssz(encode_rollup_input(original))
+    assert recovered == original
+
+
+def test_rollup_output_round_trips_through_ssz_and_back_to_json() -> None:
+    response = _load_json("getZkRollupProofV1.response.json")
+    original_output = _rollup_output_from_response(response)
+
+    recovered_output = decode_rollup_output_ssz(encode_rollup_output(original_output))
+    assert recovered_output == original_output
+
+    # The guest never emits `proof`/`programVk` (both host-attached metadata); round-tripping
+    # through the JSON encoder reproduces the original response with `proof` reset to the
+    # placeholder and the fixture's own `programVk` passed back in.
+    rebuilt_response = encode_rollup_response(
+        recovered_output,
+        prover_version=_PROVER_VERSION,
+        program_vk=_hexbytes(response["programVk"]),
+    )
+    assert rebuilt_response == {**response, "proof": "0x"}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Strict decode rejections
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# Exercised once per decode function, corrupting bytes this module's own encoder just produced
+# from the JSON fixtures — no checked-in SSZ fixture needed.
+
+def _rollup_input_bytes() -> bytes:
+    return encode_rollup_input(decode_rollup_request(_load_json("getZkRollupProofV1.request.json")))
+
+
+def _rollup_output_bytes() -> bytes:
+    return encode_rollup_output(_rollup_output_from_response(_load_json("getZkRollupProofV1.response.json")))
+
+
+_DECODE_CASES = [
+    pytest.param(decode_rollup_input_ssz, _rollup_input_bytes, 0x1001, id="rollup_input"),
+    pytest.param(decode_rollup_output_ssz, _rollup_output_bytes, 0x1801, id="rollup_output"),
+]
+
+
+@pytest.mark.parametrize("decode_fn, encode_bytes, schema_id", _DECODE_CASES)
+def test_decode_rejects_wrong_schema_id(decode_fn, encode_bytes, schema_id) -> None:
+    encoded = bytearray(encode_bytes())
+    # Flip the schema id to a value that is neither the expected id nor the
+    # other schema id in this module.
+    wrong_id = (schema_id ^ 0xFFFF).to_bytes(2, "big")
+    encoded[0:2] = wrong_id
+    with pytest.raises(InvalidSsz, match="schema id"):
+        decode_fn(bytes(encoded))
+
+
+@pytest.mark.parametrize("decode_fn, encode_bytes, schema_id", _DECODE_CASES)
+def test_decode_rejects_truncated_bytes(decode_fn, encode_bytes, schema_id) -> None:
+    encoded = encode_bytes()
+    with pytest.raises(InvalidSsz):
+        decode_fn(encoded[: len(encoded) - 1])
+
+
+@pytest.mark.parametrize("decode_fn, encode_bytes, schema_id", _DECODE_CASES)
+def test_decode_rejects_missing_schema_id(decode_fn, encode_bytes, schema_id) -> None:
+    encoded = encode_bytes()
+    with pytest.raises(InvalidSsz, match="schema id"):
+        decode_fn(encoded[:1])
+
+
+@pytest.mark.parametrize("decode_fn, encode_bytes, schema_id", _DECODE_CASES)
+def test_decode_rejects_trailing_garbage(decode_fn, encode_bytes, schema_id) -> None:
+    # A trailing byte either breaks the outer container's own offset/length
+    # bookkeeping (remerkleable raises directly) or decodes as if absorbed and
+    # is then caught by the canonical-encoding re-check — either way it must
+    # surface as InvalidSsz, not succeed silently.
+    encoded = encode_bytes()
+    with pytest.raises(InvalidSsz):
+        decode_fn(encoded + b"\x00")


### PR DESCRIPTION
Per-guest module mirroring the Zig convention (l2_execution_ssz.zig): extended input 0x0002, hash-only output 0x0003, the embedded proof containers, and the shared SSZ framing helpers the sibling guest modules build on. The Python spec is the source of truth; Go/Zig/Rust implementations are checked against it. Round-trip and strict-decode tests included.

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.
