### PR TITLE
feat(coordinator): propagate blockRlps through BlocksConflation

### DIFF
--- a/coordinator/core-interfaces/src/main/kotlin/linea/domain/Conflation.kt
+++ b/coordinator/core-interfaces/src/main/kotlin/linea/domain/Conflation.kt
@@ -7,15 +7,36 @@ import kotlin.time.Instant
 data class BlocksConflation(
   val blocks: List<Block>,
   val conflationResult: ConflationCalculationResult,
+  val blockRlps: List<ByteArray>,
 ) : BlockInterval {
   init {
     require(blocks.isSortedBy { it.number }) { "Blocks list must be sorted by blockNumber" }
+    require(blockRlps.size == blocks.size) {
+      "blockRlps.size (${blockRlps.size}) must equal blocks.size (${blocks.size})"
+    }
   }
 
   override val startBlockNumber: ULong
     get() = blocks.first().number
   override val endBlockNumber: ULong
     get() = blocks.last().number
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+    other as BlocksConflation
+    if (blocks != other.blocks) return false
+    if (conflationResult != other.conflationResult) return false
+    if (blockRlps.size != other.blockRlps.size) return false
+    return blockRlps.zip(other.blockRlps).all { (a, b) -> a.contentEquals(b) }
+  }
+
+  override fun hashCode(): Int {
+    var result = blocks.hashCode()
+    result = 31 * result + conflationResult.hashCode()
+    result = 31 * result + blockRlps.fold(0) { acc, ba -> 31 * acc + ba.contentHashCode() }
+    return result
+  }
 }
 
 data class Batch(

--- a/coordinator/core/src/main/kotlin/lineth/coordination/conflation/ConflationServiceImpl.kt
+++ b/coordinator/core/src/main/kotlin/lineth/coordination/conflation/ConflationServiceImpl.kt
@@ -24,7 +24,7 @@ class ConflationServiceImpl(
 ) :
   ConflationService {
   private var listener: ConflationHandler = ConflationHandler { SafeFuture.completedFuture<Unit>(null) }
-  private val blocksInProgress: MutableList<Block> = mutableListOf()
+  private val blocksInProgress: MutableMap<ULong, Pair<Block, ByteArray>> = mutableMapOf()
 
   data class PayloadAndBlockCounters(
     val block: Block,
@@ -77,13 +77,15 @@ class ConflationServiceImpl(
     )
     batchSizeInBlocksHistogram.record(conflation.blocksRange.count().toDouble())
 
-    val blocksToConflate =
-      blocksInProgress
-        .filter { it.number in conflation.blocksRange }
-        .sortedBy { it.number }
-    blocksInProgress.removeAll(blocksToConflate)
+    val pairs = conflation.blocksRange.mapNotNull { blockNumber -> blocksInProgress.remove(blockNumber) }
 
-    return listener.handleConflatedBatch(BlocksConflation(blocksToConflate, conflation))
+    return listener.handleConflatedBatch(
+      BlocksConflation(
+        blocks = pairs.map { it.first },
+        conflationResult = conflation,
+        blockRlps = pairs.map { it.second },
+      ),
+    )
       .whenException { th ->
         log.error(
           "Conflation listener failed: batch={} errorMessage={}",
@@ -108,7 +110,7 @@ class ConflationServiceImpl(
       blocksInProgress.size,
     )
     blocksToConflate.add(PayloadAndBlockCounters(block, blockCounters))
-    blocksInProgress.add(block)
+    blocksInProgress[block.number] = Pair(block, blockCounters.blockRLPEncoded)
     log.trace("block {} added to conflation queue", block.number)
     sendBlocksInOrderToTracesCounter()
   }

--- a/coordinator/core/src/test/kotlin/lineth/coordination/conflation/ConflationServiceImplTest.kt
+++ b/coordinator/core/src/test/kotlin/lineth/coordination/conflation/ConflationServiceImplTest.kt
@@ -92,14 +92,15 @@ class ConflationServiceImplTest {
     assertThat(conflationEvents).isEqualTo(
       listOf(
         BlocksConflation(
-          listOf(payload1, payload2),
-          ConflationCalculationResult(
+          blocks = listOf(payload1, payload2),
+          conflationResult = ConflationCalculationResult(
             startBlockNumber = 1u,
             endBlockNumber = 2u,
             conflationTrigger = ConflationTrigger.BLOCKS_LIMIT,
             // these are not counted in conflation, so will be 0
             tracesCounters = fakeTracesCountersV2(0u),
           ),
+          blockRlps = listOf(payloadCounters1.blockRLPEncoded, payloadCounters2.blockRLPEncoded),
         ),
       ),
     )

--- a/coordinator/core/src/test/kotlin/lineth/coordination/proofcreation/ZkProofCreationCoordinatorImplTest.kt
+++ b/coordinator/core/src/test/kotlin/lineth/coordination/proofcreation/ZkProofCreationCoordinatorImplTest.kt
@@ -106,6 +106,7 @@ class ZkProofCreationCoordinatorImplTest {
             conflationTrigger = ConflationTrigger.TRACES_LIMIT,
             tracesCounters = fakeTracesCountersV2(0u),
           ),
+          blockRlps = listOf(ByteArray(0), ByteArray(0)),
         ),
         traces =
         BlocksTracesConflated(


### PR DESCRIPTION
## Summary

- Adds `blockRlps: List<ByteArray>` to `BlocksConflation` so downstream consumers (rollup proof coordinator) have per-block RLP bytes without needing a separate lookup
- `ConflationServiceImpl` stores `(Block, ByteArray)` pairs keyed by block number in `blocksInProgress: MutableMap<ULong, Pair<Block, ByteArray>>`, populated in `newBlock()` and consumed with O(1) removal per block in `handleConflation()`
- `BlocksConflation` overrides `equals`/`hashCode` with `ByteArray.contentEquals` so test assertions behave correctly

## Test plan

- [ ] `ConflationServiceImplTest` — updated assertion includes `blockRlps` referencing actual `BlockCounters.blockRLPEncoded` values; passes
- [ ] `ZkProofCreationCoordinatorImplTest` — updated construction site with placeholder empty arrays; passes
- [ ] `./gradlew coordinator:core-interfaces:compileKotlin coordinator:core:compileKotlin coordinator:core:compileTestKotlin` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the conflation batch payload on the path to proof generation; behavior change is additive but any consumer constructing `BlocksConflation` must now provide aligned RLP bytes.
> 
> **Overview**
> **`BlocksConflation`** now carries **`blockRlps: List<ByteArray>`** alongside blocks and the conflation result, with an init check that RLP list length matches block count. Custom **`equals`/`hashCode`** compare RLP bytes via **`contentEquals`** / **`contentHashCode`** so tests and collections behave correctly for byte arrays.
> 
> **`ConflationServiceImpl`** keeps in-flight blocks in a **`MutableMap<ULong, Pair<Block, ByteArray>>`** instead of a list: each **`newBlock`** stores **`blockCounters.blockRLPEncoded`**, and **`handleConflation`** removes entries by block number and passes the paired RLPs into **`BlocksConflation`**.
> 
> Unit tests were updated to supply **`blockRlps`** when constructing expected or fixture **`BlocksConflation`** values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f97ea0fa75d0c01814e908e708c65a4c352ff3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->