### PR TITLE
feat(coordinator): add ConflationSegmentBuilder stub for DA segment assembly

### DIFF
--- a/coordinator/core/src/main/kotlin/lineth/coordination/riscv/da/ConflationSegmentBuilder.kt
+++ b/coordinator/core/src/main/kotlin/lineth/coordination/riscv/da/ConflationSegmentBuilder.kt
@@ -1,0 +1,187 @@
+package lineth.coordination.riscv.da
+
+import linea.domain.Block
+
+// BLOB_BYTES_LENGTH = 4096 * 32 = 131_072 bytes (one EIP-4844 KZG blob).
+// Defined here to mirror rollup_spec/src/rollup_spec/rollup.py BLOB_BYTES_LENGTH.
+const val BLOB_BYTES_LENGTH: Int = 4096 * 32
+
+// Length in bytes of the per-conflation segment length prefix in the DA stream.
+// rollup_spec §3.1: stream layout is [len][lz4(rlp(conflation))] per conflation.
+// 4 bytes in big-endian order (matching Python SEGMENT_LENGTH_PREFIX_BYTES = 4).
+private const val SEGMENT_LENGTH_PREFIX_BYTES: Int = 4
+
+/**
+ * Builds the compressed byte segment for one conflation in the DA stream.
+ *
+ * DA stream layout (rollup_spec §3.1):
+ *   [4-byte-len BE][lz4_block(rlp(truncatedBlocks))] || [4-byte-len BE][...] || ...
+ *
+ * Segments from multiple conflations are concatenated in order and sliced into
+ * BLOB_BYTES_LENGTH-sized chunks. Each chunk becomes one KZG blob on L1.
+ *
+ * Implementation reference: rollup_spec/src/rollup_spec/rollup.py
+ *   - truncate_block_rlp()           line ~734
+ *   - rlp_encode_truncated_blocks()  line ~773
+ *   - compress_lz4()                 line ~806
+ *   - _compress_conflation_segment() line ~179
+ */
+object ConflationSegmentBuilder {
+
+  /**
+   * Builds the full compressed segment bytes for one conflation.
+   *
+   * Returns: [4-byte big-endian length][lz4-block-compressed RLP of truncated blocks]
+   *
+   * Steps (see Python reference for each):
+   *   1. Truncate each block (strip tx signatures, recover ECDSA sender) — see [truncateBlock]
+   *   2. RLP-encode the list of truncated blocks — see [rlpEncodeTruncatedBlocks]
+   *   3. LZ4-block-compress the RLP bytes — see [compressLz4]
+   *   4. Prepend a 4-byte big-endian length prefix of the compressed bytes
+   */
+  fun buildSegment(blocks: List<Block>, chainId: ULong): ByteArray {
+    val truncated = blocks.map { truncateBlock(it, chainId) }
+    val rlpEncoded = rlpEncodeTruncatedBlocks(truncated)
+    val compressed = compressLz4(rlpEncoded)
+    val prefix = compressed.size.to4BytesBigEndian()
+    return prefix + compressed
+  }
+
+  /**
+   * Returns the byte length of [buildSegment] without allocating the full result.
+   *
+   * Used by ConflatedChunkCoordinator to accumulate stream buffer size before sealing a chunk.
+   */
+  fun segmentSize(blocks: List<Block>, chainId: ULong): Int = buildSegment(blocks, chainId).size
+
+  // ---------------------------------------------------------------------------
+  // Internal steps — each maps directly to one function in the Python spec.
+  // Replace each TODO with the real implementation.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Produces a [TruncatedBlock] from a [Block] domain object by stripping transaction
+   * signatures and recovering ECDSA sender addresses.
+   *
+   * Python reference: rollup_spec/src/rollup_spec/rollup.py truncate_block_rlp() ~line 734
+   *
+   * The [Block] domain object already carries all needed header fields — no RLP decoding
+   * is required. Map fields directly:
+   *   - timestamp    = block.timestamp
+   *   - blockHash    = block.hash  (already keccak256(rlp_encode(header)), computed by the node)
+   *   - prevRandao   = block.mixHash  (mixHash field holds prevRandao post-merge)
+   *
+   * For each [linea.domain.Transaction] in block.transactions:
+   *   1. Produce signature-stripped canonical tx bytes (Python: _signature_stripped_tx_bytes()):
+   *      Re-encode the tx WITHOUT the signature fields (r, s, v / yParity) in the canonical
+   *      pre-signing wire format, per transaction type:
+   *        FRONTIER:     RLP([nonce, gasPrice, gasLimit, to, value, data])
+   *                      — or with EIP-155: RLP([nonce, gasPrice, gasLimit, to, value, data, chainId, 0, 0])
+   *        ACCESS_LIST:  0x01 || RLP([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList])
+   *        EIP1559:      0x02 || RLP([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit,
+   *                                   to, value, data, accessList])
+   *        DELEGATE_CODE:0x04 || RLP([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit,
+   *                                   to, value, data, accessList, authorizationList])
+   *      All fields are available directly on [linea.domain.Transaction].
+   *   2. Recover the sender address via ECDSA from (r, s, v/yParity) and the signing hash
+   *      (keccak256 of the stripped tx bytes above):
+   *        web3j: Sign.recoverFromSignature(recId, ECDSASignature(r, s), signingHash)
+   *        → take bytes 12..31 of the recovered public key hash as the 20-byte address.
+   */
+  internal fun truncateBlock(block: Block, chainId: ULong): TruncatedBlock {
+    TODO(
+      "Implement block truncation from Block domain object: " +
+        "map block.hash/timestamp/mixHash directly, then for each Transaction in block.transactions " +
+        "produce signature-stripped bytes and recover ECDSA sender. " +
+        "See rollup_spec/src/rollup_spec/rollup.py truncate_block_rlp() ~line 734.",
+    )
+  }
+
+  /**
+   * RLP-encodes a list of [TruncatedBlock]s into the canonical DA payload bytes.
+   *
+   * Python reference: rollup_spec/src/rollup_spec/rollup.py rlp_encode_truncated_blocks() ~line 773
+   *
+   * Both the sequencer (producing the blob) and the rollup guest (recomputing the
+   * compressed payload for KZG verification) must use this exact encoding — any
+   * deviation causes KZG verification to fail on L1.
+   *
+   * Wire layout (RLP list of lists):
+   *   RLP([
+   *     [uint(timestamp), bytes32(blockHash), bytes32(prevRandao),
+   *      [strippedTx_1, strippedTx_2, ...],
+   *      [from_1, from_2, ...]],
+   *     ...
+   *   ])
+   *
+   * The lineth.rlp.RLP helper already exists in the codebase (used by BlockRLPEncoder).
+   */
+  internal fun rlpEncodeTruncatedBlocks(blocks: List<TruncatedBlock>): ByteArray {
+    TODO(
+      "Implement RLP encoding of truncated blocks. Wire layout per " +
+        "rollup_spec/src/rollup_spec/rollup.py rlp_encode_truncated_blocks() ~line 773. " +
+        "Use lineth.rlp.RLP helpers already in the codebase.",
+    )
+  }
+
+  /**
+   * LZ4-block-compresses [data] using raw LZ4 block format (no uncompressed-size header).
+   *
+   * Python reference: rollup_spec/src/rollup_spec/rollup.py compress_lz4() ~line 806
+   *   lz4.block.compress(data, store_size=False)
+   *
+   * The 'store_size=False' parameter means NO 4-byte uncompressed-size prepended —
+   * only the raw LZ4 block bytes are returned. The length prefix in [buildSegment]
+   * covers the compressed size; the decompressor must know the original size via
+   * the RLP structure, not from an LZ4 header.
+   *
+   * Suggested JVM library: net.jpountz.lz4:lz4-java
+   *   val factory = LZ4Factory.fastestInstance()
+   *   val compressor = factory.fastCompressor()
+   *   compressor.compress(data, 0, data.size, output, 0)
+   *
+   * The compression level must match the spec exactly — both the sequencer and the
+   * RISC-V guest must produce byte-for-byte identical output for KZG to verify.
+   * Verify against test vectors from rollup_spec before shipping.
+   *
+   * Dependency to add (coordinator/core/build.gradle or coordinator/app/build.gradle):
+   *   implementation("org.lz4:lz4-java:<version>")
+   */
+  internal fun compressLz4(data: ByteArray): ByteArray {
+    TODO(
+      "Implement LZ4 block compression without size header (store_size=False equivalent). " +
+        "Add net.jpountz.lz4:lz4-java dependency. Verify output matches Python " +
+        "lz4.block.compress(data, store_size=False) byte-for-byte.",
+    )
+  }
+}
+
+/**
+ * Per-conflation truncated block as defined in rollup_spec §3.2.
+ *
+ * This is the intermediate representation produced by [ConflationSegmentBuilder.truncateBlockRlp]
+ * and consumed by [ConflationSegmentBuilder.rlpEncodeTruncatedBlocks].
+ *
+ * Fields mirror TruncatedEthereumBlock in rollup_spec/src/rollup_spec/rollup.py ~line 720:
+ *   @dataclass
+ *   class TruncatedEthereumBlock:
+ *       timestamp: U64
+ *       block_hash: Hash32
+ *       prev_randao: Bytes32
+ *       transactions: List[bytes]   # signature-stripped canonical tx bytes
+ *       froms: List[Address]        # ECDSA-recovered sender per tx
+ */
+data class TruncatedBlock(
+  val timestamp: ULong,
+  val blockHash: ByteArray,   // 32 bytes, keccak256(rlp_encode(header))
+  val prevRandao: ByteArray,  // 32 bytes
+  val transactions: List<ByteArray>,  // signature-stripped tx bytes, one per tx
+  val froms: List<ByteArray>,         // 20-byte sender address per tx
+)
+
+private fun Int.to4BytesBigEndian(): ByteArray = byteArrayOf(
+  (this ushr 24).toByte(),
+  (this ushr 16).toByte(),
+  (this ushr 8).toByte(),
+  this.toByte(),
+)


### PR DESCRIPTION
## Summary

Adds `ConflationSegmentBuilder` stub in `lineth/coordination/riscv/da/` with detailed TODO comments for each implementation step. The public API is complete and wired end-to-end so the rollup proof coordinator can integrate against it before block truncation is finished.

**Public API (ready to use):**
- `buildSegment(blockRlps, chainId): ByteArray` — produces `[4-byte BE len][lz4(rlp(truncatedBlocks))]`
- `segmentSize(blockRlps, chainId): Int` — same without full allocation, used for chunk boundary detection

**Three internal steps left to implement (each has a detailed TODO comment):**
- `truncateBlockRlp` — decode full block RLP, strip tx signatures, ECDSA sender recovery per tx. Reference: `rollup_spec/src/rollup_spec/rollup.py truncate_block_rlp()` ~line 734
- `rlpEncodeTruncatedBlocks` — canonical RLP encoding matching the rollup guest wire layout exactly (any deviation causes KZG verification failure). Reference: `rollup_spec/src/rollup_spec/rollup.py rlp_encode_truncated_blocks()` ~line 773
- `compressLz4` — LZ4 block compression without size header (`store_size=False` equivalent). Requires adding `net.jpountz.lz4:lz4-java` dependency. Reference: `rollup_spec/src/rollup_spec/rollup.py compress_lz4()` ~line 806

Also adds `TruncatedBlock` data class mirroring `TruncatedEthereumBlock` from the Python spec.

## Test plan

- [ ] `./gradlew coordinator:core:compileKotlin` — clean (stub compiles with `TODO()`)
- [ ] Implementer should add unit tests verifying `buildSegment` output matches Python spec test vectors before removing TODOs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds compile-time stubs only; no DA/KZG payload is produced until the TODO implementations ship.
> 
> **Overview**
> Introduces **`ConflationSegmentBuilder`** under `lineth/coordination/riscv/da/` so the coordinator can assemble per-conflation DA stream segments that match rollup_spec §3.1: truncate blocks → RLP → LZ4 → **4-byte big-endian length prefix**, with **`BLOB_BYTES_LENGTH`** defined for EIP-4844 blob sizing.
> 
> The **public surface is wired**: `buildSegment(blocks, chainId)` and `segmentSize(...)` (for chunk boundary sizing), plus a **`TruncatedBlock`** model aligned with the Python spec. **Truncation, canonical RLP encoding, and LZ4 compression are still `TODO` stubs** with references to `rollup_spec/rollup.py`; callers can integrate against the API before those steps land.
> 
> No LZ4 dependency or tests are added in this change—implementers are expected to match Python test vectors before removing the TODOs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4377d524b70a89e3c7d8d73b2e856ce3006f646. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->