### PR TITLE
feat(contracts): deploy create2 proxy eip 7997

### DIFF
--- a/.github/workflows/contracts-forge-deployer-build-and-publish.yml
+++ b/.github/workflows/contracts-forge-deployer-build-and-publish.yml
@@ -49,6 +49,7 @@ jobs:
   build-scan-and-publish:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     name: Forge contract deployer build
+    timeout-minutes: 30
     env:
       IMAGE_TAG: ${{ inputs.image_tag }}
       IMAGE_NAME: ${{ inputs.image_name }}

--- a/.github/workflows/run-smc-tests.yml
+++ b/.github/workflows/run-smc-tests.yml
@@ -58,14 +58,15 @@ jobs:
         run: pnpm -F contracts run lint:ts
 
       - name: Test Forge contract deployer
+        working-directory: contracts/forge-deployer
         run: |
-          pnpm --filter @lfdt-lineth/forge-contract-deployer test
-          pnpm --filter @lfdt-lineth/forge-contract-deployer typecheck
-          pnpm --filter @lfdt-lineth/forge-contract-deployer build
+          pnpm test
+          pnpm typecheck
+          pnpm build
 
       # Required for hardhat commands due to @nomicfoundation/hardhat-foundry package
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d #v1.8.0
+        uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 #v1.9.1
 
       - name: Compile kzg.node
         run: pnpm -F contracts exec node-gyp --directory=node_modules/c-kzg rebuild # explicitly running rebuild to get the .node file

--- a/contracts/common/helpers/deploymentRecord.ts
+++ b/contracts/common/helpers/deploymentRecord.ts
@@ -14,7 +14,13 @@ export interface ParsedDeploymentRecord {
   chainId: string;
 }
 
-interface Acknowledgement {
+// Generic wire shape for the checkpoint parent's reply to any `sendAndAwaitAck`
+// message. There is no single fixed meaning: `type` is the discriminator that
+// says *what* is being acknowledged (one of "lineth-deployment-intent-ack",
+// "lineth-deployment-record-ack", or bootstrap.ts's "lineth-bootstrap-record-ack"),
+// matched by the caller-supplied `ackType`. `error`, when present, means the
+// parent rejected the request rather than acknowledging it.
+interface AckEnvelope {
   type: string;
   id: string;
   error?: string;
@@ -45,9 +51,9 @@ export function parseDeploymentRecord(line: string): ParsedDeploymentRecord | un
   };
 }
 
-function isAcknowledgement(message: unknown, id: string, ackType: string): message is Acknowledgement {
+function isMatchingAckEnvelope(message: unknown, id: string, ackType: string): message is AckEnvelope {
   if (typeof message !== "object" || message === null) return false;
-  const candidate = message as Partial<Acknowledgement>;
+  const candidate = message as Partial<AckEnvelope>;
   return candidate.type === ackType && candidate.id === id;
 }
 
@@ -75,7 +81,7 @@ export async function sendAndAwaitAck(
       process.off("disconnect", onDisconnect);
     };
     const onMessage = (received: unknown) => {
-      if (!isAcknowledgement(received, id, ackType)) return;
+      if (!isMatchingAckEnvelope(received, id, ackType)) return;
       cleanup();
       if (received.error) reject(new Error(received.error));
       else resolve();

--- a/contracts/common/helpers/deploymentRecord.ts
+++ b/contracts/common/helpers/deploymentRecord.ts
@@ -14,14 +14,8 @@ export interface ParsedDeploymentRecord {
   chainId: string;
 }
 
-interface DeploymentRecordAcknowledgement {
-  type: "lineth-deployment-record-ack";
-  id: string;
-  error?: string;
-}
-
-interface DeploymentIntentAcknowledgement {
-  type: "lineth-deployment-intent-ack";
+interface Acknowledgement {
+  type: string;
   id: string;
   error?: string;
 }
@@ -51,74 +45,70 @@ export function parseDeploymentRecord(line: string): ParsedDeploymentRecord | un
   };
 }
 
-function isAcknowledgement(message: unknown, id: string): message is DeploymentRecordAcknowledgement {
+function isAcknowledgement(message: unknown, id: string, ackType: string): message is Acknowledgement {
   if (typeof message !== "object" || message === null) return false;
-  const candidate = message as Partial<DeploymentRecordAcknowledgement>;
-  return candidate.type === "lineth-deployment-record-ack" && candidate.id === id;
+  const candidate = message as Partial<Acknowledgement>;
+  return candidate.type === ackType && candidate.id === id;
 }
 
-function isIntentAcknowledgement(message: unknown, id: string): message is DeploymentIntentAcknowledgement {
-  if (typeof message !== "object" || message === null) return false;
-  const candidate = message as Partial<DeploymentIntentAcknowledgement>;
-  return candidate.type === "lineth-deployment-intent-ack" && candidate.id === id;
+/**
+ * Sends an IPC message to the connected parent process (a no-op when there is
+ * none) and waits for a matching acknowledgement of `ackType`, rejecting on
+ * an error payload or a parent disconnect. Shared by
+ * `awaitParentDeploymentIntent`/`awaitParentCheckpoint` (which differ only in
+ * the message/ack type names, payload shape, and id generation) and by
+ * `bootstrap.ts`'s `awaitBootstrapRecord`.
+ */
+export async function sendAndAwaitAck(
+  buildMessage: (id: string) => { type: string; id: string } & Record<string, unknown>,
+  ackType: string,
+  generateId: () => string,
+  disconnectErrorMessage: string,
+): Promise<void> {
+  if (!process.send || !process.connected) return;
+
+  const id = generateId();
+  const message = buildMessage(id);
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      process.off("message", onMessage);
+      process.off("disconnect", onDisconnect);
+    };
+    const onMessage = (received: unknown) => {
+      if (!isAcknowledgement(received, id, ackType)) return;
+      cleanup();
+      if (received.error) reject(new Error(received.error));
+      else resolve();
+    };
+    const onDisconnect = () => {
+      cleanup();
+      reject(new Error(disconnectErrorMessage));
+    };
+
+    process.on("message", onMessage);
+    process.once("disconnect", onDisconnect);
+    process.send?.(message, (error) => {
+      if (!error) return;
+      cleanup();
+      reject(error);
+    });
+  });
 }
 
 export async function awaitParentDeploymentIntent(contractName: string): Promise<void> {
-  if (!process.send || !process.connected) return;
-
-  const id = `${process.pid}-intent-${intentSequence++}`;
-  await new Promise<void>((resolve, reject) => {
-    const cleanup = () => {
-      process.off("message", onMessage);
-      process.off("disconnect", onDisconnect);
-    };
-    const onMessage = (message: unknown) => {
-      if (!isIntentAcknowledgement(message, id)) return;
-      cleanup();
-      if (message.error) reject(new Error(message.error));
-      else resolve();
-    };
-    const onDisconnect = () => {
-      cleanup();
-      reject(new Error("checkpoint parent disconnected before authorizing deployment broadcast"));
-    };
-
-    process.on("message", onMessage);
-    process.once("disconnect", onDisconnect);
-    process.send?.({ type: "lineth-deployment-intent", id, contractName }, (error) => {
-      if (!error) return;
-      cleanup();
-      reject(error);
-    });
-  });
+  await sendAndAwaitAck(
+    (id) => ({ type: "lineth-deployment-intent", id, contractName }),
+    "lineth-deployment-intent-ack",
+    () => `${process.pid}-intent-${intentSequence++}`,
+    "checkpoint parent disconnected before authorizing deployment broadcast",
+  );
 }
 
 export async function awaitParentCheckpoint(record: ParsedDeploymentRecord): Promise<void> {
-  if (!process.send || !process.connected) return;
-
-  const id = `${process.pid}-${recordSequence++}`;
-  await new Promise<void>((resolve, reject) => {
-    const cleanup = () => {
-      process.off("message", onMessage);
-      process.off("disconnect", onDisconnect);
-    };
-    const onMessage = (message: unknown) => {
-      if (!isAcknowledgement(message, id)) return;
-      cleanup();
-      if (message.error) reject(new Error(message.error));
-      else resolve();
-    };
-    const onDisconnect = () => {
-      cleanup();
-      reject(new Error("checkpoint parent disconnected before acknowledging deployment"));
-    };
-
-    process.on("message", onMessage);
-    process.once("disconnect", onDisconnect);
-    process.send?.({ type: "lineth-deployment-record", id, record }, (error) => {
-      if (!error) return;
-      cleanup();
-      reject(error);
-    });
-  });
+  await sendAndAwaitAck(
+    (id) => ({ type: "lineth-deployment-record", id, record }),
+    "lineth-deployment-record-ack",
+    () => `${process.pid}-${recordSequence++}`,
+    "checkpoint parent disconnected before acknowledging deployment",
+  );
 }

--- a/contracts/common/helpers/deterministicDeploymentProxy.ts
+++ b/contracts/common/helpers/deterministicDeploymentProxy.ts
@@ -1,0 +1,185 @@
+import { ethers } from "ethers";
+
+import { DeploymentRecordInput, formatDeploymentRecord } from "./deploymentRecord";
+import { FeeOverrides } from "./feeOverrides";
+
+const DETERMINISTIC_DEPLOYMENT_PROXY_CONTRACT_NAME = "DeterministicDeploymentProxy";
+
+/**
+ * EIP-7997 / Arachnid deterministic deployment proxy ("Create2Factory").
+ *
+ * This is the well-known keyless deployment pattern: a pre-signed legacy
+ * transaction whose `r`/`s` are the fixed `0x2222...` values deploys the same
+ * factory at the same address on every EVM chain. Because the transaction is
+ * already signed, broadcasting it does not consume any nonce from our keys and
+ * is not signed by the deployer wallet — we only need to fund the recovered
+ * signer so the network accepts the pre-signed transaction.
+ */
+export const ARACHNID_SIGNER = ethers.getAddress("0x3fAB184622Dc19b6109349B94811493BF2a45362");
+export const ARACHNID_FACTORY = ethers.getAddress("0x4e59b44847b379578588920cA78FbF26c0B4956C");
+
+// gasLimit(0x186a0 = 100000) * gasPrice(0x174876e800 = 100 gwei) hardcoded by the raw tx.
+export const ARACHNID_FUNDING_WEI = 10_000_000_000_000_000n;
+
+export const ARACHNID_RAW_TX =
+  "0xf8a58085174876e800830186a08080b853604580600e600039806000f350fe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf31ba02222222222222222222222222222222222222222222222222222222222222222a02222222222222222222222222222222222222222222222222222222222222222";
+
+// The runtime bytecode the factory is expected to have after a successful deploy
+// (the portion of ARACHNID_RAW_TX's init code returned via CODECOPY/RETURN). Used
+// to distinguish "factory genuinely deployed" from "unrelated bytecode happens to
+// occupy this address", rather than trusting any non-empty code at ARACHNID_FACTORY.
+export const ARACHNID_FACTORY_RUNTIME_CODE =
+  "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3";
+export const ARACHNID_FACTORY_RUNTIME_CODE_HASH = ethers.keccak256(ARACHNID_FACTORY_RUNTIME_CODE);
+
+// Fails fast if ARACHNID_RAW_TX ever stops recovering to ARACHNID_SIGNER — e.g.
+// a future edit corrupts the constant. Funding the wrong recovered signer would
+// silently waste the transfer and leave the pre-signed broadcast unable to
+// land. Called explicitly from ensureDeterministicDeploymentProxy (before any
+// funds move) rather than at module import time, so merely importing a type
+// from this module can never throw as a side effect.
+function assertArachnidRawTxIntegrity(): void {
+  const recoveredSigner = ethers.Transaction.from(ARACHNID_RAW_TX).from;
+  if (!recoveredSigner || ethers.getAddress(recoveredSigner) !== ARACHNID_SIGNER) {
+    throw new Error(
+      `ARACHNID_RAW_TX recovers to signer ${recoveredSigner ?? "<none>"}, expected ${ARACHNID_SIGNER}; refusing to use the deterministic-deployment-proxy helper`,
+    );
+  }
+}
+
+export interface EnsureDeterministicProxyInput {
+  provider: ethers.Provider;
+  wallet: ethers.Wallet;
+  fees: FeeOverrides;
+  /** Nonce for the funding transfer (the deployer's next free nonce). */
+  nonce: number;
+}
+
+export interface EnsureDeterministicProxyResult {
+  factoryAddress: string;
+  /** Present only when a funding transfer was actually broadcast. */
+  fundingTxHash?: string;
+  /** Present only when the raw deployment transaction was actually broadcast. */
+  deployTxHash?: string;
+  /** Block number the deployment transaction was mined in (when broadcast). */
+  deployBlockNumber?: number;
+  /** True when the factory already existed and nothing was broadcast. */
+  alreadyDeployed: boolean;
+}
+
+/** Whether the on-chain code at ARACHNID_FACTORY is absent, the expected factory, or something else. */
+export type DeterministicProxyCodeStatus = "absent" | "match" | "mismatch";
+
+/**
+ * Checks the bytecode at ARACHNID_FACTORY against the known factory runtime
+ * code, rather than merely checking for non-empty code. Any non-empty code
+ * that does not hash-match the expected factory is treated as a "mismatch",
+ * not as "already deployed" — this guards against adopting or funding on top
+ * of unrelated bytecode that could occupy the well-known address (e.g. a
+ * misbehaving RPC endpoint, or a chain that does not actually preinstall it).
+ */
+export async function getDeterministicProxyCodeStatus(
+  provider: ethers.Provider,
+): Promise<DeterministicProxyCodeStatus> {
+  const code = await provider.getCode(ARACHNID_FACTORY);
+  if (code === "0x") return "absent";
+  return ethers.keccak256(code) === ARACHNID_FACTORY_RUNTIME_CODE_HASH ? "match" : "mismatch";
+}
+
+export async function isDeterministicProxyDeployed(provider: ethers.Provider): Promise<boolean> {
+  return (await getDeterministicProxyCodeStatus(provider)) !== "absent";
+}
+
+/**
+ * Idempotently installs the deterministic deployment proxy on the connected
+ * chain. Returns early when factory bytecode already exists. Otherwise funds
+ * the keyless signer with the exact gas budget and broadcasts the pre-signed
+ * raw transaction, then verifies the factory has code.
+ */
+export async function ensureDeterministicDeploymentProxy(
+  input: EnsureDeterministicProxyInput,
+): Promise<EnsureDeterministicProxyResult> {
+  assertArachnidRawTxIntegrity();
+  const { provider, wallet, fees, nonce } = input;
+
+  const initialStatus = await getDeterministicProxyCodeStatus(provider);
+  if (initialStatus === "mismatch") {
+    throw new Error(
+      `Refusing to treat ${ARACHNID_FACTORY} as the deterministic deployment proxy; on-chain bytecode does not match the expected factory`,
+    );
+  }
+  if (initialStatus === "match") {
+    console.log(`DeterministicDeploymentProxy already deployed at ${ARACHNID_FACTORY}; skipping`);
+    return { factoryAddress: ARACHNID_FACTORY, alreadyDeployed: true };
+  }
+
+  console.log(`Funding deterministic deployment signer ${ARACHNID_SIGNER} with ${ARACHNID_FUNDING_WEI} wei`);
+  const fundingTx = await wallet.sendTransaction({
+    to: ARACHNID_SIGNER,
+    value: ARACHNID_FUNDING_WEI,
+    nonce,
+    ...fees,
+  });
+  const fundingReceipt = await fundingTx.wait();
+  if (!fundingReceipt || fundingReceipt.status !== 1) {
+    throw new Error(`Funding transaction ${fundingTx.hash} for ${ARACHNID_SIGNER} failed`);
+  }
+  console.log(`Funded deterministic deployment signer: tx=${fundingTx.hash} block=${fundingReceipt.blockNumber}`);
+
+  const deployTx = await provider.broadcastTransaction(ARACHNID_RAW_TX);
+  const deployReceipt = await deployTx.wait();
+  if (!deployReceipt || deployReceipt.status !== 1) {
+    throw new Error(`Deterministic deployment proxy broadcast ${deployTx.hash} failed`);
+  }
+  console.log(`Broadcast deterministic deployment proxy: tx=${deployTx.hash} block=${deployReceipt.blockNumber}`);
+
+  const finalStatus = await getDeterministicProxyCodeStatus(provider);
+  if (finalStatus !== "match") {
+    throw new Error(
+      `Deterministic deployment proxy broadcast ${deployTx.hash} left ${finalStatus === "absent" ? "no code" : "unexpected code"} at ${ARACHNID_FACTORY}`,
+    );
+  }
+
+  return {
+    factoryAddress: ARACHNID_FACTORY,
+    fundingTxHash: fundingTx.hash,
+    deployTxHash: deployTx.hash,
+    deployBlockNumber: deployReceipt.blockNumber,
+    alreadyDeployed: false,
+  };
+}
+
+export interface EnsureAndDescribeDeterministicProxyOutput {
+  result: EnsureDeterministicProxyResult;
+  /** Ready to hand to `awaitParentCheckpoint`/a checkpoint store. */
+  record: DeploymentRecordInput;
+  /** `formatDeploymentRecord(record)`, provided so callers don't reformat it themselves. */
+  formattedRecord: string;
+}
+
+/**
+ * Installs the proxy (see `ensureDeterministicDeploymentProxy`) and builds the
+ * single canonical `DeploymentRecordInput`/log line describing the result, so
+ * every entrypoint (local dev, quickstart, forge-deployer) reports the same
+ * shape instead of each hand-formatting its own log line. On an "already
+ * deployed" skip there is no real transaction hash, so `transactionHash`
+ * falls back to `ZeroHash` — `formatDeploymentRecord`'s output always
+ * includes a txHash field, matching `DEPLOYMENT_RECORD_PATTERN`.
+ */
+export async function ensureAndDescribeDeterministicDeploymentProxy(
+  input: EnsureDeterministicProxyInput,
+): Promise<EnsureAndDescribeDeterministicProxyOutput> {
+  const result = await ensureDeterministicDeploymentProxy(input);
+  const [blockNumber, network] = await Promise.all([
+    result.deployBlockNumber ? Promise.resolve(result.deployBlockNumber) : input.provider.getBlockNumber(),
+    input.provider.getNetwork(),
+  ]);
+  const record: DeploymentRecordInput = {
+    contractName: DETERMINISTIC_DEPLOYMENT_PROXY_CONTRACT_NAME,
+    address: result.factoryAddress,
+    transactionHash: result.deployTxHash ?? ethers.ZeroHash,
+    blockNumber,
+    chainId: network.chainId,
+  };
+  return { result, record, formattedRecord: formatDeploymentRecord(record) };
+}

--- a/contracts/common/helpers/feeOverrides.ts
+++ b/contracts/common/helpers/feeOverrides.ts
@@ -83,6 +83,11 @@ export async function resolveOneModelFeeOverrides(
     }
   }
 
+  // Deliberately not delegating to scripts/utils.ts's get1559Fees: that helper
+  // treats a falsy fee (including a legitimate `0n`, used for gas-free L2s
+  // via L2_DEPLOY_GAS_PRICE_WEI=0) as absent, which would silently misreport
+  // "no usable fee data" here. Only null/undefined mean "provider didn't
+  // return this field".
   const { gasPrice, maxFeePerGas, maxPriorityFeePerGas } = await provider.getFeeData();
   const hasMaxFee = maxFeePerGas !== null && maxFeePerGas !== undefined;
   const hasPriorityFee = maxPriorityFeePerGas !== null && maxPriorityFeePerGas !== undefined;

--- a/contracts/eslint.config.mjs
+++ b/contracts/eslint.config.mjs
@@ -6,6 +6,7 @@ export default [
     ignores: [
       ".solcover.js",
       "docs/**",
+      "forge-deployer/test/fixtures/**",
       "integrity-verifier/**",
       "signer-ui/.next/**",
       "signer-ui/node_modules/**",

--- a/contracts/forge-deployer/Dockerfile
+++ b/contracts/forge-deployer/Dockerfile
@@ -15,6 +15,26 @@ COPY contracts ./contracts
 RUN pnpm install --frozen-lockfile --filter @lfdt-lineth/forge-contract-deployer...
 RUN pnpm --filter @lfdt-lineth/forge-contract-deployer build
 
+# Custom bootstrap scripts run as plain Node children and may `require("ethers")`.
+# The runtime image strips package managers, so do a self-contained isolated
+# install of ethers whose node_modules those children can resolve. The version
+# is read from pnpm-workspace.yaml's catalog (already COPY'd above) rather than
+# hardcoded here a second time, so it can never silently drift from the version
+# the rest of the deployer builds against.
+RUN set -eux; \
+  ethers_version="$(grep -oE '^[[:space:]]*ethers:[[:space:]]*[^[:space:]]+' pnpm-workspace.yaml | awk '{print $2}')"; \
+  if [ -z "$ethers_version" ]; then \
+    echo "failed to resolve the ethers catalog version from pnpm-workspace.yaml" >&2; \
+    exit 1; \
+  fi; \
+  mkdir -p /bootstrap-libs/pkg; \
+  printf '{ "name": "bootstrap-libs", "version": "0.0.0", "private": true, "dependencies": { "ethers": "%s" } }' "$ethers_version" \
+    > /bootstrap-libs/pkg/package.json; \
+  cd /bootstrap-libs/pkg; \
+  COREPACK_ENABLE_STRICT=0 pnpm install --ignore-workspace --node-linker=isolated \
+    --modules-dir /bootstrap-libs/node_modules --virtual-store-dir /bootstrap-libs/node_modules/.pnpm; \
+  node -e "process.env.NODE_PATH='/bootstrap-libs/node_modules'; require('module').Module._initPaths(); const e=require('ethers'); console.log('ethers resolvable for bootstrap scripts:', e.version)"
+
 FROM node:${NODE_VERSION}-bookworm-slim AS runtime
 
 ENV NODE_ENV=production
@@ -33,6 +53,8 @@ RUN rm -rf \
   /usr/local/bin/yarnpkg
 
 COPY --from=build --chown=node:node /workspace/contracts/forge-deployer/dist ./dist
+COPY --from=build --chown=node:node /bootstrap-libs/node_modules ./bootstrap-libs/node_modules
+ENV BOOTSTRAP_LIB_NODE_PATH=/app/bootstrap-libs/node_modules
 COPY --from=build --chown=node:node \
   /workspace/contracts/local-deployments-artifacts/dynamic-artifacts/IntegrationTestTrueVerifier.json \
   ./dist/artifacts/dynamic-artifacts/IntegrationTestTrueVerifier.json

--- a/contracts/forge-deployer/README.md
+++ b/contracts/forge-deployer/README.md
@@ -1,12 +1,13 @@
 # Forge contract deployer
 
 One-shot, dev/test-only deployer for the Lineth Forge chart. It packages the
-four boot-critical deployment steps used by the Lineth Stack quickstart:
+five boot-critical deployment steps used by the Lineth Stack quickstart:
 
 1. L1 `IntegrationTestTrueVerifier` and `LinethRollupV8`
 2. L2 `L2MessageService`
 3. L1 `BridgedToken` and `TokenBridge`
 4. L2 `BridgedToken` and `TokenBridge`
+5. L2 EIP-7997 / Arachnid deterministic deployment proxy (`Create2Factory`)
 
 It intentionally does not deploy coordinator, prover, postman, demo-token, or
 Forced Transaction Gateway contracts.
@@ -33,6 +34,8 @@ the corresponding starting nonce to its expected pending nonce before the
 first run; changing it after a checkpoint exists fails closed.
 
 `L2_GENESIS_TIMESTAMP` is optional and otherwise comes from L2 block 0.
+`BOOTSTRAP_MANIFEST_FILE` (and optionally `BOOTSTRAP_SCRIPTS_DIR`) enable the
+custom bootstrap phase; see below.
 `L1_DEPLOYER_ADDRESS` and `L2_DEPLOYER_ADDRESS` can be supplied to assert that
 the mounted keys derive the bootstrap/operator-published identities.
 `EXPECTED_L1_CHAIN_ID` and `EXPECTED_L2_CHAIN_ID` fail before deployment when
@@ -54,12 +57,14 @@ the service account namespace and can be set with `POD_NAMESPACE` and
 
 In Kubernetes the Lineth chart creates the `lineth-contract-addresses`
 placeholder ConfigMap and the deployer updates it using resource-version
-guards. Its schema-version-2 `checkpoint.json` contains the exact deployment
+guards. Its schema-version-3 `checkpoint.json` contains the exact deployment
 image digest, chain IDs, signer addresses, starting nonces, deterministic
-expected addresses, the public deployment-configuration hash, transaction
-hashes, and block numbers. It never contains private keys or RPC URLs.
+expected addresses, the public deployment-configuration hash, the bootstrap
+manifest hash, completed custom bootstrap records, transaction hashes, and
+block numbers. It never contains private keys or RPC URLs.
 `addresses.json` exposes the same versioned, secret-free deployment record,
-while four top-level keys expose the completed primary contract addresses.
+while five top-level keys expose the completed primary contract addresses
+(including `deterministic-deployment-proxy`).
 
 Before every deployment broadcast, the parent persists an intent containing
 the planned contract, nonce, and deterministic address, then acknowledges the
@@ -79,6 +84,112 @@ unexplained signer nonce drift also fail closed.
 
 For local runs, set `CHECKPOINT_FILE=/path/to/checkpoint.json` instead of using
 the Kubernetes API.
+
+## Deterministic deployment proxy (step 5)
+
+The final L2 step installs the well-known EIP-7997 / Arachnid
+`Create2Factory` so downstream tooling can deploy contracts at deterministic
+addresses:
+
+- Factory address: `0x4e59b44847b379578588920cA78FbF26c0B4956C` (a fixed,
+  well-known constant — not derived from the deployer nonce)
+- Keyless signer it funds: `0x3fAB184622Dc19b6109349B94811493BF2a45362`
+- Funding amount: exactly `0.01 ETH` (`10000000000000000` wei) — the budget the
+  pre-signed raw transaction hardcodes (`gasLimit 100000` x `gasPrice 100 gwei`)
+
+The step runs **after** the four contract-deployment steps. The deployment
+transaction is a pre-signed, keyless broadcast, so it consumes **no** deployer
+nonce; only the funding transfer consumes one L2 deployer nonce.
+
+The step is idempotent and restart-safe. When factory bytecode already exists
+at the well-known address — including dev chains such as anvil that preinstall
+it in genesis — the deployer adopts it as a `recovered` checkpoint record and
+sends nothing (no funding transfer, no broadcast). Otherwise it funds the
+signer and broadcasts the raw transaction, then verifies the factory bytecode
+and checkpoints the broadcast transaction hash.
+
+**Gas-free L2 caveat.** On a gas-free L2 (`L2_DEPLOY_GAS_PRICE_WEI=0`) the
+funding transfer itself is free, but the funding is still required: the
+pre-signed raw transaction hardcodes a 100 gwei gas price, so the signer must
+actually hold 0.01 ETH for the network to accept the broadcast regardless of
+the chain's configured gas price.
+
+## Custom bootstrap phase (optional)
+
+Operators of new networks can inject extra transactions after the five core
+steps — for example a consortium deploying its own contracts on every partner
+network for cross-chain interoperability. The phase is opt-in: when
+`BOOTSTRAP_MANIFEST_FILE` is unset the deployer behaves exactly as before.
+
+Set `BOOTSTRAP_MANIFEST_FILE` to the path of a JSON manifest mounted into the
+Job. The manifest declares an ordered list of items; `id` values must be unique
+lowercase kebab-case and stay stable across reruns (they key the checkpoint).
+
+```json
+{
+  "version": 1,
+  "items": [
+    { "id": "fund-relayer", "kind": "sign", "chain": "l2",
+      "to": "0xConsortiumRelayer", "valueWei": "100000000000000000" },
+    { "id": "bridge-factory", "kind": "presigned", "chain": "l2",
+      "rawTx": "0x...", "expectAddress": "0x..." },
+    { "id": "extra-setup", "kind": "script", "chain": "l2",
+      "script": "consortium/extra.js" }
+  ]
+}
+```
+
+Item kinds:
+
+- **`sign`** — the deployer signs and submits. Set `to` for a value transfer,
+  `data` (bytecode) for a bare contract create, or **both** for a contract call
+  that carries data — which is exactly how a CREATE2 deploy through the
+  deterministic proxy works (a signed call to the factory `to` with the encoded
+  deploy `data`). `valueWei` defaults to `0`; `gasLimit` is optional. These are
+  how you fund the external accounts that pre-signed transactions spend from.
+  They hook into the existing nonce management: the runner reads the deployer's
+  current pending nonce after the core steps and hands it to the phase as the
+  starting nonce, so each `sign` item continues the chain's nonce sequence with
+  no gaps.
+  - **Constructor args / create data:** `data` is the raw transaction payload,
+    so constructor arguments are pre-encoded onto the bytecode by the operator
+    (`bytecode ++ abiEncode(args)`); the step submits it verbatim.
+  - **Deployed address:** set `expectAddress` to pin and record the resulting
+    contract. For a bare create the step asserts `receipt.contractAddress`
+    matches it. For a CREATE2-proxy call the receipt has no contract address
+    (it's a call to the factory), so the step instead verifies bytecode landed
+    at `expectAddress`.
+- **`presigned`** — broadcast a keyless, externally-signed raw transaction
+  verbatim. Consumes no deployer nonce. With `expectAddress` set, the item is
+  skipped when that address already has bytecode (the same idempotency check
+  the deterministic-proxy step uses).
+- **`script`** — run an operator-supplied Node script (resolved relative to
+  `BOOTSTRAP_SCRIPTS_DIR`) that may create/sign/submit anything. The child
+  receives `RPC_URL`, `DEPLOYER_PRIVATE_KEY`, `BOOTSTRAP_ITEM_ID`,
+  `BOOTSTRAP_CHAIN`, `BOOTSTRAP_CHAIN_ID`, and `BOOTSTRAP_START_NONCE`, and can
+  `require("ethers")` (bundled into the image). Scripts run as restricted child
+  processes and are trusted operator input. A script performs arbitrary actions
+  with no single transaction hash, so on success it is recorded with a sentinel
+  hash and skipped on rerun — the script itself must make its own on-chain
+  actions safe to have run once.
+
+Within a run, `sign` (funding) items execute first in manifest order, then
+`presigned`, then `script` — so funded accounts exist before any pre-signed
+transaction that spends from them. Items are grouped by chain and each chain's
+pending items run in one pass.
+
+### Restart-safety and fail-closed semantics
+
+Each completed item is durably recorded in the checkpoint under
+`bootstrap.<id>` (kind, chain, transaction hash, block number, chain ID, and
+the deployed address when one exists). Completed items are skipped on rerun, so
+re-running with the same manifest sends no further transactions.
+
+The manifest content is hashed (`keccak256` over the normalized manifest) into
+the checkpoint identity as `bootstrapHash`. Changing the manifest against an
+existing checkpoint fails closed with a `bootstrap manifest` mismatch — the same
+rule that guards the image digest, chain IDs, and signers. To deploy a changed
+manifest, recreate the network from clean chain state and a fresh checkpoint.
 
 ## Development
 

--- a/contracts/forge-deployer/src/address-plan.ts
+++ b/contracts/forge-deployer/src/address-plan.ts
@@ -1,7 +1,21 @@
 import { getAddress, getCreateAddress } from "ethers";
 
+import { ARACHNID_FACTORY } from "../../common/helpers/deterministicDeploymentProxy";
+
 export type ChainName = "l1" | "l2";
-export type StepId = "l1-rollup" | "l2-message-service" | "l1-token-bridge" | "l2-token-bridge";
+export type StepId =
+  | "l1-rollup"
+  | "l2-message-service"
+  | "l1-token-bridge"
+  | "l2-token-bridge"
+  | "l2-deterministic-proxy";
+
+/**
+ * Single source of truth for the deterministic-deployment-proxy step's
+ * identity, so runner/cli/store don't each re-type the string literal.
+ */
+export const L2_DETERMINISTIC_PROXY_STEP_ID: StepId = "l2-deterministic-proxy";
+export const L2_DETERMINISTIC_PROXY_FACTORY_KEY = `${L2_DETERMINISTIC_PROXY_STEP_ID}.factory`;
 
 export interface PlannedDeployment {
   key: string;
@@ -14,7 +28,7 @@ export interface DeploymentStep {
   id: StepId;
   chain: ChainName;
   startingNonce: number;
-  script: "l1-rollup" | "l2-message-service" | "token-bridge";
+  script: "l1-rollup" | "l2-message-service" | "token-bridge" | "deterministic-deployment-proxy";
   deployments: PlannedDeployment[];
 }
 
@@ -48,6 +62,26 @@ function planStep(
       nonce: startingNonce + index,
       expectedAddress: getCreateAddress({ from: signer, nonce: startingNonce + index }),
     })),
+  };
+}
+
+// The deterministic deployment proxy lands at a well-known constant address
+// (keyless pre-signed transaction), not a nonce-derived CREATE address, so it
+// cannot reuse planStep's getCreateAddress derivation.
+function planDeterministicProxyStep(id: StepId, startingNonce: number): DeploymentStep {
+  return {
+    id,
+    chain: "l2",
+    startingNonce,
+    script: "deterministic-deployment-proxy",
+    deployments: [
+      {
+        key: `${id}.factory`,
+        contractName: "DeterministicDeploymentProxy",
+        nonce: startingNonce,
+        expectedAddress: ARACHNID_FACTORY,
+      },
+    ],
   };
 }
 
@@ -97,6 +131,10 @@ export function buildAddressPlan(input: AddressPlanInput): DeploymentStep[] {
       ["proxy", "TokenBridge"],
     ],
   );
+  const l2DeterministicProxy = planDeterministicProxyStep(
+    L2_DETERMINISTIC_PROXY_STEP_ID,
+    input.l2StartingNonce + l2MessageService.deployments.length + l2TokenBridge.deployments.length,
+  );
 
-  return [l1Rollup, l2MessageService, l1TokenBridge, l2TokenBridge];
+  return [l1Rollup, l2MessageService, l1TokenBridge, l2TokenBridge, l2DeterministicProxy];
 }

--- a/contracts/forge-deployer/src/bootstrap-manifest.ts
+++ b/contracts/forge-deployer/src/bootstrap-manifest.ts
@@ -1,0 +1,181 @@
+import { getAddress, isAddress, keccak256, toUtf8Bytes } from "ethers";
+
+import { ChainName } from "./address-plan";
+
+// Custom bootstrap items let operators of new networks (e.g. a consortium)
+// deploy their own contracts/transactions on top of the 5 core steps. They are
+// declared in a manifest file supplied at runtime so each network opts into its
+// own set. Three kinds are supported:
+//   - sign:      the deployer signs & submits (value send or contract create);
+//                consumes a deployer nonce supplied by the runner for continuity.
+//   - presigned: a keyless/external raw transaction broadcast as-is; consumes no
+//                deployer nonce.
+//   - script:    an operator-supplied child script that may create/sign/submit.
+export type BootstrapItemKind = "sign" | "presigned" | "script";
+
+interface BootstrapItemBase {
+  id: string;
+  chain: ChainName;
+}
+
+export interface SignBootstrapItem extends BootstrapItemBase {
+  kind: "sign";
+  to?: string;
+  data?: string;
+  valueWei: string;
+  gasLimit?: string;
+  expectAddress?: string;
+}
+
+export interface PresignedBootstrapItem extends BootstrapItemBase {
+  kind: "presigned";
+  rawTx: string;
+  expectAddress?: string;
+}
+
+export interface ScriptBootstrapItem extends BootstrapItemBase {
+  kind: "script";
+  script: string;
+}
+
+export type BootstrapItem = SignBootstrapItem | PresignedBootstrapItem | ScriptBootstrapItem;
+
+export interface BootstrapManifest {
+  version: number;
+  items: BootstrapItem[];
+}
+
+const ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+const HEX_DATA_PATTERN = /^0x([0-9a-fA-F]{2})*$/;
+const RAW_TX_PATTERN = /^0x[0-9a-fA-F]+$/;
+const UINT_PATTERN = /^[0-9]+$/;
+
+function fail(message: string): never {
+  throw new Error(`bootstrap manifest: ${message}`);
+}
+
+function requireId(value: unknown): string {
+  if (typeof value !== "string" || !ID_PATTERN.test(value)) {
+    fail(`item id must be lowercase kebab-case (a-z0-9-), got: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+function requireChain(value: unknown, id: string): ChainName {
+  if (value !== "l1" && value !== "l2") fail(`item ${id} chain must be "l1" or "l2", got: ${JSON.stringify(value)}`);
+  return value;
+}
+
+function optionalAddress(value: unknown, field: string, id: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !isAddress(value)) {
+    fail(`item ${id} ${field} must be an Ethereum address, got: ${JSON.stringify(value)}`);
+  }
+  return getAddress(value);
+}
+
+function optionalHex(value: unknown, field: string, id: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !HEX_DATA_PATTERN.test(value)) {
+    fail(`item ${id} ${field} must be 0x-prefixed even-length hex, got: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+function requireUint(value: unknown, field: string, id: string): string {
+  if (typeof value !== "string" || !UINT_PATTERN.test(value)) {
+    fail(`item ${id} ${field} must be a non-negative integer string, got: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+function optionalUint(value: unknown, field: string, id: string): string | undefined {
+  if (value === undefined) return undefined;
+  return requireUint(value, field, id);
+}
+
+function parseItem(raw: unknown, index: number): BootstrapItem {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    fail(`item at index ${index} must be an object`);
+  }
+  const candidate = raw as Record<string, unknown>;
+  const id = requireId(candidate.id);
+  const chain = requireChain(candidate.chain, id);
+  const kind = candidate.kind;
+
+  if (kind === "sign") {
+    const to = optionalAddress(candidate.to, "to", id);
+    const data = optionalHex(candidate.data, "data", id);
+    if (to === undefined && data === undefined) {
+      fail(`item ${id} (sign) must set "to" for a transfer/call or "data" for a bare create`);
+    }
+    const gasLimit = optionalUint(candidate.gasLimit, "gasLimit", id);
+    const expectAddress = optionalAddress(candidate.expectAddress, "expectAddress", id);
+    return {
+      id,
+      chain,
+      kind,
+      valueWei: requireUint(candidate.valueWei ?? "0", "valueWei", id),
+      ...(to !== undefined ? { to } : {}),
+      ...(data !== undefined ? { data } : {}),
+      ...(gasLimit !== undefined ? { gasLimit } : {}),
+      ...(expectAddress !== undefined ? { expectAddress } : {}),
+    };
+  }
+
+  if (kind === "presigned") {
+    if (typeof candidate.rawTx !== "string" || !RAW_TX_PATTERN.test(candidate.rawTx)) {
+      fail(`item ${id} (presigned) rawTx must be a 0x-prefixed raw transaction`);
+    }
+    const expectAddress = optionalAddress(candidate.expectAddress, "expectAddress", id);
+    return {
+      id,
+      chain,
+      kind,
+      rawTx: candidate.rawTx,
+      ...(expectAddress !== undefined ? { expectAddress } : {}),
+    };
+  }
+
+  if (kind === "script") {
+    if (typeof candidate.script !== "string" || candidate.script.length === 0) {
+      fail(`item ${id} (script) must set a non-empty "script" path`);
+    }
+    if (candidate.script.includes("..")) {
+      fail(`item ${id} (script) path must not contain ".."`);
+    }
+    return { id, chain, kind, script: candidate.script };
+  }
+
+  fail(`item ${id} kind must be "sign", "presigned", or "script", got: ${JSON.stringify(kind)}`);
+}
+
+export function parseBootstrapManifest(raw: string): BootstrapManifest {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    fail(`invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    fail("root must be an object");
+  }
+  const candidate = parsed as Record<string, unknown>;
+  if (candidate.version !== 1) fail(`version must be 1, got: ${JSON.stringify(candidate.version)}`);
+  if (!Array.isArray(candidate.items)) fail("items must be an array");
+
+  const items = candidate.items.map((item, index) => parseItem(item, index));
+  const seen = new Set<string>();
+  for (const item of items) {
+    if (seen.has(item.id)) fail(`duplicate item id ${item.id}`);
+    seen.add(item.id);
+  }
+  return { version: 1, items };
+}
+
+// Normalized, deterministic serialization for the identity hash. Field order is
+// fixed by the explicit per-kind mapping in parseItem, so JSON.stringify over the
+// parsed items is stable for identical manifests.
+export function bootstrapManifestHash(manifest: BootstrapManifest): string {
+  return keccak256(toUtf8Bytes(JSON.stringify(manifest)));
+}

--- a/contracts/forge-deployer/src/checkpoint.ts
+++ b/contracts/forge-deployer/src/checkpoint.ts
@@ -2,7 +2,7 @@ import { getAddress, isAddress, keccak256, toUtf8Bytes } from "ethers";
 
 import { ChainName, DeploymentStep, StepId } from "./address-plan";
 
-export const SCHEMA_VERSION = 2;
+export const SCHEMA_VERSION = 3;
 export const DEPLOYMENT_PROFILE = "forge-dev-v1";
 
 export interface CheckpointIdentity {
@@ -15,6 +15,9 @@ export interface CheckpointIdentity {
   signers: { l1: string; l2: string };
   startingNonces: { l1: number; l2: number };
   configurationHash: string;
+  // keccak256 of the normalized bootstrap manifest. ZeroHash when no manifest is
+  // configured. Changing the manifest against an existing checkpoint fails closed.
+  bootstrapHash: string;
 }
 
 interface DeploymentConfiguration {
@@ -52,11 +55,24 @@ export interface InFlightDeployment {
   expectedAddress: string;
 }
 
+// A completed custom bootstrap item. `address` is present only for items that
+// deploy a contract (sign create or presigned/script with expectAddress).
+export interface CompletedBootstrapItem {
+  kind: "sign" | "presigned" | "script";
+  chain: ChainName;
+  transactionHash: string;
+  blockNumber: number;
+  chainId: string;
+  address?: string;
+}
+
 export interface DeploymentCheckpoint extends CheckpointIdentity {
   expectedDeployments: Record<string, ExpectedDeployment>;
   deployments: Record<string, CompletedDeployment>;
   inFlightDeployments: Record<string, InFlightDeployment>;
   completedSteps: StepId[];
+  // Completed custom bootstrap items keyed by `bootstrap.<id>`.
+  bootstrap: Record<string, CompletedBootstrapItem>;
   createdAt: string;
   updatedAt: string;
 }
@@ -117,6 +133,7 @@ export function createCheckpoint(input: CreateCheckpointInput): DeploymentCheckp
     deployments: {},
     inFlightDeployments: {},
     completedSteps: [],
+    bootstrap: {},
     createdAt: now,
     updatedAt: now,
   };
@@ -144,6 +161,7 @@ export function assertCheckpointCompatible(checkpoint: DeploymentCheckpoint, ide
   assertEqual(checkpoint.startingNonces.l1, expected.startingNonces.l1, "L1 starting nonce");
   assertEqual(checkpoint.startingNonces.l2, expected.startingNonces.l2, "L2 starting nonce");
   assertEqual(checkpoint.configurationHash.toLowerCase(), expected.configurationHash, "deployment configuration");
+  assertEqual(checkpoint.bootstrapHash.toLowerCase(), expected.bootstrapHash.toLowerCase(), "bootstrap manifest");
 }
 
 export function assertNoInFlightDeployments(checkpoint: DeploymentCheckpoint): void {
@@ -178,6 +196,28 @@ export function parseCheckpoint(raw: string): DeploymentCheckpoint {
     !Array.isArray(candidate.completedSteps)
   ) {
     throw new Error("checkpoint JSON is missing required fields");
+  }
+  if (typeof candidate.bootstrapHash !== "string" || !/^0x[0-9a-fA-F]{64}$/.test(candidate.bootstrapHash)) {
+    throw new Error("checkpoint JSON has an invalid or missing bootstrap hash");
+  }
+  if (!candidate.bootstrap || typeof candidate.bootstrap !== "object" || Array.isArray(candidate.bootstrap)) {
+    throw new Error("checkpoint JSON has an invalid or missing bootstrap record");
+  }
+  for (const [key, record] of Object.entries(candidate.bootstrap)) {
+    if (
+      typeof record !== "object" ||
+      record === null ||
+      (record.kind !== "sign" && record.kind !== "presigned" && record.kind !== "script") ||
+      (record.chain !== "l1" && record.chain !== "l2") ||
+      !/^0x[0-9a-fA-F]{64}$/.test(record.transactionHash) ||
+      !Number.isSafeInteger(record.blockNumber) ||
+      record.blockNumber < 0 ||
+      typeof record.chainId !== "string" ||
+      !/^[0-9]+$/.test(record.chainId) ||
+      (record.address !== undefined && !isAddress(record.address))
+    ) {
+      throw new Error(`checkpoint contains invalid bootstrap record ${key}`);
+    }
   }
   if (
     !candidate.startingNonces ||

--- a/contracts/forge-deployer/src/cli.ts
+++ b/contracts/forge-deployer/src/cli.ts
@@ -1,4 +1,5 @@
-import { loadConfig, sanitizeText } from "./config";
+import { L2_DETERMINISTIC_PROXY_FACTORY_KEY } from "./address-plan";
+import { loadConfig, sanitizeText, SENSITIVE_ENV_VAR_NAMES } from "./config";
 import { runDeployment } from "./runner";
 import { createCheckpointStore } from "./store";
 
@@ -11,13 +12,14 @@ async function main(): Promise<void> {
     l2MessageService: checkpoint.deployments["l2-message-service.proxy"]?.address,
     l1TokenBridge: checkpoint.deployments["l1-token-bridge.proxy"]?.address,
     l2TokenBridge: checkpoint.deployments["l2-token-bridge.proxy"]?.address,
+    deterministicDeploymentProxy: checkpoint.deployments[L2_DETERMINISTIC_PROXY_FACTORY_KEY]?.address,
   };
   console.log(`Contract deployment complete: ${JSON.stringify(publicAddresses)}`);
 }
 
 main().catch((error: unknown) => {
   const sensitiveValues: string[] = [];
-  for (const name of ["L1_DEPLOYER_PRIVATE_KEY", "L2_DEPLOYER_PRIVATE_KEY", "L1_RPC_URL", "L2_RPC_URL"]) {
+  for (const name of SENSITIVE_ENV_VAR_NAMES) {
     if (process.env[name]) sensitiveValues.push(process.env[name]!);
   }
   const detail = error instanceof Error ? (error.stack ?? error.message) : String(error);

--- a/contracts/forge-deployer/src/config.ts
+++ b/contracts/forge-deployer/src/config.ts
@@ -1,6 +1,22 @@
 import { getAddress, isAddress, ZeroAddress } from "ethers";
 
 const UINT256_MAX = (1n << 256n) - 1n;
+const SECONDS_PER_DAY = 86_400;
+const DEFAULT_RATE_LIMIT_PERIOD_SECONDS = SECONDS_PER_DAY.toString();
+// 1000 tokens at 18 decimals.
+const DEFAULT_RATE_LIMIT_AMOUNT_WEI = (1000n * 10n ** 18n).toString();
+
+/**
+ * Env vars whose values must never appear in logs. Shared with `cli.ts` so
+ * the top-level error handler can redact them even when `loadConfig()`
+ * itself throws before producing a `DeployerConfig.sensitiveValues`.
+ */
+export const SENSITIVE_ENV_VAR_NAMES = [
+  "L1_DEPLOYER_PRIVATE_KEY",
+  "L2_DEPLOYER_PRIVATE_KEY",
+  "L1_RPC_URL",
+  "L2_RPC_URL",
+] as const;
 
 export interface DeployerConfig {
   l1RpcUrl: string;
@@ -26,6 +42,8 @@ export interface DeployerConfig {
   l1DeployGasPriceWei?: string;
   l2DeployGasPriceWei?: string;
   checkpointFile?: string;
+  bootstrapManifestFile?: string;
+  bootstrapScriptsDir?: string;
 }
 
 export interface RoleConfig {
@@ -119,12 +137,12 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): DeployerConfig
   const l2StartingNonce = requireStartingNonce(env, "L2_STARTING_NONCE");
   const artifactDigest = requireSha256Digest(env, "DEPLOYER_IMAGE_DIGEST");
   const rateLimitPeriod = assertUint256(
-    optionalValue(env, "CONTRACT_RATE_LIMIT_PERIOD") ?? "86400",
+    optionalValue(env, "CONTRACT_RATE_LIMIT_PERIOD") ?? DEFAULT_RATE_LIMIT_PERIOD_SECONDS,
     "CONTRACT_RATE_LIMIT_PERIOD",
     false,
   );
   const rateLimitAmount = assertUint256(
-    optionalValue(env, "CONTRACT_RATE_LIMIT_AMOUNT") ?? "1000000000000000000000",
+    optionalValue(env, "CONTRACT_RATE_LIMIT_AMOUNT") ?? DEFAULT_RATE_LIMIT_AMOUNT_WEI,
     "CONTRACT_RATE_LIMIT_AMOUNT",
     false,
   );
@@ -156,6 +174,8 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): DeployerConfig
     ["l1DeployGasPriceWei", optionalValue(env, "L1_DEPLOY_GAS_PRICE_WEI")],
     ["l2DeployGasPriceWei", optionalValue(env, "L2_DEPLOY_GAS_PRICE_WEI")],
     ["checkpointFile", optionalValue(env, "CHECKPOINT_FILE")],
+    ["bootstrapManifestFile", optionalValue(env, "BOOTSTRAP_MANIFEST_FILE")],
+    ["bootstrapScriptsDir", optionalValue(env, "BOOTSTRAP_SCRIPTS_DIR")],
   ];
   for (const [key, value] of optionalEntries) {
     if (value !== undefined) Object.assign(config, { [key]: value });

--- a/contracts/forge-deployer/src/decision.ts
+++ b/contracts/forge-deployer/src/decision.ts
@@ -1,17 +1,39 @@
 import { DeploymentStep } from "./address-plan";
 import { DeploymentCheckpoint } from "./checkpoint";
 
-export type StepAction = { action: "deploy" | "recover" | "skip" };
+/**
+ * "adopt" is distinct from "recover": "recover" marks a step complete when
+ * every deployment already has a checkpoint record (only the completion
+ * marker is missing). "adopt" is for steps whose deployments can legitimately
+ * exist on-chain with *no* checkpoint record at all (e.g. a well-known,
+ * non-nonce-derived address a chain preinstalls in genesis) — the caller must
+ * synthesize checkpoint records for each deployment before marking it complete.
+ */
+export type StepAction = { action: "deploy" | "recover" | "skip" | "adopt" };
+
+/**
+ * Whether on-chain code at a step's well-known (non-nonce-derived) address is
+ * the expected contract. Only relevant for steps that can be legitimately
+ * pre-deployed outside of this tool's own deployment flow.
+ */
+export type WellKnownCodeStatus = "match" | "mismatch";
 
 interface DecideStepActionInput {
   step: DeploymentStep;
   checkpoint: DeploymentCheckpoint;
   codeByKey: Record<string, boolean>;
   currentNonce: number;
+  /**
+   * Present only for steps whose deployments live at a well-known address
+   * rather than a nonce-derived one. Called only when code exists without a
+   * checkpoint record, to distinguish "the expected contract is already
+   * there" from "something unexpected occupies this address".
+   */
+  verifyWellKnownCode?: () => Promise<WellKnownCodeStatus>;
 }
 
-export function decideStepAction(input: DecideStepActionInput): StepAction {
-  const { step, checkpoint, codeByKey, currentNonce } = input;
+export async function decideStepAction(input: DecideStepActionInput): Promise<StepAction> {
+  const { step, checkpoint, codeByKey, currentNonce, verifyWellKnownCode } = input;
   const records = step.deployments.map((deployment) => checkpoint.deployments[deployment.key]);
 
   for (const [index, record] of records.entries()) {
@@ -34,6 +56,13 @@ export function decideStepAction(input: DecideStepActionInput): StepAction {
 
   if (hasAllCode) {
     if (!hasAllRecords) {
+      if (verifyWellKnownCode) {
+        const status = await verifyWellKnownCode();
+        if (status === "mismatch") {
+          throw new Error(`refusing to recover ${step.id}; unexpected bytecode at its well-known address`);
+        }
+        return { action: "adopt" };
+      }
       throw new Error(`uncheckpointed code detected for ${step.id}; refusing to infer contract identity`);
     }
     return checkpoint.completedSteps.includes(step.id) ? { action: "skip" } : { action: "recover" };

--- a/contracts/forge-deployer/src/process-runner.ts
+++ b/contracts/forge-deployer/src/process-runner.ts
@@ -1,5 +1,5 @@
 import { getAddress } from "ethers";
-import { spawn } from "node:child_process";
+import { ChildProcess, spawn } from "node:child_process";
 import { createInterface } from "node:readline";
 
 import { DeploymentStep } from "./address-plan";
@@ -27,6 +27,21 @@ interface DeploymentIntentMessage {
   type: "lineth-deployment-intent";
   id: string;
   contractName: string;
+}
+
+// A completed custom bootstrap item reported by the bootstrap step child.
+interface BootstrapRecordMessage {
+  type: "lineth-bootstrap-record";
+  id: string;
+  record: {
+    itemId: string;
+    kind: "sign" | "presigned" | "script";
+    chain: "l1" | "l2";
+    transactionHash: string;
+    blockNumber: number;
+    chainId: string;
+    address?: string;
+  };
 }
 
 const INHERITED_CHILD_ENVIRONMENT = [
@@ -70,21 +85,54 @@ function isDeploymentIntentMessage(message: unknown): message is DeploymentInten
   );
 }
 
-function expectedDeployment(input: RunStepScriptInput, contractName: string) {
-  const matches = input.step.deployments.filter((deployment) => deployment.contractName === contractName);
+function isBootstrapRecordMessage(message: unknown): message is BootstrapRecordMessage {
+  if (typeof message !== "object" || message === null) return false;
+  const candidate = message as Partial<BootstrapRecordMessage>;
+  return (
+    candidate.type === "lineth-bootstrap-record" &&
+    typeof candidate.id === "string" &&
+    !!candidate.record &&
+    typeof candidate.record.itemId === "string"
+  );
+}
+
+function expectedDeployment(step: DeploymentStep, contractName: string) {
+  const matches = step.deployments.filter((deployment) => deployment.contractName === contractName);
   if (matches.length !== 1) {
-    throw new Error(`${input.step.id} emitted unexpected or ambiguous deployment ${contractName}`);
+    throw new Error(`${step.id} emitted unexpected or ambiguous deployment ${contractName}`);
   }
   return matches[0]!;
 }
 
-export async function runStepScript(input: RunStepScriptInput): Promise<void> {
+interface RunChildScriptInput {
+  scriptPath: string;
+  environment: NodeJS.ProcessEnv;
+  sensitiveValues: readonly string[];
+  /** Used in "failed to capture output for X" and "X exited with code N" errors. */
+  errorContextLabel: string;
+  /**
+   * Invoked for every IPC message the child sends, in order (never
+   * concurrently). Throwing aborts the run: the child is killed and the
+   * thrown error propagates once the child has fully exited.
+   */
+  onMessage: (message: unknown, child: ChildProcess) => Promise<void> | void;
+}
+
+/**
+ * Owns the spawn/stdio/close/kill lifecycle shared by every forge-deployer
+ * child script (deployment steps and the bootstrap step): pipes stdout/stderr
+ * through `sanitizeText`, serializes IPC message handling so persistence
+ * never races itself, and kills the child if message handling throws.
+ * Callers only need to supply an `onMessage` handler for their own message
+ * shape and any post-run invariants (e.g. expected record counts).
+ */
+async function runChildScript(input: RunChildScriptInput): Promise<void> {
   const child = spawn(process.execPath, [input.scriptPath], {
     env: childEnvironment(input.environment),
     stdio: ["ignore", "pipe", "pipe", "ipc"],
   });
   const { stdout, stderr } = child;
-  if (!stdout || !stderr) throw new Error(`failed to capture output for ${input.step.id}`);
+  if (!stdout || !stderr) throw new Error(`failed to capture output for ${input.errorContextLabel}`);
 
   const closePromise = new Promise<number>((resolve, reject) => {
     child.once("error", reject);
@@ -96,72 +144,11 @@ export async function runStepScript(input: RunStepScriptInput): Promise<void> {
     }
   })();
 
-  const recordedKeys = new Set<string>();
   let messageProcessing = Promise.resolve();
   let messageProcessingError: unknown;
   child.on("message", (message: unknown) => {
-    if (!isDeploymentIntentMessage(message) && !isDeploymentRecordMessage(message)) return;
     messageProcessing = messageProcessing
-      .then(async () => {
-        try {
-          if (isDeploymentIntentMessage(message)) {
-            const { id, contractName } = message;
-            const expected = expectedDeployment(input, contractName);
-            if (input.checkpoint.deployments[expected.key] || input.checkpoint.inFlightDeployments[expected.key]) {
-              throw new Error(`${input.step.id} requested ${contractName} twice`);
-            }
-            input.checkpoint.inFlightDeployments[expected.key] = {
-              stepId: input.step.id,
-              chain: input.step.chain,
-              contractName: expected.contractName,
-              nonce: expected.nonce,
-              expectedAddress: getAddress(expected.expectedAddress),
-            };
-            await input.store.save(input.checkpoint);
-            child.send({ type: "lineth-deployment-intent-ack", id });
-            return;
-          }
-
-          const { id, record } = message;
-          const expected = expectedDeployment(input, record.contractName);
-          if (recordedKeys.has(expected.key) || input.checkpoint.deployments[expected.key]) {
-            throw new Error(`${input.step.id} emitted ${record.contractName} twice`);
-          }
-          if (!input.checkpoint.inFlightDeployments[expected.key]) {
-            throw new Error(`${input.step.id} emitted ${record.contractName} without a durable deployment intent`);
-          }
-          if (getAddress(record.address) !== getAddress(expected.expectedAddress)) {
-            throw new Error(
-              `${input.step.id} deployed ${record.contractName} at ${record.address}; expected ${expected.expectedAddress}`,
-            );
-          }
-          const expectedChainId = input.checkpoint.chainIds[input.step.chain];
-          if (record.chainId !== expectedChainId) {
-            throw new Error(
-              `${input.step.id} emitted chain ID ${record.chainId} for ${record.contractName}; expected ${expectedChainId}`,
-            );
-          }
-
-          input.checkpoint.deployments[expected.key] = {
-            address: getAddress(record.address),
-            transactionHash: record.transactionHash,
-            blockNumber: record.blockNumber,
-            chainId: record.chainId,
-            recovered: false,
-          };
-          delete input.checkpoint.inFlightDeployments[expected.key];
-          await input.store.save(input.checkpoint);
-          recordedKeys.add(expected.key);
-          child.send({ type: "lineth-deployment-record-ack", id });
-        } catch (error) {
-          child.send({
-            type: isDeploymentIntentMessage(message) ? "lineth-deployment-intent-ack" : "lineth-deployment-record-ack",
-            id: message.id,
-            error: "deployment checkpoint persistence failed",
-          });
-          throw error;
-        }
-      })
+      .then(() => input.onMessage(message, child))
       .catch((error: unknown) => {
         messageProcessingError ??= error;
         child.kill("SIGTERM");
@@ -181,10 +168,142 @@ export async function runStepScript(input: RunStepScriptInput): Promise<void> {
   const [exitCode] = await Promise.all([closePromise, stderrPromise]);
   await messageProcessing;
   if (messageProcessingError) throw messageProcessingError;
-  if (exitCode !== 0) throw new Error(`${input.step.id} deploy script exited with code ${exitCode}`);
+  if (exitCode !== 0) throw new Error(`${input.errorContextLabel} exited with code ${exitCode}`);
+}
+
+export async function runStepScript(input: RunStepScriptInput): Promise<void> {
+  const recordedKeys = new Set<string>();
+
+  await runChildScript({
+    scriptPath: input.scriptPath,
+    environment: input.environment,
+    sensitiveValues: input.sensitiveValues,
+    errorContextLabel: `${input.step.id} deploy script`,
+    onMessage: async (message, child) => {
+      if (!isDeploymentIntentMessage(message) && !isDeploymentRecordMessage(message)) return;
+      try {
+        if (isDeploymentIntentMessage(message)) {
+          const { id, contractName } = message;
+          const expected = expectedDeployment(input.step, contractName);
+          if (input.checkpoint.deployments[expected.key] || input.checkpoint.inFlightDeployments[expected.key]) {
+            throw new Error(`${input.step.id} requested ${contractName} twice`);
+          }
+          input.checkpoint.inFlightDeployments[expected.key] = {
+            stepId: input.step.id,
+            chain: input.step.chain,
+            contractName: expected.contractName,
+            nonce: expected.nonce,
+            expectedAddress: getAddress(expected.expectedAddress),
+          };
+          await input.store.save(input.checkpoint);
+          child.send({ type: "lineth-deployment-intent-ack", id });
+          return;
+        }
+
+        const { id, record } = message;
+        const expected = expectedDeployment(input.step, record.contractName);
+        if (recordedKeys.has(expected.key) || input.checkpoint.deployments[expected.key]) {
+          throw new Error(`${input.step.id} emitted ${record.contractName} twice`);
+        }
+        if (!input.checkpoint.inFlightDeployments[expected.key]) {
+          throw new Error(`${input.step.id} emitted ${record.contractName} without a durable deployment intent`);
+        }
+        if (getAddress(record.address) !== getAddress(expected.expectedAddress)) {
+          throw new Error(
+            `${input.step.id} deployed ${record.contractName} at ${record.address}; expected ${expected.expectedAddress}`,
+          );
+        }
+        const expectedChainId = input.checkpoint.chainIds[input.step.chain];
+        if (record.chainId !== expectedChainId) {
+          throw new Error(
+            `${input.step.id} emitted chain ID ${record.chainId} for ${record.contractName}; expected ${expectedChainId}`,
+          );
+        }
+
+        input.checkpoint.deployments[expected.key] = {
+          address: getAddress(record.address),
+          transactionHash: record.transactionHash,
+          blockNumber: record.blockNumber,
+          chainId: record.chainId,
+          recovered: false,
+        };
+        delete input.checkpoint.inFlightDeployments[expected.key];
+        await input.store.save(input.checkpoint);
+        recordedKeys.add(expected.key);
+        child.send({ type: "lineth-deployment-record-ack", id });
+      } catch (error) {
+        child.send({
+          type: isDeploymentIntentMessage(message) ? "lineth-deployment-intent-ack" : "lineth-deployment-record-ack",
+          id: message.id,
+          error: error instanceof Error ? error.message : "deployment checkpoint persistence failed",
+        });
+        throw error;
+      }
+    },
+  });
+
   if (recordedKeys.size !== input.step.deployments.length) {
     throw new Error(
       `${input.step.id} emitted ${recordedKeys.size} deployment records; expected ${input.step.deployments.length}`,
     );
   }
+}
+
+interface RunBootstrapScriptInput {
+  scriptPath: string;
+  environment: NodeJS.ProcessEnv;
+  checkpoint: DeploymentCheckpoint;
+  store: CheckpointStore;
+  sensitiveValues: readonly string[];
+  // Keys of bootstrap items the child is expected to complete (not already done).
+  pendingItemKeys: string[];
+}
+
+// Runs the custom bootstrap step child. Unlike runStepScript there is no
+// per-broadcast intent dance: bootstrap items may be plain transfers, keyless
+// broadcasts, or operator scripts, so the child reports each completed item via
+// a `lineth-bootstrap-record` message which the parent durably checkpoints.
+export async function runBootstrapScript(input: RunBootstrapScriptInput): Promise<void> {
+  await runChildScript({
+    scriptPath: input.scriptPath,
+    environment: input.environment,
+    sensitiveValues: input.sensitiveValues,
+    errorContextLabel: "bootstrap step script",
+    onMessage: async (message, child) => {
+      if (!isBootstrapRecordMessage(message)) return;
+      try {
+        const { id, record } = message;
+        const key = `bootstrap.${record.itemId}`;
+        if (!input.pendingItemKeys.includes(key)) {
+          throw new Error(`bootstrap step emitted unexpected or already-recorded item ${record.itemId}`);
+        }
+        if (input.checkpoint.bootstrap[key]) {
+          throw new Error(`bootstrap step emitted ${record.itemId} twice`);
+        }
+        const expectedChainId = input.checkpoint.chainIds[record.chain];
+        if (record.chainId !== expectedChainId) {
+          throw new Error(
+            `bootstrap item ${record.itemId} emitted chain ID ${record.chainId}; expected ${expectedChainId}`,
+          );
+        }
+        input.checkpoint.bootstrap[key] = {
+          kind: record.kind,
+          chain: record.chain,
+          transactionHash: record.transactionHash,
+          blockNumber: record.blockNumber,
+          chainId: record.chainId,
+          ...(record.address ? { address: getAddress(record.address) } : {}),
+        };
+        await input.store.save(input.checkpoint);
+        child.send({ type: "lineth-bootstrap-record-ack", id });
+      } catch (error) {
+        child.send({
+          type: "lineth-bootstrap-record-ack",
+          id: message.id,
+          error: error instanceof Error ? error.message : "bootstrap checkpoint failed",
+        });
+        throw error;
+      }
+    },
+  });
 }

--- a/contracts/forge-deployer/src/runner.ts
+++ b/contracts/forge-deployer/src/runner.ts
@@ -1,8 +1,16 @@
-import { JsonRpcProvider, Wallet } from "ethers";
+import { JsonRpcProvider, Wallet, ZeroHash } from "ethers";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 
-import { buildAddressPlan, DeploymentStep, PlannedDeployment } from "./address-plan";
+import {
+  buildAddressPlan,
+  DeploymentStep,
+  L2_DETERMINISTIC_PROXY_STEP_ID,
+  PlannedDeployment,
+  StepId,
+} from "./address-plan";
+import { bootstrapManifestHash, parseBootstrapManifest } from "./bootstrap-manifest";
 import {
   assertCheckpointCompatible,
   assertNoInFlightDeployments,
@@ -14,11 +22,12 @@ import {
   SCHEMA_VERSION,
 } from "./checkpoint";
 import { DeployerConfig, resolveRoleConfig, RoleConfig } from "./config";
-import { decideStepAction } from "./decision";
+import { decideStepAction, WellKnownCodeStatus } from "./decision";
 import { assertDeployerCanPay } from "./funds";
 import { resolveGenesisTimestamp } from "./genesis";
-import { runStepScript } from "./process-runner";
+import { runBootstrapScript, runStepScript } from "./process-runner";
 import { CheckpointStore } from "./store";
+import { getDeterministicProxyCodeStatus } from "../../common/helpers/deterministicDeploymentProxy";
 import {
   feeBudgetPricePerGas,
   resolveL2DeployFeeOverrides,
@@ -33,9 +42,11 @@ interface ChainContext {
 }
 
 const PROFILE_DEPLOY_GAS_BUDGET = 50_000_000n;
+const DEFAULT_RPC_READY_TIMEOUT_MS = 300_000;
+const RPC_READY_POLL_INTERVAL_MS = 3_000;
 
 async function waitForRpc(provider: JsonRpcProvider, label: string): Promise<void> {
-  const timeoutMs = Number(process.env.RPC_READY_TIMEOUT_MS ?? "300000");
+  const timeoutMs = Number(process.env.RPC_READY_TIMEOUT_MS ?? DEFAULT_RPC_READY_TIMEOUT_MS);
   if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
     throw new Error("RPC_READY_TIMEOUT_MS must be a positive integer");
   }
@@ -47,11 +58,32 @@ async function waitForRpc(provider: JsonRpcProvider, label: string): Promise<voi
       return;
     } catch (error) {
       lastError = error;
-      await delay(3000);
+      await delay(RPC_READY_POLL_INTERVAL_MS);
     }
   }
   throw new Error(`${label} RPC was not ready within ${timeoutMs}ms`, { cause: lastError });
 }
+
+/**
+ * Verifies on-chain code at a step's well-known (non-nonce-derived) address
+ * matches the expected contract, collapsing "absent" into "mismatch" since
+ * this is only ever called after `codeByKey` already observed non-empty code
+ * — an "absent" result here means the code disappeared between reads, which
+ * is exactly the kind of inconsistency that should fail closed.
+ */
+async function verifyDeterministicProxyCode(provider: JsonRpcProvider): Promise<WellKnownCodeStatus> {
+  const status = await getDeterministicProxyCodeStatus(provider);
+  return status === "match" ? "match" : "mismatch";
+}
+
+// Registry of steps whose deployments may legitimately be pre-deployed at a
+// well-known address (see decision.ts's "adopt" action). Adding a future step
+// of this kind only requires a new entry here, not a new special case in the
+// deployment loop below.
+const WELL_KNOWN_CODE_VERIFIERS: Partial<Record<StepId, (provider: JsonRpcProvider) => Promise<WellKnownCodeStatus>>> =
+  {
+    [L2_DETERMINISTIC_PROXY_STEP_ID]: verifyDeterministicProxyCode,
+  };
 
 export function assertDistinctChainIds(l1ChainId: string, l2ChainId: string): void {
   if (l1ChainId === l2ChainId) throw new Error("L1 and L2 chain IDs must differ");
@@ -181,6 +213,14 @@ function buildStepEnvironment(
       L2_NONCE: step.startingNonce.toString(),
     };
   }
+  if (step.id === L2_DETERMINISTIC_PROXY_STEP_ID) {
+    return {
+      ...common,
+      RPC_URL: config.l2RpcUrl,
+      DEPLOYER_PRIVATE_KEY: config.l2PrivateKey,
+      L2_NONCE: step.startingNonce.toString(),
+    };
+  }
 
   const deployOnL1 = step.chain === "l1";
   return {
@@ -209,10 +249,23 @@ function recoverStep(checkpoint: DeploymentCheckpoint, step: DeploymentStep, cha
   if (!checkpoint.completedSteps.includes(step.id)) checkpoint.completedSteps.push(step.id);
 }
 
-export async function runDeployment(config: DeployerConfig, store: CheckpointStore): Promise<DeploymentCheckpoint> {
-  const context = await createChainContext(config);
+interface DeploymentIdentity {
+  identity: CheckpointIdentity;
+  roles: RoleConfig;
+  bootstrapManifest: ReturnType<typeof parseBootstrapManifest> | undefined;
+}
+
+// Derives the checkpoint identity (the fields that must match exactly between
+// runs for a checkpoint to be considered compatible) and the resolved roles
+// and bootstrap manifest needed later, without touching any checkpoint state.
+async function resolveDeploymentIdentity(config: DeployerConfig, context: ChainContext): Promise<DeploymentIdentity> {
   const roles = resolveRoleConfig(config, context.signers.l1, context.signers.l2);
   const l2GenesisTimestamp = await resolveGenesisTimestamp(context.l2Provider, config.l2GenesisTimestampOverride);
+  const bootstrapManifest = config.bootstrapManifestFile
+    ? parseBootstrapManifest(await readFile(config.bootstrapManifestFile, "utf8"))
+    : undefined;
+  const bootstrapHash = bootstrapManifest ? bootstrapManifestHash(bootstrapManifest) : ZeroHash;
+
   const identity: CheckpointIdentity = {
     profile: DEPLOYMENT_PROFILE,
     schemaVersion: SCHEMA_VERSION,
@@ -230,37 +283,154 @@ export async function runDeployment(config: DeployerConfig, store: CheckpointSto
       rateLimitAmount: config.rateLimitAmount,
       roles,
     }),
+    bootstrapHash,
   };
 
-  let checkpoint = await store.load();
-  if (checkpoint) {
-    assertCheckpointCompatible(checkpoint, identity);
-  } else {
-    const [currentL1Nonce, currentL2Nonce] = await Promise.all([
-      context.l1Provider.getTransactionCount(context.signers.l1, "pending"),
-      context.l2Provider.getTransactionCount(context.signers.l2, "pending"),
-    ]);
-    if (currentL1Nonce !== config.l1StartingNonce) {
-      throw new Error(
-        `no checkpoint and L1 signer nonce is ${currentL1Nonce}, expected ${config.l1StartingNonce}; refusing deployment`,
-      );
-    }
-    if (currentL2Nonce !== config.l2StartingNonce) {
-      throw new Error(
-        `no checkpoint and L2 signer nonce is ${currentL2Nonce}, expected ${config.l2StartingNonce}; refusing deployment`,
-      );
-    }
-    checkpoint = createCheckpoint({
-      ...identity,
-      plan: buildAddressPlan({
-        l1Signer: context.signers.l1,
-        l2Signer: context.signers.l2,
-        l1StartingNonce: config.l1StartingNonce,
-        l2StartingNonce: config.l2StartingNonce,
-      }),
-    });
-    await store.save(checkpoint);
+  return { identity, roles, bootstrapManifest };
+}
+
+// Loads an existing checkpoint (asserting it's compatible with the current
+// identity) or, on a fresh deployment, verifies the signer nonces match the
+// configured starting nonces before creating one.
+async function loadOrInitCheckpoint(
+  config: DeployerConfig,
+  context: ChainContext,
+  identity: CheckpointIdentity,
+  store: CheckpointStore,
+): Promise<DeploymentCheckpoint> {
+  const existing = await store.load();
+  if (existing) {
+    assertCheckpointCompatible(existing, identity);
+    return existing;
   }
+
+  const [currentL1Nonce, currentL2Nonce] = await Promise.all([
+    context.l1Provider.getTransactionCount(context.signers.l1, "pending"),
+    context.l2Provider.getTransactionCount(context.signers.l2, "pending"),
+  ]);
+  if (currentL1Nonce !== config.l1StartingNonce) {
+    throw new Error(
+      `no checkpoint and L1 signer nonce is ${currentL1Nonce}, expected ${config.l1StartingNonce}; refusing deployment`,
+    );
+  }
+  if (currentL2Nonce !== config.l2StartingNonce) {
+    throw new Error(
+      `no checkpoint and L2 signer nonce is ${currentL2Nonce}, expected ${config.l2StartingNonce}; refusing deployment`,
+    );
+  }
+
+  const checkpoint = createCheckpoint({
+    ...identity,
+    plan: buildAddressPlan({
+      l1Signer: context.signers.l1,
+      l2Signer: context.signers.l2,
+      l1StartingNonce: config.l1StartingNonce,
+      l2StartingNonce: config.l2StartingNonce,
+    }),
+  });
+  await store.save(checkpoint);
+  return checkpoint;
+}
+
+// Executes (or skips/recovers) a single deployment step. Mutates `checkpoint`
+// and `fundingVerified` in place, mirroring the durable-checkpoint-first
+// approach used throughout this module.
+async function executeStep(
+  step: DeploymentStep,
+  context: ChainContext,
+  config: DeployerConfig,
+  roles: RoleConfig,
+  checkpoint: DeploymentCheckpoint,
+  plan: DeploymentStep[],
+  store: CheckpointStore,
+  fundingVerified: { l1: boolean; l2: boolean },
+): Promise<void> {
+  const provider = step.chain === "l1" ? context.l1Provider : context.l2Provider;
+  const signer = step.chain === "l1" ? context.signers.l1 : context.signers.l2;
+  const chainId = step.chain === "l1" ? context.chainIds.l1 : context.chainIds.l2;
+  const [codeByKey, currentNonce] = await Promise.all([
+    inspectCode(provider, step.deployments),
+    provider.getTransactionCount(signer, "pending"),
+  ]);
+
+  const wellKnownCodeVerifier = WELL_KNOWN_CODE_VERIFIERS[step.id];
+  const decision = await decideStepAction({
+    step,
+    checkpoint,
+    codeByKey,
+    currentNonce,
+    ...(wellKnownCodeVerifier ? { verifyWellKnownCode: () => wellKnownCodeVerifier(provider) } : {}),
+  });
+
+  if (decision.action === "skip") {
+    console.log(`Verified ${step.id}; skipping deployment`);
+    return;
+  }
+  if (decision.action === "recover") {
+    recoverStep(checkpoint, step, chainId);
+    await store.save(checkpoint);
+    console.log(`Recovered ${step.id} from deterministic on-chain addresses`);
+    return;
+  }
+  if (decision.action === "adopt") {
+    // Code exists at a well-known (non-nonce-derived) address with no
+    // checkpoint record and has been verified to match the expected
+    // contract; synthesize records for each deployment and mark complete.
+    const blockNumber = await provider.getBlockNumber();
+    for (const deployment of step.deployments) {
+      checkpoint.deployments[deployment.key] = {
+        address: deployment.expectedAddress,
+        transactionHash: ZeroHash,
+        blockNumber,
+        chainId,
+        recovered: true,
+      };
+    }
+    if (!checkpoint.completedSteps.includes(step.id)) checkpoint.completedSteps.push(step.id);
+    await store.save(checkpoint);
+    console.log(`Recovered ${step.id}; on-chain code at its well-known address matched the expected contract`);
+    return;
+  }
+
+  if (!fundingVerified[step.chain]) {
+    if (step.chain === "l1") {
+      const [fees, balance] = await Promise.all([
+        resolveOneModelFeeOverrides(context.l1Provider, "L1_DEPLOY_GAS_PRICE_WEI"),
+        context.l1Provider.getBalance(context.signers.l1),
+      ]);
+      assertDeployerCanPay("L1", context.signers.l1, balance, fees, PROFILE_DEPLOY_GAS_BUDGET);
+    } else {
+      const fees = resolveL2DeployFeeOverrides();
+      const balance = feeBudgetPricePerGas(fees) === 0n ? 0n : await context.l2Provider.getBalance(context.signers.l2);
+      assertDeployerCanPay("L2", context.signers.l2, balance, fees, PROFILE_DEPLOY_GAS_BUDGET);
+    }
+    fundingVerified[step.chain] = true;
+  }
+
+  console.log(`Deploying ${step.id}`);
+  await runStepScript({
+    scriptPath: path.join(__dirname, "steps", `${step.script}.js`),
+    environment: buildStepEnvironment(step, config, roles, context, checkpoint, plan),
+    step,
+    checkpoint,
+    store,
+    sensitiveValues: config.sensitiveValues,
+  });
+  const verifiedCode = await inspectCode(provider, step.deployments);
+  if (!Object.values(verifiedCode).every(Boolean)) {
+    throw new Error(`${step.id} script completed but one or more expected addresses have no bytecode`);
+  }
+  if (!step.deployments.every((deployment) => checkpoint.deployments[deployment.key])) {
+    throw new Error(`${step.id} script completed without a durable record for every deployment`);
+  }
+  checkpoint.completedSteps.push(step.id);
+  await store.save(checkpoint);
+}
+
+export async function runDeployment(config: DeployerConfig, store: CheckpointStore): Promise<DeploymentCheckpoint> {
+  const context = await createChainContext(config);
+  const { identity, roles, bootstrapManifest } = await resolveDeploymentIdentity(config, context);
+  const checkpoint = await loadOrInitCheckpoint(config, context, identity, store);
 
   const plan = buildAddressPlan({
     l1Signer: context.signers.l1,
@@ -273,61 +443,59 @@ export async function runDeployment(config: DeployerConfig, store: CheckpointSto
 
   const fundingVerified = { l1: false, l2: false };
   for (const step of plan) {
-    const provider = step.chain === "l1" ? context.l1Provider : context.l2Provider;
-    const signer = step.chain === "l1" ? context.signers.l1 : context.signers.l2;
-    const chainId = step.chain === "l1" ? context.chainIds.l1 : context.chainIds.l2;
-    const [codeByKey, currentNonce] = await Promise.all([
-      inspectCode(provider, step.deployments),
-      provider.getTransactionCount(signer, "pending"),
-    ]);
-    const decision = decideStepAction({ step, checkpoint, codeByKey, currentNonce });
+    await executeStep(step, context, config, roles, checkpoint, plan, store, fundingVerified);
+  }
 
-    if (decision.action === "skip") {
-      console.log(`Verified ${step.id}; skipping deployment`);
-      continue;
-    }
-    if (decision.action === "recover") {
-      recoverStep(checkpoint, step, chainId);
-      await store.save(checkpoint);
-      console.log(`Recovered ${step.id} from deterministic on-chain addresses`);
-      continue;
-    }
+  await runBootstrapPhase(config, context, checkpoint, store, bootstrapManifest);
 
-    if (!fundingVerified[step.chain]) {
-      if (step.chain === "l1") {
-        const [fees, balance] = await Promise.all([
-          resolveOneModelFeeOverrides(context.l1Provider, "L1_DEPLOY_GAS_PRICE_WEI"),
-          context.l1Provider.getBalance(context.signers.l1),
-        ]);
-        assertDeployerCanPay("L1", context.signers.l1, balance, fees, PROFILE_DEPLOY_GAS_BUDGET);
-      } else {
-        const fees = resolveL2DeployFeeOverrides();
-        const balance =
-          feeBudgetPricePerGas(fees) === 0n ? 0n : await context.l2Provider.getBalance(context.signers.l2);
-        assertDeployerCanPay("L2", context.signers.l2, balance, fees, PROFILE_DEPLOY_GAS_BUDGET);
-      }
-      fundingVerified[step.chain] = true;
-    }
+  return checkpoint;
+}
 
-    console.log(`Deploying ${step.id}`);
-    await runStepScript({
-      scriptPath: path.join(__dirname, "steps", `${step.script}.js`),
-      environment: buildStepEnvironment(step, config, roles, context, checkpoint, plan),
-      step,
+// Runs the optional custom bootstrap phase after the 5 core steps. Items are
+// grouped by chain; each chain's pending items execute in one child process that
+// receives the deployer's current pending nonce for continuity. Idempotent:
+// items already in the checkpoint are filtered out before spawning.
+async function runBootstrapPhase(
+  config: DeployerConfig,
+  context: ChainContext,
+  checkpoint: DeploymentCheckpoint,
+  store: CheckpointStore,
+  manifest: ReturnType<typeof parseBootstrapManifest> | undefined,
+): Promise<void> {
+  if (!manifest || manifest.items.length === 0) return;
+
+  for (const chain of ["l1", "l2"] as const) {
+    const provider = chain === "l1" ? context.l1Provider : context.l2Provider;
+    const signer = chain === "l1" ? context.signers.l1 : context.signers.l2;
+    const privateKey = chain === "l1" ? config.l1PrivateKey : config.l2PrivateKey;
+
+    const chainItems = manifest.items.filter((item) => item.chain === chain);
+    const pending = chainItems.filter((item) => !checkpoint.bootstrap[`bootstrap.${item.id}`]);
+    if (pending.length === 0) continue;
+
+    const startNonce = await provider.getTransactionCount(signer, "pending");
+    console.log(`Running bootstrap phase on ${chain}: ${pending.length} item(s), starting nonce ${startNonce}`);
+    await runBootstrapScript({
+      scriptPath: path.join(__dirname, "steps", "bootstrap.js"),
+      environment: {
+        RPC_URL: chain === "l1" ? config.l1RpcUrl : config.l2RpcUrl,
+        DEPLOYER_PRIVATE_KEY: privateKey,
+        BOOTSTRAP_CHAIN: chain,
+        BOOTSTRAP_START_NONCE: startNonce.toString(),
+        BOOTSTRAP_ITEMS: JSON.stringify(pending),
+        ...optionalEnvironment("L1_DEPLOY_GAS_PRICE_WEI", config.l1DeployGasPriceWei),
+        ...optionalEnvironment("L2_DEPLOY_GAS_PRICE_WEI", config.l2DeployGasPriceWei),
+        ...optionalEnvironment("BOOTSTRAP_SCRIPTS_DIR", config.bootstrapScriptsDir),
+        // Forward the image-bundled ethers path so script children can resolve it.
+        ...optionalEnvironment("BOOTSTRAP_LIB_NODE_PATH", process.env.BOOTSTRAP_LIB_NODE_PATH),
+      },
       checkpoint,
       store,
       sensitiveValues: config.sensitiveValues,
+      pendingItemKeys: pending.map((item) => `bootstrap.${item.id}`),
     });
-    const verifiedCode = await inspectCode(provider, step.deployments);
-    if (!Object.values(verifiedCode).every(Boolean)) {
-      throw new Error(`${step.id} script completed but one or more expected addresses have no bytecode`);
-    }
-    if (!step.deployments.every((deployment) => checkpoint.deployments[deployment.key])) {
-      throw new Error(`${step.id} script completed without a durable record for every deployment`);
-    }
-    checkpoint.completedSteps.push(step.id);
-    await store.save(checkpoint);
+    // No trailing save here: runBootstrapScript's message handler already
+    // durably saves the checkpoint after every completed item, and nothing
+    // mutates the in-memory checkpoint between the last item and this point.
   }
-
-  return checkpoint;
 }

--- a/contracts/forge-deployer/src/steps/bootstrap-helpers.ts
+++ b/contracts/forge-deployer/src/steps/bootstrap-helpers.ts
@@ -1,0 +1,28 @@
+// Pure helpers extracted from bootstrap.ts so they're importable/testable
+// without triggering that file's top-level `main().catch(...)` entrypoint
+// (bootstrap.ts, like the other step scripts, is always run standalone via
+// process-runner.ts's spawn, never imported as a module).
+import path from "node:path";
+
+import { BootstrapItem } from "../bootstrap-manifest";
+
+// Resolves a script item's path within `scriptsDir`, rejecting any `item.script`
+// (e.g. containing `../`) that would resolve outside of it.
+export function resolveBootstrapScriptPath(scriptsDir: string, itemId: string, itemScript: string): string {
+  const root = path.resolve(scriptsDir);
+  const scriptPath = path.resolve(root, itemScript);
+  if (scriptPath !== root && !scriptPath.startsWith(root + path.sep)) {
+    throw new Error(`bootstrap script item ${itemId} resolves outside BOOTSTRAP_SCRIPTS_DIR`);
+  }
+  return scriptPath;
+}
+
+// Funding (sign) items first so funded external accounts exist before any
+// presigned tx that spends from them, then presigned, then scripts.
+export function orderBootstrapItems(items: BootstrapItem[]): BootstrapItem[] {
+  return [
+    ...items.filter((item) => item.kind === "sign"),
+    ...items.filter((item) => item.kind === "presigned"),
+    ...items.filter((item) => item.kind === "script"),
+  ];
+}

--- a/contracts/forge-deployer/src/steps/bootstrap.ts
+++ b/contracts/forge-deployer/src/steps/bootstrap.ts
@@ -113,12 +113,36 @@ async function runPresignedItem(item: PresignedBootstrapItem, context: Bootstrap
     const existing = await context.provider.getCode(item.expectAddress);
     if (existing !== "0x") {
       console.log(`bootstrap=${item.id} already deployed at ${item.expectAddress}; skipping`);
+      // A skip still needs a checkpoint record, otherwise a rerun would keep
+      // this item pending and re-check it every time. No real tx hash exists
+      // for a skip, so reuse the script item's sentinel to signal "done".
+      const blockNow = await context.provider.getBlockNumber();
+      await awaitBootstrapRecord({
+        itemId: item.id,
+        kind: item.kind,
+        chain: context.chain,
+        transactionHash: SCRIPT_ITEM_SENTINEL,
+        blockNumber: blockNow,
+        chainId: context.chainId,
+        address: item.expectAddress,
+      });
       return;
     }
   }
   const tx = await context.provider.broadcastTransaction(item.rawTx);
   const receipt = await tx.wait();
   if (!receipt || receipt.status !== 1) throw new Error(`bootstrap presigned item ${item.id} tx ${tx.hash} failed`);
+  // Verify code actually landed at expectAddress when one is pinned — a
+  // "successful" broadcast isn't proof the deployment happened (e.g. it could
+  // be a value-only transfer, or the raw tx wasn't actually a deployment).
+  if (item.expectAddress) {
+    const code = await context.provider.getCode(item.expectAddress);
+    if (code === "0x") {
+      throw new Error(
+        `bootstrap presigned item ${item.id} produced no bytecode at expectAddress ${item.expectAddress}`,
+      );
+    }
+  }
   await awaitBootstrapRecord({
     itemId: item.id,
     kind: item.kind,

--- a/contracts/forge-deployer/src/steps/bootstrap.ts
+++ b/contracts/forge-deployer/src/steps/bootstrap.ts
@@ -1,0 +1,206 @@
+// Executes the custom bootstrap phase: operator-supplied transactions that run
+// after the 5 core deployment steps. Three item kinds share one ordered pass:
+//   - sign:      deployer signs & submits (value send or contract create) using
+//                the runner-supplied starting nonce for continuity.
+//   - presigned: broadcast a keyless/external raw transaction as-is.
+//   - script:    spawn an operator child script that may create/sign/submit.
+// Items arrive via BOOTSTRAP_ITEMS (JSON array) filtered to this chain by the
+// runner. Each completed item emits a `lineth-bootstrap-record` IPC message so
+// the parent checkpoints it; completed items are skipped on rerun.
+import { ethers } from "ethers";
+import { spawn } from "node:child_process";
+
+import { sendAndAwaitAck } from "../../../common/helpers/deploymentRecord";
+import { getRequiredEnvVar } from "../../../common/helpers/environment";
+import { resolveL2DeployFeeOverrides, resolveOneModelFeeOverrides } from "../../../common/helpers/feeOverrides";
+import { BootstrapItem, PresignedBootstrapItem, ScriptBootstrapItem, SignBootstrapItem } from "../bootstrap-manifest";
+import { orderBootstrapItems, resolveBootstrapScriptPath } from "./bootstrap-helpers";
+
+interface BootstrapRunContext {
+  provider: ethers.JsonRpcProvider;
+  wallet: ethers.Wallet;
+  chain: "l1" | "l2";
+  chainId: string;
+  scriptsDir?: string | undefined;
+}
+
+// Placeholder transactionHash for script items, which perform arbitrary actions
+// with no single hash to record. Signals "completed; rerun must skip".
+const SCRIPT_ITEM_SENTINEL = "0x" + "00".repeat(32);
+
+let recordSequence = 0;
+
+function requireItems(): BootstrapItem[] {
+  const raw = getRequiredEnvVar("BOOTSTRAP_ITEMS");
+  const parsed: unknown = JSON.parse(raw);
+  if (!Array.isArray(parsed)) throw new Error("BOOTSTRAP_ITEMS must be a JSON array");
+  // Items were fully validated by the runner before serialization; trust them here.
+  return parsed as BootstrapItem[];
+}
+
+// Persist one completed bootstrap item with the checkpoint parent and wait for
+// its acknowledgement, via the same send/ack/disconnect handling as
+// awaitParentCheckpoint/awaitParentDeploymentIntent.
+async function awaitBootstrapRecord(record: {
+  itemId: string;
+  kind: BootstrapItem["kind"];
+  chain: "l1" | "l2";
+  transactionHash: string;
+  blockNumber: number;
+  chainId: string;
+  address?: string | undefined;
+}): Promise<void> {
+  console.log(
+    `bootstrap=${record.itemId} complete: tx=${record.transactionHash} block=${record.blockNumber}` +
+      (record.address ? ` address=${record.address}` : ""),
+  );
+  await sendAndAwaitAck(
+    (id) => ({ type: "lineth-bootstrap-record", id, record }),
+    "lineth-bootstrap-record-ack",
+    () => `${process.pid}-bootstrap-${recordSequence++}`,
+    "checkpoint parent disconnected before acknowledging bootstrap record",
+  );
+}
+
+async function runSignItem(item: SignBootstrapItem, nonce: number, context: BootstrapRunContext): Promise<void> {
+  const fees =
+    context.chain === "l2"
+      ? resolveL2DeployFeeOverrides()
+      : await resolveOneModelFeeOverrides(context.provider, "L1_DEPLOY_GAS_PRICE_WEI");
+  const request: ethers.TransactionRequest = {
+    value: BigInt(item.valueWei),
+    nonce,
+    ...(item.to !== undefined ? { to: item.to } : {}),
+    ...(item.data !== undefined ? { data: item.data } : {}),
+    ...(item.gasLimit !== undefined ? { gasLimit: BigInt(item.gasLimit) } : {}),
+    ...fees,
+  };
+  const tx = await context.wallet.sendTransaction(request);
+  const receipt = await tx.wait();
+  if (!receipt || receipt.status !== 1) throw new Error(`bootstrap sign item ${item.id} tx ${tx.hash} failed`);
+
+  let address = item.expectAddress;
+  if (item.to === undefined) {
+    // Bare CREATE: the deployed address is receipt.contractAddress. Assert it
+    // matches the pinned expectAddress when one is supplied.
+    const deployed = receipt.contractAddress;
+    if (!deployed) throw new Error(`bootstrap sign create ${item.id} tx ${tx.hash} returned no contract address`);
+    if (address && deployed.toLowerCase() !== address.toLowerCase()) {
+      throw new Error(`bootstrap sign create ${item.id} deployed at ${deployed}; expected ${address}`);
+    }
+    address = deployed;
+  } else if (address) {
+    // Contract call (e.g. a CREATE2 deploy through the deterministic proxy):
+    // receipt.contractAddress is null, so verify code landed at expectAddress.
+    const code = await context.provider.getCode(address);
+    if (code === "0x") {
+      throw new Error(`bootstrap sign item ${item.id} produced no bytecode at expectAddress ${address}`);
+    }
+  }
+  await awaitBootstrapRecord({
+    itemId: item.id,
+    kind: item.kind,
+    chain: context.chain,
+    transactionHash: tx.hash,
+    blockNumber: receipt.blockNumber,
+    chainId: context.chainId,
+    address,
+  });
+}
+
+async function runPresignedItem(item: PresignedBootstrapItem, context: BootstrapRunContext): Promise<void> {
+  if (item.expectAddress) {
+    const existing = await context.provider.getCode(item.expectAddress);
+    if (existing !== "0x") {
+      console.log(`bootstrap=${item.id} already deployed at ${item.expectAddress}; skipping`);
+      return;
+    }
+  }
+  const tx = await context.provider.broadcastTransaction(item.rawTx);
+  const receipt = await tx.wait();
+  if (!receipt || receipt.status !== 1) throw new Error(`bootstrap presigned item ${item.id} tx ${tx.hash} failed`);
+  await awaitBootstrapRecord({
+    itemId: item.id,
+    kind: item.kind,
+    chain: context.chain,
+    transactionHash: tx.hash,
+    blockNumber: receipt.blockNumber,
+    chainId: context.chainId,
+    address: item.expectAddress,
+  });
+}
+
+async function runScriptItem(item: ScriptBootstrapItem, nonce: number, context: BootstrapRunContext): Promise<void> {
+  if (!context.scriptsDir) throw new Error(`bootstrap script item ${item.id} requires BOOTSTRAP_SCRIPTS_DIR`);
+  const scriptPath = resolveBootstrapScriptPath(context.scriptsDir, item.id, item.script);
+  const environment: NodeJS.ProcessEnv = {
+    RPC_URL: process.env.RPC_URL ?? "",
+    DEPLOYER_PRIVATE_KEY: process.env.DEPLOYER_PRIVATE_KEY ?? "",
+    BOOTSTRAP_ITEM_ID: item.id,
+    BOOTSTRAP_CHAIN: context.chain,
+    BOOTSTRAP_CHAIN_ID: context.chainId,
+    BOOTSTRAP_START_NONCE: nonce.toString(),
+    // Let operator scripts require libraries bundled into the image (ethers).
+    ...(process.env.BOOTSTRAP_LIB_NODE_PATH ? { NODE_PATH: process.env.BOOTSTRAP_LIB_NODE_PATH } : {}),
+  };
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath], { env: environment, stdio: ["ignore", "inherit", "inherit"] });
+    child.once("error", reject);
+    child.once("close", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`bootstrap script item ${item.id} exited with code ${code ?? 1}`));
+    });
+  });
+  // A script runs arbitrary actions (often many transactions), so there is no
+  // single hash to record. The sentinel marks the item complete so a rerun
+  // skips it; the script itself is responsible for idempotency of its own
+  // on-chain actions. Record the chain head it completed at for traceability.
+  const blockAfter = await context.provider.getBlockNumber();
+  await awaitBootstrapRecord({
+    itemId: item.id,
+    kind: item.kind,
+    chain: context.chain,
+    transactionHash: SCRIPT_ITEM_SENTINEL,
+    blockNumber: blockAfter,
+    chainId: context.chainId,
+  });
+}
+
+async function main(): Promise<void> {
+  const chain = process.env.BOOTSTRAP_CHAIN;
+  if (chain !== "l1" && chain !== "l2") throw new Error(`BOOTSTRAP_CHAIN must be "l1" or "l2", got: ${chain}`);
+  const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
+  const wallet = new ethers.Wallet(getRequiredEnvVar("DEPLOYER_PRIVATE_KEY"), provider);
+  const rawNonce = getRequiredEnvVar("BOOTSTRAP_START_NONCE");
+  if (!/^[0-9]+$/.test(rawNonce)) throw new Error(`BOOTSTRAP_START_NONCE must be a non-negative integer`);
+  let nonce = Number(rawNonce);
+  const chainId = (await provider.getNetwork()).chainId.toString();
+  const context: BootstrapRunContext = {
+    provider,
+    wallet,
+    chain,
+    chainId,
+    scriptsDir: process.env.BOOTSTRAP_SCRIPTS_DIR,
+  };
+
+  const items = requireItems();
+  const ordered = orderBootstrapItems(items);
+
+  for (const item of ordered) {
+    if (item.kind === "sign") {
+      await runSignItem(item, nonce, context);
+      nonce += 1;
+    } else if (item.kind === "presigned") {
+      await runPresignedItem(item, context);
+    } else {
+      await runScriptItem(item, nonce, context);
+      // A script may consume deployer nonces; resync from the chain.
+      nonce = await provider.getTransactionCount(wallet.address, "pending");
+    }
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/contracts/forge-deployer/src/steps/deterministic-deployment-proxy.ts
+++ b/contracts/forge-deployer/src/steps/deterministic-deployment-proxy.ts
@@ -1,0 +1,43 @@
+// Installs the EIP-7997 / Arachnid deterministic deployment proxy on L2.
+//
+// Thin glue over contracts/common/helpers/deterministicDeploymentProxy.ts.
+// The factory lands at a well-known constant address rather than a
+// nonce-derived CREATE address, so this step records the deployment via the
+// shared parent IPC channel instead of deployContractFromArtifacts.
+import { ethers } from "ethers";
+
+import { awaitParentCheckpoint, awaitParentDeploymentIntent } from "../../../common/helpers/deploymentRecord";
+import { ensureAndDescribeDeterministicDeploymentProxy } from "../../../common/helpers/deterministicDeploymentProxy";
+import { getRequiredEnvVar } from "../../../common/helpers/environment";
+import { resolveL2DeployFeeOverrides } from "../../../common/helpers/feeOverrides";
+
+const CONTRACT_NAME = "DeterministicDeploymentProxy";
+
+async function main(): Promise<void> {
+  const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
+  const wallet = new ethers.Wallet(getRequiredEnvVar("DEPLOYER_PRIVATE_KEY"), provider);
+  const rawNonce = getRequiredEnvVar("L2_NONCE");
+  if (!/^[0-9]+$/.test(rawNonce)) {
+    throw new Error(`L2_NONCE must be a non-negative integer, got: ${rawNonce}`);
+  }
+  const nonce = Number(rawNonce);
+  const fees = resolveL2DeployFeeOverrides();
+
+  await awaitParentDeploymentIntent(CONTRACT_NAME);
+  // On an early skip the factory already existed; the record reuses the
+  // current head as a stable block reference. On a real deploy it uses the
+  // broadcast tx's block (see ensureAndDescribeDeterministicDeploymentProxy).
+  const { record, formattedRecord } = await ensureAndDescribeDeterministicDeploymentProxy({
+    provider,
+    wallet,
+    fees,
+    nonce,
+  });
+  await awaitParentCheckpoint({ ...record, chainId: record.chainId.toString() });
+  console.log(formattedRecord);
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/contracts/forge-deployer/src/store.ts
+++ b/contracts/forge-deployer/src/store.ts
@@ -1,7 +1,9 @@
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import https from "node:https";
 import path from "node:path";
+import { setTimeout as wait } from "node:timers/promises";
 
+import { L2_DETERMINISTIC_PROXY_FACTORY_KEY } from "./address-plan";
 import { DeploymentCheckpoint, parseCheckpoint, touchCheckpoint } from "./checkpoint";
 import { DeployerConfig } from "./config";
 
@@ -10,6 +12,7 @@ const CHECKPOINT_DATA_KEY = "checkpoint.json";
 const SERVICE_ACCOUNT_PATH = "/var/run/secrets/kubernetes.io/serviceaccount";
 const KUBERNETES_WRITE_ATTEMPTS = 5;
 const KUBERNETES_REQUEST_TIMEOUT_MS = 10_000;
+const KUBERNETES_RETRY_BASE_DELAY_MS = 100;
 
 export interface CheckpointStore {
   load(): Promise<DeploymentCheckpoint | undefined>;
@@ -36,6 +39,7 @@ export function checkpointToConfigMapData(checkpoint: DeploymentCheckpoint): Rec
     ["l2-message-service", completedAddress(checkpoint, "l2-message-service.proxy")],
     ["l1-token-bridge", completedAddress(checkpoint, "l1-token-bridge.proxy")],
     ["l2-token-bridge", completedAddress(checkpoint, "l2-token-bridge.proxy")],
+    ["deterministic-deployment-proxy", completedAddress(checkpoint, L2_DETERMINISTIC_PROXY_FACTORY_KEY)],
   ];
   for (const [key, value] of publicAddresses) {
     if (value !== undefined) data[key] = value;
@@ -114,10 +118,6 @@ class KubernetesHttpError extends Error {
 }
 
 class KubernetesTransportError extends Error {}
-
-function wait(milliseconds: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, milliseconds));
-}
 
 export class KubernetesCheckpointStore implements CheckpointStore {
   private readonly host: string;
@@ -290,7 +290,7 @@ export class KubernetesCheckpointStore implements CheckpointStore {
             (error instanceof KubernetesHttpError && isRetryableKubernetesStatus(error.statusCode))) &&
           attempt < KUBERNETES_WRITE_ATTEMPTS;
         if (!shouldRetry) throw error;
-        await wait(100 * 2 ** (attempt - 1));
+        await wait(KUBERNETES_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1));
       }
     }
     throw new Error("Kubernetes ConfigMap write attempts exhausted");

--- a/contracts/forge-deployer/test/address-plan.test.ts
+++ b/contracts/forge-deployer/test/address-plan.test.ts
@@ -2,6 +2,7 @@ import { getCreateAddress } from "ethers";
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { ARACHNID_FACTORY } from "../../common/helpers/deterministicDeploymentProxy";
 import { buildAddressPlan } from "../src/address-plan";
 
 const L1_SIGNER = "0x1000000000000000000000000000000000000001";
@@ -22,6 +23,7 @@ test("builds the four-step deterministic deployment address plan", () => {
       ["l2-message-service", 3],
       ["l1-token-bridge", 5],
       ["l2-token-bridge", 5],
+      ["l2-deterministic-proxy", 1],
     ],
   );
   assert.equal(plan[0]?.deployments.at(-1)?.nonce, 14);
@@ -30,6 +32,16 @@ test("builds the four-step deterministic deployment address plan", () => {
   assert.equal(plan[3]?.deployments.at(-1)?.nonce, 27);
   assert.equal(plan[0]?.deployments.at(-1)?.expectedAddress, getCreateAddress({ from: L1_SIGNER, nonce: 14 }));
   assert.equal(plan[3]?.deployments.at(-1)?.expectedAddress, getCreateAddress({ from: L2_SIGNER, nonce: 27 }));
+
+  const proxy = plan[4];
+  assert.equal(proxy?.id, "l2-deterministic-proxy");
+  assert.equal(proxy?.chain, "l2");
+  // Funding send uses the nonce after the 8 L2 contract deployments (3 + 5).
+  assert.equal(proxy?.startingNonce, 28);
+  assert.equal(proxy?.deployments[0]?.nonce, 28);
+  assert.equal(proxy?.deployments[0]?.contractName, "DeterministicDeploymentProxy");
+  // Keyless pre-signed deployment: fixed well-known factory, not a CREATE address.
+  assert.equal(proxy?.deployments[0]?.expectedAddress, ARACHNID_FACTORY);
 });
 
 test("uses distinct stable keys for repeated infrastructure contracts", () => {

--- a/contracts/forge-deployer/test/bootstrap-helpers.test.ts
+++ b/contracts/forge-deployer/test/bootstrap-helpers.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+
+import { BootstrapItem } from "../src/bootstrap-manifest";
+import { orderBootstrapItems, resolveBootstrapScriptPath } from "../src/steps/bootstrap-helpers";
+
+test("resolveBootstrapScriptPath accepts a script inside scriptsDir", () => {
+  const scriptsDir = "/bootstrap/scripts";
+  const resolved = resolveBootstrapScriptPath(scriptsDir, "item-1", "deploy.js");
+  assert.equal(resolved, path.resolve(scriptsDir, "deploy.js"));
+});
+
+test("resolveBootstrapScriptPath accepts a script in a nested subdirectory", () => {
+  const scriptsDir = "/bootstrap/scripts";
+  const resolved = resolveBootstrapScriptPath(scriptsDir, "item-1", "nested/deploy.js");
+  assert.equal(resolved, path.resolve(scriptsDir, "nested/deploy.js"));
+});
+
+test("resolveBootstrapScriptPath rejects a script that escapes scriptsDir via ../", () => {
+  assert.throws(
+    () => resolveBootstrapScriptPath("/bootstrap/scripts", "item-1", "../outside.js"),
+    /resolves outside BOOTSTRAP_SCRIPTS_DIR/,
+  );
+});
+
+test("resolveBootstrapScriptPath rejects an absolute path outside scriptsDir", () => {
+  assert.throws(
+    () => resolveBootstrapScriptPath("/bootstrap/scripts", "item-1", "/etc/passwd"),
+    /resolves outside BOOTSTRAP_SCRIPTS_DIR/,
+  );
+});
+
+test("resolveBootstrapScriptPath rejects a sibling directory with a matching name prefix", () => {
+  // "/bootstrap/scripts-evil/x.js" starts with the string "/bootstrap/scripts"
+  // but is not inside it; the check must compare against root + path.sep.
+  assert.throws(
+    () => resolveBootstrapScriptPath("/bootstrap/scripts", "item-1", "../scripts-evil/x.js"),
+    /resolves outside BOOTSTRAP_SCRIPTS_DIR/,
+  );
+});
+
+function signItem(id: string): BootstrapItem {
+  return { kind: "sign", id, chain: "l2", valueWei: "0" };
+}
+function presignedItem(id: string): BootstrapItem {
+  return { kind: "presigned", id, chain: "l2", rawTx: "0x" };
+}
+function scriptItem(id: string): BootstrapItem {
+  return { kind: "script", id, chain: "l2", script: "x.js" };
+}
+
+test("orderBootstrapItems runs sign items first, then presigned, then scripts", () => {
+  const items: BootstrapItem[] = [scriptItem("s1"), presignedItem("p1"), signItem("sign1"), signItem("sign2")];
+  const ordered = orderBootstrapItems(items);
+  assert.deepEqual(
+    ordered.map((item) => item.id),
+    ["sign1", "sign2", "p1", "s1"],
+  );
+});
+
+test("orderBootstrapItems preserves relative order within each kind", () => {
+  const items: BootstrapItem[] = [signItem("sign2"), signItem("sign1"), scriptItem("s2"), scriptItem("s1")];
+  const ordered = orderBootstrapItems(items);
+  assert.deepEqual(
+    ordered.map((item) => item.id),
+    ["sign2", "sign1", "s2", "s1"],
+  );
+});
+
+test("orderBootstrapItems is a no-op on an already-ordered or empty list", () => {
+  assert.deepEqual(orderBootstrapItems([]), []);
+});

--- a/contracts/forge-deployer/test/bootstrap-manifest.test.ts
+++ b/contracts/forge-deployer/test/bootstrap-manifest.test.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { bootstrapManifestHash, parseBootstrapManifest } from "../src/bootstrap-manifest";
+
+const RAW_TX = `0x${"ab".repeat(64)}`;
+const ADDRESS = "0x1000000000000000000000000000000000000001";
+
+test("parses a manifest with all three item kinds", () => {
+  const manifest = parseBootstrapManifest(
+    JSON.stringify({
+      version: 1,
+      items: [
+        { id: "fund-relayer", kind: "sign", chain: "l2", to: ADDRESS, valueWei: "1000" },
+        { id: "deploy-factory", kind: "presigned", chain: "l2", rawTx: RAW_TX, expectAddress: ADDRESS },
+        { id: "extra", kind: "script", chain: "l1", script: "bootstrap/extra.js" },
+      ],
+    }),
+  );
+
+  assert.equal(manifest.version, 1);
+  assert.equal(manifest.items.length, 3);
+  assert.equal(manifest.items[0]?.kind, "sign");
+  assert.equal(manifest.items[1]?.kind, "presigned");
+  assert.equal(manifest.items[2]?.kind, "script");
+});
+
+test("normalizes addresses to checksummed form and defaults valueWei to zero", () => {
+  const manifest = parseBootstrapManifest(
+    JSON.stringify({
+      version: 1,
+      items: [{ id: "fund", kind: "sign", chain: "l2", to: ADDRESS.toLowerCase() }],
+    }),
+  );
+  const item = manifest.items[0];
+  assert.equal(item?.kind, "sign");
+  if (item?.kind === "sign") {
+    assert.equal(item.to, ADDRESS);
+    assert.equal(item.valueWei, "0");
+  }
+});
+
+test("rejects a sign item with neither to nor data, and allows to+data (CREATE2 proxy call)", () => {
+  assert.throws(
+    () => parseBootstrapManifest(JSON.stringify({ version: 1, items: [{ id: "x", kind: "sign", chain: "l2" }] })),
+    /must set "to" for a transfer\/call or "data" for a bare create/,
+  );
+  // to + data together is valid: a CREATE2 deploy through the deterministic
+  // proxy is a normal signed call to the factory carrying the encoded deploy data.
+  const proxyCall = parseBootstrapManifest(
+    JSON.stringify({
+      version: 1,
+      items: [{ id: "x", kind: "sign", chain: "l2", to: ADDRESS, data: "0x1234", expectAddress: ADDRESS }],
+    }),
+  );
+  assert.equal(proxyCall.items[0]?.kind, "sign");
+  // A bare create (data, no to) is allowed; expectAddress is optional and, when
+  // set, is asserted against receipt.contractAddress at execution time.
+  const create = parseBootstrapManifest(
+    JSON.stringify({ version: 1, items: [{ id: "x", kind: "sign", chain: "l2", data: "0x6000" }] }),
+  );
+  assert.equal(create.items[0]?.kind, "sign");
+});
+
+test("rejects duplicate ids, bad kinds, wrong version, and non-array items", () => {
+  const base = { id: "x", kind: "presigned", chain: "l2", rawTx: RAW_TX };
+  assert.throws(
+    () => parseBootstrapManifest(JSON.stringify({ version: 1, items: [base, base] })),
+    /duplicate item id x/,
+  );
+  assert.throws(
+    () => parseBootstrapManifest(JSON.stringify({ version: 1, items: [{ ...base, kind: "nope" }] })),
+    /kind must be "sign", "presigned", or "script"/,
+  );
+  assert.throws(() => parseBootstrapManifest(JSON.stringify({ version: 2, items: [] })), /version must be 1/);
+  assert.throws(() => parseBootstrapManifest(JSON.stringify({ version: 1, items: {} })), /items must be an array/);
+});
+
+test("rejects malformed fields per kind", () => {
+  assert.throws(
+    () =>
+      parseBootstrapManifest(
+        JSON.stringify({ version: 1, items: [{ id: "BAD ID", kind: "script", chain: "l2", script: "s.js" }] }),
+      ),
+    /item id must be lowercase kebab-case/,
+  );
+  assert.throws(
+    () =>
+      parseBootstrapManifest(
+        JSON.stringify({ version: 1, items: [{ id: "x", kind: "sign", chain: "l3", to: ADDRESS }] }),
+      ),
+    /chain must be "l1" or "l2"/,
+  );
+  assert.throws(
+    () =>
+      parseBootstrapManifest(
+        JSON.stringify({ version: 1, items: [{ id: "x", kind: "presigned", chain: "l2", rawTx: "nothex" }] }),
+      ),
+    /rawTx must be a 0x-prefixed raw transaction/,
+  );
+  assert.throws(
+    () =>
+      parseBootstrapManifest(
+        JSON.stringify({ version: 1, items: [{ id: "x", kind: "script", chain: "l2", script: "../escape.js" }] }),
+      ),
+    /must not contain "\.\."/,
+  );
+  assert.throws(
+    () =>
+      parseBootstrapManifest(
+        JSON.stringify({ version: 1, items: [{ id: "x", kind: "sign", chain: "l2", to: "0x1234" }] }),
+      ),
+    /to must be an Ethereum address/,
+  );
+});
+
+test("produces a stable, content-sensitive hash", () => {
+  const one = parseBootstrapManifest(
+    JSON.stringify({ version: 1, items: [{ id: "a", kind: "sign", chain: "l2", to: ADDRESS, valueWei: "1" }] }),
+  );
+  const same = parseBootstrapManifest(
+    JSON.stringify({
+      version: 1,
+      items: [{ id: "a", kind: "sign", chain: "l2", to: ADDRESS.toLowerCase(), valueWei: "1" }],
+    }),
+  );
+  const different = parseBootstrapManifest(
+    JSON.stringify({ version: 1, items: [{ id: "a", kind: "sign", chain: "l2", to: ADDRESS, valueWei: "2" }] }),
+  );
+
+  assert.match(bootstrapManifestHash(one), /^0x[0-9a-f]{64}$/);
+  // Address normalization makes equivalent manifests hash identically.
+  assert.equal(bootstrapManifestHash(one), bootstrapManifestHash(same));
+  assert.notEqual(bootstrapManifestHash(one), bootstrapManifestHash(different));
+});

--- a/contracts/forge-deployer/test/checkpoint.test.ts
+++ b/contracts/forge-deployer/test/checkpoint.test.ts
@@ -35,6 +35,7 @@ function identity() {
     chainIds: { l1: "1", l2: "1337" },
     signers: { l1: L1_SIGNER, l2: L2_SIGNER },
     configurationHash: `0x${"12".repeat(32)}`,
+    bootstrapHash: `0x${"00".repeat(32)}`,
     startingNonces: { l1: 3, l2: 7 },
   };
 }
@@ -56,13 +57,20 @@ function checkpoint() {
 test("creates a versioned checkpoint with every expected address and no secrets", () => {
   const value = checkpoint();
   const serialized = JSON.stringify(value);
+  const startingNonces = identity().startingNonces;
+  const expectedDeploymentCount = buildAddressPlan({
+    l1Signer: L1_SIGNER,
+    l2Signer: L2_SIGNER,
+    l1StartingNonce: startingNonces.l1,
+    l2StartingNonce: startingNonces.l2,
+  }).reduce((total, step) => total + step.deployments.length, 0);
 
   assert.equal(value.profile, DEPLOYMENT_PROFILE);
-  assert.equal(SCHEMA_VERSION, 2);
-  assert.equal(value.schemaVersion, 2);
+  assert.equal(SCHEMA_VERSION, 3);
+  assert.equal(value.schemaVersion, 3);
   assert.equal(value.artifactDigest, IMAGE_DIGEST);
   assert.deepEqual(value.inFlightDeployments, {});
-  assert.equal(Object.keys(value.expectedDeployments).length, 18);
+  assert.equal(Object.keys(value.expectedDeployments).length, expectedDeploymentCount);
   assert.doesNotMatch(serialized, /private.?key|rpc.?url/i);
 });
 
@@ -105,6 +113,44 @@ test("rejects incompatible chain, signer, state root, profile, and artifact", ()
     () => assertCheckpointCompatible(value, { ...identity(), artifactDigest: `sha256:${"ef".repeat(32)}` }),
     /artifact digest/,
   );
+  assert.throws(
+    () => assertCheckpointCompatible(value, { ...identity(), bootstrapHash: `0x${"11".repeat(32)}` }),
+    /bootstrap manifest/,
+  );
+});
+
+test("round-trips completed bootstrap records and rejects malformed ones", () => {
+  const value = checkpoint();
+  value.bootstrap["bootstrap.fund-relayer"] = {
+    kind: "sign",
+    chain: "l2",
+    transactionHash: `0x${"cd".repeat(32)}`,
+    blockNumber: 42,
+    chainId: "1337",
+  };
+  value.bootstrap["bootstrap.deploy-factory"] = {
+    kind: "presigned",
+    chain: "l2",
+    transactionHash: `0x${"ef".repeat(32)}`,
+    blockNumber: 43,
+    chainId: "1337",
+    address: "0x4e59b44847b379578588920cA78FbF26c0B4956C",
+  };
+  assert.deepEqual(parseCheckpoint(JSON.stringify(value)).bootstrap, value.bootstrap);
+
+  const malformed = checkpoint();
+  malformed.bootstrap["bootstrap.bad"] = {
+    kind: "sign",
+    chain: "l2",
+    transactionHash: "not-a-hash",
+    blockNumber: 1,
+    chainId: "1337",
+  };
+  assert.throws(() => parseCheckpoint(JSON.stringify(malformed)), /invalid bootstrap record/);
+
+  const missing = checkpoint() as Partial<ReturnType<typeof checkpoint>>;
+  delete (missing as Record<string, unknown>).bootstrap;
+  assert.throws(() => parseCheckpoint(JSON.stringify(missing)), /missing bootstrap record/);
 });
 
 test("serializes sufficient ConfigMap state and public addresses", () => {

--- a/contracts/forge-deployer/test/config.test.ts
+++ b/contracts/forge-deployer/test/config.test.ts
@@ -55,6 +55,19 @@ test("rejects identical L1 and L2 chain IDs", () => {
   assert.doesNotThrow(() => assertDistinctChainIds("1", "1337"));
 });
 
+test("captures optional bootstrap manifest and scripts dir inputs", () => {
+  const unset = loadConfig(requiredEnvironment());
+  assert.equal(unset.bootstrapManifestFile, undefined);
+  assert.equal(unset.bootstrapScriptsDir, undefined);
+
+  const env = requiredEnvironment();
+  env.BOOTSTRAP_MANIFEST_FILE = "/etc/bootstrap/manifest.json";
+  env.BOOTSTRAP_SCRIPTS_DIR = "/etc/bootstrap/scripts";
+  const config = loadConfig(env);
+  assert.equal(config.bootstrapManifestFile, "/etc/bootstrap/manifest.json");
+  assert.equal(config.bootstrapScriptsDir, "/etc/bootstrap/scripts");
+});
+
 test("requires pinned safe-integer starting nonces", () => {
   const missing = requiredEnvironment();
   delete missing.L1_STARTING_NONCE;

--- a/contracts/forge-deployer/test/decision.test.ts
+++ b/contracts/forge-deployer/test/decision.test.ts
@@ -27,13 +27,14 @@ function fixture() {
     chainIds: { l1: "1", l2: "1337" },
     signers: { l1: L1_SIGNER, l2: L2_SIGNER },
     configurationHash: `0x${"12".repeat(32)}`,
+    bootstrapHash: `0x${"00".repeat(32)}`,
     startingNonces: { l1: 5, l2: 9 },
     plan,
   });
   return { checkpoint, step: plan[0]! };
 }
 
-test("skips only when all records and bytecode verify", () => {
+test("skips only when all records and bytecode verify", async () => {
   const { checkpoint, step } = fixture();
   const codeByKey: Record<string, boolean> = {};
   for (const deployment of step.deployments) {
@@ -48,10 +49,10 @@ test("skips only when all records and bytecode verify", () => {
   }
   checkpoint.completedSteps.push(step.id);
 
-  assert.deepEqual(decideStepAction({ step, checkpoint, codeByKey, currentNonce: 10 }), { action: "skip" });
+  assert.deepEqual(await decideStepAction({ step, checkpoint, codeByKey, currentNonce: 10 }), { action: "skip" });
 });
 
-test("recovers a fully checkpointed step when only its completion marker is missing", () => {
+test("recovers a fully checkpointed step when only its completion marker is missing", async () => {
   const { checkpoint, step } = fixture();
   const codeByKey = Object.fromEntries(step.deployments.map((deployment) => [deployment.key, true]));
   for (const deployment of step.deployments) {
@@ -64,33 +65,33 @@ test("recovers a fully checkpointed step when only its completion marker is miss
     };
   }
 
-  assert.deepEqual(decideStepAction({ step, checkpoint, codeByKey, currentNonce: 10 }), { action: "recover" });
+  assert.deepEqual(await decideStepAction({ step, checkpoint, codeByKey, currentNonce: 10 }), { action: "recover" });
 });
 
-test("fails closed when addresses contain code without durable deployment records", () => {
+test("fails closed when addresses contain code without durable deployment records", async () => {
   const { checkpoint, step } = fixture();
   const codeByKey = Object.fromEntries(step.deployments.map((deployment) => [deployment.key, true]));
 
-  assert.throws(() => decideStepAction({ step, checkpoint, codeByKey, currentNonce: 10 }), /uncheckpointed code/);
+  await assert.rejects(decideStepAction({ step, checkpoint, codeByKey, currentNonce: 10 }), /uncheckpointed code/);
 });
 
-test("deploys only when the range is empty and nonce has not drifted", () => {
+test("deploys only when the range is empty and nonce has not drifted", async () => {
   const { checkpoint, step } = fixture();
   const codeByKey = Object.fromEntries(step.deployments.map((deployment) => [deployment.key, false]));
 
-  assert.deepEqual(decideStepAction({ step, checkpoint, codeByKey, currentNonce: 5 }), { action: "deploy" });
+  assert.deepEqual(await decideStepAction({ step, checkpoint, codeByKey, currentNonce: 5 }), { action: "deploy" });
 });
 
-test("fails closed on partial deployment, nonce drift, or lost bytecode", () => {
+test("fails closed on partial deployment, nonce drift, or lost bytecode", async () => {
   const { checkpoint, step } = fixture();
   const partialCode = Object.fromEntries(step.deployments.map((deployment, index) => [deployment.key, index === 0]));
   const noCode = Object.fromEntries(step.deployments.map((deployment) => [deployment.key, false]));
 
-  assert.throws(
-    () => decideStepAction({ step, checkpoint, codeByKey: partialCode, currentNonce: 6 }),
+  await assert.rejects(
+    decideStepAction({ step, checkpoint, codeByKey: partialCode, currentNonce: 6 }),
     /partial deployment/,
   );
-  assert.throws(() => decideStepAction({ step, checkpoint, codeByKey: noCode, currentNonce: 6 }), /nonce drift/);
+  await assert.rejects(decideStepAction({ step, checkpoint, codeByKey: noCode, currentNonce: 6 }), /nonce drift/);
 
   const first = step.deployments[0]!;
   checkpoint.deployments[first.key] = {
@@ -100,8 +101,66 @@ test("fails closed on partial deployment, nonce drift, or lost bytecode", () => 
     chainId: "1",
     recovered: false,
   };
-  assert.throws(
-    () => decideStepAction({ step, checkpoint, codeByKey: noCode, currentNonce: 5 }),
+  await assert.rejects(
+    decideStepAction({ step, checkpoint, codeByKey: noCode, currentNonce: 5 }),
     /checkpointed deployment.*has no bytecode/,
+  );
+});
+
+test("deterministic proxy step skips on existing factory code, ignoring nonce drift", async () => {
+  const { checkpoint } = fixture();
+  const plan = buildAddressPlan({ l1Signer: L1_SIGNER, l2Signer: L2_SIGNER, l1StartingNonce: 5, l2StartingNonce: 9 });
+  const step = plan.find((candidate) => candidate.id === "l2-deterministic-proxy")!;
+  const deployment = step.deployments[0]!;
+
+  // Factory already deployed and checkpointed: skip even though the L2 deployer
+  // nonce advanced past the funding-send nonce on the prior run.
+  checkpoint.deployments[deployment.key] = {
+    address: deployment.expectedAddress,
+    transactionHash: TX_HASH,
+    blockNumber: 200,
+    chainId: "1337",
+    recovered: false,
+  };
+  checkpoint.completedSteps.push(step.id);
+
+  assert.deepEqual(
+    await decideStepAction({ step, checkpoint, codeByKey: { [deployment.key]: true }, currentNonce: 18 }),
+    { action: "skip" },
+  );
+});
+
+test("adopts uncheckpointed well-known-address code when the verifier reports a match", async () => {
+  const { checkpoint } = fixture();
+  const plan = buildAddressPlan({ l1Signer: L1_SIGNER, l2Signer: L2_SIGNER, l1StartingNonce: 5, l2StartingNonce: 9 });
+  const step = plan.find((candidate) => candidate.id === "l2-deterministic-proxy")!;
+  const deployment = step.deployments[0]!;
+
+  const result = await decideStepAction({
+    step,
+    checkpoint,
+    codeByKey: { [deployment.key]: true },
+    currentNonce: 18,
+    verifyWellKnownCode: async () => "match",
+  });
+
+  assert.deepEqual(result, { action: "adopt" });
+});
+
+test("refuses to adopt uncheckpointed well-known-address code when the verifier reports a mismatch", async () => {
+  const { checkpoint } = fixture();
+  const plan = buildAddressPlan({ l1Signer: L1_SIGNER, l2Signer: L2_SIGNER, l1StartingNonce: 5, l2StartingNonce: 9 });
+  const step = plan.find((candidate) => candidate.id === "l2-deterministic-proxy")!;
+  const deployment = step.deployments[0]!;
+
+  await assert.rejects(
+    decideStepAction({
+      step,
+      checkpoint,
+      codeByKey: { [deployment.key]: true },
+      currentNonce: 18,
+      verifyWellKnownCode: async () => "mismatch",
+    }),
+    /unexpected bytecode/,
   );
 });

--- a/contracts/forge-deployer/test/deployment-record.test.ts
+++ b/contracts/forge-deployer/test/deployment-record.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  awaitParentCheckpoint,
   awaitParentDeploymentIntent,
   formatDeploymentRecord,
   parseDeploymentRecord,
@@ -9,6 +10,39 @@ import {
 
 const ADDRESS = "0x1000000000000000000000000000000000000001";
 const TX_HASH = `0x${"ab".repeat(32)}`;
+
+// Temporarily makes `process` look like a connected IPC child (as it is when
+// spawned by process-runner.ts), and fully restores the original
+// process.send/process.connected descriptors afterwards (including "was
+// unset", the normal non-IPC-child state), so awaitParent*'s ack/reject/
+// disconnect branches can be exercised without spawning a real child process.
+async function withMockedIpcParent<T>(
+  run: (sent: { message: unknown; callback?: (error: Error | null) => void }[]) => Promise<T>,
+): Promise<T> {
+  const originalSend = Object.getOwnPropertyDescriptor(process, "send");
+  const originalConnected = Object.getOwnPropertyDescriptor(process, "connected");
+  const sent: { message: unknown; callback?: (error: Error | null) => void }[] = [];
+
+  Object.defineProperties(process, {
+    connected: { configurable: true, value: true },
+    send: {
+      configurable: true,
+      value: (message: unknown, callback?: (error: Error | null) => void) => {
+        sent.push(callback ? { message, callback } : { message });
+        return true;
+      },
+    },
+  });
+
+  try {
+    return await run(sent);
+  } finally {
+    if (originalSend) Object.defineProperty(process, "send", originalSend);
+    else delete (process as unknown as { send?: typeof process.send }).send;
+    if (originalConnected) Object.defineProperty(process, "connected", originalConnected);
+    else delete (process as unknown as { connected?: boolean }).connected;
+  }
+}
 
 test("formats and parses a durable deployment record", () => {
   const line = formatDeploymentRecord({
@@ -89,3 +123,33 @@ test("deployment intent waits for its matching parent acknowledgement", async ()
     else delete (process as unknown as { connected?: boolean }).connected;
   }
 });
+
+test("awaitParentCheckpoint rejects when the parent acknowledges with an error", () =>
+  withMockedIpcParent(async (sent) => {
+    const pending = awaitParentCheckpoint({
+      contractName: "LinethRollupV8",
+      address: ADDRESS,
+      transactionHash: TX_HASH,
+      blockNumber: 42,
+      chainId: "1337",
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    const message = sent[0]!.message as { type: string; id: string };
+    assert.equal(message.type, "lineth-deployment-record");
+    process.emit("message", { type: "lineth-deployment-record-ack", id: message.id, error: "boom" }, undefined);
+    await assert.rejects(pending, /boom/);
+  }));
+
+test("awaitParentCheckpoint rejects when the parent disconnects before acknowledging", () =>
+  withMockedIpcParent(async () => {
+    const pending = awaitParentCheckpoint({
+      contractName: "LinethRollupV8",
+      address: ADDRESS,
+      transactionHash: TX_HASH,
+      blockNumber: 42,
+      chainId: "1337",
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    process.emit("disconnect");
+    await assert.rejects(pending, /disconnected before acknowledging/);
+  }));

--- a/contracts/forge-deployer/test/deterministic-deployment-proxy-helper.test.ts
+++ b/contracts/forge-deployer/test/deterministic-deployment-proxy-helper.test.ts
@@ -1,0 +1,66 @@
+import { ethers } from "ethers";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ARACHNID_FACTORY,
+  ARACHNID_FACTORY_RUNTIME_CODE,
+  ARACHNID_FACTORY_RUNTIME_CODE_HASH,
+  ARACHNID_RAW_TX,
+  ARACHNID_SIGNER,
+  getDeterministicProxyCodeStatus,
+  isDeterministicProxyDeployed,
+} from "../../common/helpers/deterministicDeploymentProxy";
+
+const UNRELATED_CODE = "0x6001600101";
+
+function mockProvider(code: string): ethers.Provider {
+  return {
+    getCode: async () => code,
+  } as unknown as ethers.Provider;
+}
+
+test("ARACHNID_RAW_TX recovers to ARACHNID_SIGNER", () => {
+  const recovered = ethers.Transaction.from(ARACHNID_RAW_TX).from;
+  assert.ok(recovered);
+  assert.equal(ethers.getAddress(recovered), ARACHNID_SIGNER);
+});
+
+test("ARACHNID_FACTORY_RUNTIME_CODE_HASH matches the runtime code embedded in ARACHNID_RAW_TX's init code", () => {
+  // The deployment transaction's init code is `PUSH1 0x45 DUP1 PUSH1 0x0e
+  // PUSH1 0x00 CODECOPY DUP1 PUSH1 0x00 RETURN POP INVALID <runtime code>`:
+  // 10 bytes of deploy preamble (offset 0x0e) followed by 0x45 (69) bytes of
+  // runtime code that CODECOPY/RETURN install as the factory's deployed code.
+  const tx = ethers.Transaction.from(ARACHNID_RAW_TX);
+  const initCode = ethers.getBytes(tx.data);
+  const runtimeCode = ethers.hexlify(initCode.subarray(14, 14 + 0x45));
+  assert.equal(runtimeCode, ARACHNID_FACTORY_RUNTIME_CODE);
+  assert.equal(ethers.keccak256(runtimeCode), ARACHNID_FACTORY_RUNTIME_CODE_HASH);
+});
+
+test("getDeterministicProxyCodeStatus reports absent when no code exists", async () => {
+  const status = await getDeterministicProxyCodeStatus(mockProvider("0x"));
+  assert.equal(status, "absent");
+  assert.equal(await isDeterministicProxyDeployed(mockProvider("0x")), false);
+});
+
+test("getDeterministicProxyCodeStatus reports match for the known factory runtime code", async () => {
+  const status = await getDeterministicProxyCodeStatus(mockProvider(ARACHNID_FACTORY_RUNTIME_CODE));
+  assert.equal(status, "match");
+  assert.equal(await isDeterministicProxyDeployed(mockProvider(ARACHNID_FACTORY_RUNTIME_CODE)), true);
+});
+
+test("getDeterministicProxyCodeStatus reports mismatch for unrelated non-empty code", async () => {
+  const status = await getDeterministicProxyCodeStatus(mockProvider(UNRELATED_CODE));
+  assert.equal(status, "mismatch");
+  // A mismatch is still non-empty code, so isDeterministicProxyDeployed (a
+  // coarse "is something there" check) reports true; callers that need to
+  // distinguish "safe to adopt" from "unexpected occupant" must use
+  // getDeterministicProxyCodeStatus directly, as ensureDeterministicDeploymentProxy
+  // and the forge-deployer recovery path both do.
+  assert.equal(await isDeterministicProxyDeployed(mockProvider(UNRELATED_CODE)), true);
+});
+
+test("ARACHNID_FACTORY is the canonical well-known address", () => {
+  assert.equal(ARACHNID_FACTORY, ethers.getAddress("0x4e59b44847b379578588920cA78FbF26c0B4956C"));
+});

--- a/contracts/forge-deployer/test/fixtures/bootstrap/deploy-via-create2.js
+++ b/contracts/forge-deployer/test/fixtures/bootstrap/deploy-via-create2.js
@@ -1,0 +1,27 @@
+// Custom bootstrap script: deploys a simple contract through the deterministic
+// CREATE2 proxy via a normal signed call from the deployer, at the runner-provided
+// starting nonce. The EIP-7997 factory takes raw calldata salt(32) ++ initCode
+// (no function selector). The proxy is Anvil-preinstalled on L2 in this scenario.
+const { ethers } = require("ethers");
+
+const FACTORY = "0x4e59b44847b379578588920cA78FbF26c0B4956C";
+const SALT = "0x00000000000000000000000000000000000000000000000000000000000000cd";
+const INITCODE = "0x6001600c60003960016000f300";
+
+async function main() {
+  const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
+  const wallet = new ethers.Wallet(process.env.DEPLOYER_PRIVATE_KEY, provider);
+  const nonce = Number(process.env.BOOTSTRAP_START_NONCE);
+  const data = ethers.concat([SALT, INITCODE]);
+  const tx = await wallet.sendTransaction({ to: FACTORY, data, nonce, gasPrice: 0n });
+  const receipt = await tx.wait();
+  const initCodeHash = ethers.keccak256(INITCODE);
+  const addr = ethers.getCreate2Address(FACTORY, SALT, initCodeHash);
+  const code = await provider.getCode(addr);
+  console.log(`bootstrap create2 deployed at ${addr} status=${receipt.status} codeBytes=${(code.length - 2) / 2}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/contracts/forge-deployer/test/fixtures/bootstrap/manifest.json
+++ b/contracts/forge-deployer/test/fixtures/bootstrap/manifest.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "items": [
+    {
+      "id": "fund-target",
+      "kind": "sign",
+      "chain": "l2",
+      "to": "0x00000000000000000000000000000000000ba5e1",
+      "valueWei": "0"
+    },
+    {
+      "id": "bare-create",
+      "kind": "sign",
+      "chain": "l2",
+      "data": "0x6001600c60003960016000f300"
+    },
+    {
+      "id": "create2-deploy",
+      "kind": "script",
+      "chain": "l2",
+      "script": "deploy-via-create2.js"
+    }
+  ]
+}

--- a/contracts/forge-deployer/test/integration/two-chain.sh
+++ b/contracts/forge-deployer/test/integration/two-chain.sh
@@ -10,6 +10,15 @@ L1_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 L2_KEY="0x0000000000000000000000000000000000000000000000000000000000000001"
 STATE_ROOT="0xabababababababababababababababababababababababababababababababab"
 
+RPC_READY_TIMEOUT_S=60
+RPC_READY_POLL_INTERVAL_S=1
+# The intent/pending-nonce condition below settles much faster than RPC
+# readiness (it's just local checkpoint-file + nonce reads, no container
+# boot), so it polls a shorter overall budget at a finer interval.
+INTENT_POLL_TIMEOUT_S=20
+INTENT_POLL_INTERVAL_S=0.1
+INTENT_POLL_ITERATIONS=200 # INTENT_POLL_TIMEOUT_S / INTENT_POLL_INTERVAL_S
+
 NETWORK=""
 CHECKPOINT_DIR=""
 L1_CONTAINER=""
@@ -44,12 +53,12 @@ DEPLOYER_IMAGE_DIGEST="$(docker image inspect --format '{{.Id}}' "$DEPLOYER_IMAG
 
 wait_for_rpc() {
   local container="$1"
-  for _ in $(seq 1 60); do
+  for _ in $(seq 1 "$RPC_READY_TIMEOUT_S"); do
     if docker run --rm --network "$NETWORK" --entrypoint cast "$FOUNDRY_IMAGE" \
       block-number --rpc-url "http://${container}:8545" >/dev/null 2>&1; then
       return 0
     fi
-    sleep 1
+    sleep "$RPC_READY_POLL_INTERVAL_S"
   done
   echo "${container} RPC did not become ready" >&2
   return 1
@@ -58,6 +67,8 @@ wait_for_rpc() {
 start_scenario() {
   local label="$1"
   cleanup_scenario
+  # Reset any bootstrap inputs a prior scenario exported so they never leak.
+  unset BOOTSTRAP_MANIFEST_FILE BOOTSTRAP_SCRIPTS_DIR
   NETWORK="forge-deployer-${label}-$$"
   CHECKPOINT_DIR="$(mktemp -d)"
   L1_CONTAINER="forge-deployer-${label}-l1-$$"
@@ -108,6 +119,8 @@ deployer_container() {
     -e "L1_DEPLOY_GAS_PRICE_WEI=0" \
     -e "L2_DEPLOY_GAS_PRICE_WEI=0" \
     -e "CHECKPOINT_FILE=/checkpoint/checkpoint.json" \
+    ${BOOTSTRAP_MANIFEST_FILE:+-e "BOOTSTRAP_MANIFEST_FILE=$BOOTSTRAP_MANIFEST_FILE"} \
+    ${BOOTSTRAP_SCRIPTS_DIR:+-e "BOOTSTRAP_SCRIPTS_DIR=$BOOTSTRAP_SCRIPTS_DIR"} \
     "$DEPLOYER_IMAGE"
 }
 
@@ -138,7 +151,7 @@ wait_for_intent_and_pending_nonce() {
   local signer="$3"
   local expected_pending_nonce="$4"
   local intent_address=""
-  for _ in $(seq 1 200); do
+  for _ in $(seq 1 "$INTENT_POLL_ITERATIONS"); do
     if [[ -s "$CHECKPOINT_DIR/checkpoint.json" ]]; then
       intent_address="$(
         jq -r --arg chain "$chain" \
@@ -151,7 +164,7 @@ wait_for_intent_and_pending_nonce() {
         return 0
       fi
     fi
-    sleep 0.1
+    sleep "$INTENT_POLL_INTERVAL_S"
   done
   echo "timed out waiting for ${chain} intent at pending nonce ${expected_pending_nonce}; address=${intent_address:-unknown}" >&2
   return 1
@@ -179,11 +192,23 @@ verify_happy_path() {
   l2_nonce_before="$(get_nonce latest "$L2_CONTAINER" "$L2_ADDRESS")"
 
   test "$l1_nonce_before" -eq "$((INITIAL_L1_NONCE + 10))"
+  # Anvil preinstalls the deterministic proxy factory in genesis, so the runner
+  # adopts it as recovered and the funding send is skipped: only the 8 contract
+  # deployments consume L2 deployer nonces here.
   test "$l2_nonce_before" -eq "$((INITIAL_L2_NONCE + 8))"
-  test "$(jq '.completedSteps | length' "$CHECKPOINT_DIR/checkpoint.json")" -eq 4
-  test "$(jq '.deployments | length' "$CHECKPOINT_DIR/checkpoint.json")" -eq 18
+  test "$(jq '.completedSteps | length' "$CHECKPOINT_DIR/checkpoint.json")" -eq 5
+  # Total deployment-key count from buildAddressPlan(); kept as a literal since
+  # this shell test can't import the TS plan. Update alongside
+  # test/checkpoint.test.ts (which derives it dynamically) if the plan changes.
+  test "$(jq '.deployments | length' "$CHECKPOINT_DIR/checkpoint.json")" -eq 19
   jq -e --arg digest "$DEPLOYER_IMAGE_DIGEST" \
-    '.schemaVersion == 2 and .artifactDigest == $digest and (.inFlightDeployments | length) == 0' \
+    '.schemaVersion == 3 and .artifactDigest == $digest and (.inFlightDeployments | length) == 0' \
+    "$CHECKPOINT_DIR/checkpoint.json" >/dev/null
+
+  # The deterministic deployment proxy factory must be installed on L2, and the
+  # checkpoint records it as recovered (adopted from the preinstalled code).
+  test "$(get_code "$L2_CONTAINER" "0x4e59b44847b379578588920cA78FbF26c0B4956C")" != "0x"
+  jq -e '.deployments["l2-deterministic-proxy.factory"].recovered == true' \
     "$CHECKPOINT_DIR/checkpoint.json" >/dev/null
 
   while IFS=$'\t' read -r chain address; do
@@ -265,9 +290,70 @@ verify_l2_broadcast_crash() {
   test "$(jq -c '{completedSteps, deployments: [.deployments | to_entries[] | select(.value.chainId == "31337")]}' "$CHECKPOINT_DIR/checkpoint.json")" = "$l1_prefix"
 }
 
+# Exercises the optional custom bootstrap phase: a sign funding item, a keyless
+# presigned deploy, and an operator script, all on L2, then asserts the rerun
+# skips every item and advances no further nonce.
+verify_custom_bootstrap() {
+  start_scenario bootstrap
+
+  # Operator-supplied bootstrap inputs are real files shipped under
+  # test/fixtures/bootstrap/ and copied into the checkpoint mount exactly as an
+  # operator would mount them, rather than being constructed inline here.
+  local fixtures_dir
+  fixtures_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures/bootstrap" && pwd)"
+  # Bytecode/salt/factory used by the fixture manifest and its create2 script.
+  local simple_initcode="0x6001600c60003960016000f300"
+  local create2_salt="0x00000000000000000000000000000000000000000000000000000000000000cd"
+  local proxy_factory="0x4e59b44847b379578588920cA78FbF26c0B4956C"
+
+  mkdir -p "$CHECKPOINT_DIR/bootstrap"
+  cp "$fixtures_dir/manifest.json" "$CHECKPOINT_DIR/manifest.json"
+  cp "$fixtures_dir/deploy-via-create2.js" "$CHECKPOINT_DIR/bootstrap/deploy-via-create2.js"
+  chmod -R 0777 "$CHECKPOINT_DIR/bootstrap"
+
+  BOOTSTRAP_MANIFEST_FILE="/checkpoint/manifest.json"
+  BOOTSTRAP_SCRIPTS_DIR="/checkpoint/bootstrap"
+
+  # The bootstrap phase runs sign items first (nonce N, N+1), then the script's
+  # create2 call (nonce N+2), where N = INITIAL_L2_NONCE + 8 (the 8 core L2
+  # deploys; the Anvil-preinstalled det-proxy consumes no nonce).
+  local bare_create_nonce=$((INITIAL_L2_NONCE + 9))
+
+  run_deployer
+  local l2_nonce_after_first
+  l2_nonce_after_first="$(get_nonce latest "$L2_CONTAINER" "$L2_ADDRESS")"
+  # 8 core L2 deploys + 2 sign items + 1 create2 script call.
+  test "$l2_nonce_after_first" -eq "$((INITIAL_L2_NONCE + 11))"
+
+  # The bare create landed at the deployer's CREATE address and the create2
+  # script landed at the deterministic CREATE2 address.
+  local bare_create_addr create2_addr
+  bare_create_addr="$(docker run --rm --entrypoint cast "$FOUNDRY_IMAGE" compute-address --nonce "$bare_create_nonce" "$L2_ADDRESS" | awk '{print $NF}')"
+  create2_addr="$(docker run --rm --entrypoint cast "$FOUNDRY_IMAGE" compute-address --salt "$create2_salt" --init-code "$simple_initcode" "$proxy_factory" | awk '{print $NF}')"
+  test "$(get_code "$L2_CONTAINER" "$bare_create_addr")" != "0x"
+  test "$(get_code "$L2_CONTAINER" "$create2_addr")" != "0x"
+
+  jq -e '.bootstrap["bootstrap.fund-target"].kind == "sign"' "$CHECKPOINT_DIR/checkpoint.json" >/dev/null
+  jq -e '.bootstrap["bootstrap.bare-create"].kind == "sign"' "$CHECKPOINT_DIR/checkpoint.json" >/dev/null
+  jq -e --arg addr "$bare_create_addr" \
+    '.bootstrap["bootstrap.bare-create"].address | ascii_downcase == ($addr | ascii_downcase)' \
+    "$CHECKPOINT_DIR/checkpoint.json" >/dev/null
+  jq -e '.bootstrap["bootstrap.create2-deploy"].kind == "script"' "$CHECKPOINT_DIR/checkpoint.json" >/dev/null
+
+  # A rerun with the same manifest completes no additional items and advances no
+  # further nonce: completed bootstrap items are skipped.
+  cp "$CHECKPOINT_DIR/checkpoint.json" "$CHECKPOINT_DIR/checkpoint.before-rerun.json"
+  run_deployer
+  test "$(get_nonce latest "$L2_CONTAINER" "$L2_ADDRESS")" -eq "$l2_nonce_after_first"
+  cmp "$CHECKPOINT_DIR/checkpoint.before-rerun.json" "$CHECKPOINT_DIR/checkpoint.json"
+
+  unset BOOTSTRAP_MANIFEST_FILE BOOTSTRAP_SCRIPTS_DIR
+}
+
 verify_happy_path
 verify_l1_broadcast_crash
 verify_l2_broadcast_crash
+verify_custom_bootstrap
 cleanup_scenario
 
-echo "two-chain deployment, zero-transaction rerun, checkpoint-loss refusal, and L1/L2 crash refusal verified"
+echo "two-chain deployment, zero-transaction rerun, checkpoint-loss refusal, L1/L2 crash refusal, and custom bootstrap verified"

--- a/contracts/forge-deployer/tsup.config.ts
+++ b/contracts/forge-deployer/tsup.config.ts
@@ -6,6 +6,8 @@ export default defineConfig({
     "steps/l1-rollup": "src/steps/l1-rollup.ts",
     "steps/l2-message-service": "src/steps/l2-message-service.ts",
     "steps/token-bridge": "src/steps/token-bridge.ts",
+    "steps/deterministic-deployment-proxy": "src/steps/deterministic-deployment-proxy.ts",
+    "steps/bootstrap": "src/steps/bootstrap.ts",
   },
   format: ["cjs"],
   platform: "node",

--- a/contracts/local-deployments-artifacts/deploy-deterministic-deployment-proxy.ts
+++ b/contracts/local-deployments-artifacts/deploy-deterministic-deployment-proxy.ts
@@ -1,0 +1,23 @@
+import * as dotenv from "dotenv";
+import { ethers } from "ethers";
+
+import { ensureAndDescribeDeterministicDeploymentProxy } from "../common/helpers/deterministicDeploymentProxy";
+import { getRequiredEnvVar } from "../common/helpers/environment";
+import { resolveL2DeployFeeOverrides } from "../common/helpers/feeOverrides";
+
+dotenv.config();
+
+async function main() {
+  const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
+  const wallet = new ethers.Wallet(getRequiredEnvVar("DEPLOYER_PRIVATE_KEY"), provider);
+  const fees = resolveL2DeployFeeOverrides();
+  const nonce = await provider.getTransactionCount(wallet.address, "pending");
+
+  const { formattedRecord } = await ensureAndDescribeDeterministicDeploymentProxy({ provider, wallet, fees, nonce });
+  console.log(formattedRecord);
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/contracts/makefile-contracts.mk
+++ b/contracts/makefile-contracts.mk
@@ -127,6 +127,15 @@ deploy-l2messageservice:
 		L2_MESSAGE_SERVICE_RATE_LIMIT_AMOUNT=1000000000000000000000 \
 		pnpm exec ts-node local-deployments-artifacts/deployL2MessageServiceV1.ts
 
+deploy-deterministic-proxy-l2:
+		# WARNING: FOR LOCAL DEV ONLY - DO NOT REUSE THESE KEYS ELSEWHERE
+		# EIP-7997 / Arachnid Create2Factory at the well-known 0x4e59...956C. Runs after
+		# the parallel contract deploys; skips automatically when factory code exists.
+		cd $(contracts_package_dir); \
+		DEPLOYER_PRIVATE_KEY=$${DEPLOYMENT_PRIVATE_KEY:-0x1dd171cec7e2995408b5513004e8207fe88d6820aeff0d82463b3e41df251aae} \
+		RPC_URL=http:\\localhost:8545/ \
+		pnpm exec ts-node local-deployments-artifacts/deploy-deterministic-deployment-proxy.ts
+
 deploy-token-bridge-l1:
 		# WARNING: FOR LOCAL DEV ONLY - DO NOT REUSE THESE KEYS ELSEWHERE
 		cd $(contracts_package_dir); \
@@ -188,6 +197,10 @@ deploy-contracts:
 	else \
 		$(MAKE) -j6 $(LINETH_L1_CONTRACT_DEPLOYMENT_TARGET) deploy-l2messageservice; \
 	fi
+	# Run serially after the parallel batch above (not folded into it): the proxy
+	# deploy needs the L2 deployer's next nonce settled after every L2 deploy in
+	# that batch has landed. Adding it to the -j6/-j7 list would race that nonce.
+	$(MAKE) deploy-deterministic-proxy-l2
 
 
 deploy-l2-evm-opcode-tester:

--- a/docs/getting-started/lineth-stack/.env.example
+++ b/docs/getting-started/lineth-stack/.env.example
@@ -128,6 +128,21 @@ L1_RPC_URL=
 # expensive EIP-1559 fee. Default is 0.1 gwei.
 # L2_GAS_PRICE_WEI=100000000
 
+# -----------------------------------------------------------------------------
+# INFORMATIONAL — deterministic deployment proxy (no configuration needed)
+#
+# After the L2 contract deployments, the quickstart installs the well-known
+# EIP-7997 / Arachnid "Create2Factory" so downstream tooling can deploy
+# contracts at deterministic CREATE2 addresses. These values are fixed protocol
+# constants, not user settings — they are documented here only for visibility:
+#   factory address: 0x4e59b44847b379578588920cA78FbF26c0B4956C
+#   keyless signer funded: 0x3fAB184622Dc19b6109349B94811493BF2a45362
+#   funding amount: 0.01 ETH (the budget the pre-signed broadcast hardcodes)
+# The step reuses L2_DEPLOYER_PRIVATE_KEY and L2_RPC_URL (already in scope) and
+# is idempotent: it is skipped automatically when factory bytecode already
+# exists at the factory address.
+# -----------------------------------------------------------------------------
+
 # Prover mode. Default quickstart behavior is dev proofs so ordinary laptops
 # can complete a boot. Set PROVER_DEV_OVERRIDE=false only for production-shaped
 # partial proving, and raise Docker Desktop memory substantially first.

--- a/docs/getting-started/lineth-stack/scripts/check-quickstart-static.sh
+++ b/docs/getting-started/lineth-stack/scripts/check-quickstart-static.sh
@@ -1854,6 +1854,32 @@ check_quickstart_lib_consolidation() {
   fi
 }
 
+check_deterministic_proxy_factory_address_consistency() {
+  arachnid_helper="$ROOT/contracts/common/helpers/deterministicDeploymentProxy.ts"
+  deploy_contracts="$STACK/scripts/phases/04-deploy-contracts.sh"
+  env_example="$STACK/.env.example"
+
+  # The well-known factory address is a fixed protocol constant duplicated in
+  # three places for readability (TS source of truth, the bash step that logs
+  # it, and the .env.example doc comment). Guard against any of them drifting.
+  # Extractions are guarded with `|| true` (and quoted with `-- -oE`-safe
+  # patterns) so a missing/renamed literal reports a normal `fail` below
+  # instead of aborting the whole script under `set -e`.
+  canonical_factory="$( { grep -oE 'ARACHNID_FACTORY = ethers\.getAddress\("0x[0-9a-fA-F]{40}"\)' "$arachnid_helper" \
+    || true; } | grep -oE '0x[0-9a-fA-F]{40}' || true)"
+  script_factory="$( { grep -oE 'DETERMINISTIC_PROXY_FACTORY="0x[0-9a-fA-F]{40}"' "$deploy_contracts" \
+    || true; } | grep -oE '0x[0-9a-fA-F]{40}' || true)"
+  doc_factory="$(grep -oE 'factory address: 0x[0-9a-fA-F]{40}' "$env_example" | grep -oE '0x[0-9a-fA-F]{40}' || true)"
+
+  if [ -n "$canonical_factory" ] \
+    && [ "$canonical_factory" = "$script_factory" ] \
+    && [ "$canonical_factory" = "$doc_factory" ]; then
+    pass "deterministic deployment proxy factory address is consistent across TS source, deploy script, and .env.example"
+  else
+    fail "deterministic deployment proxy factory address drifted: helper=${canonical_factory:-missing} script=${script_factory:-missing} env.example=${doc_factory:-missing}"
+  fi
+}
+
 check_no_tracked_generated_genesis
 check_restructured_layout_paths
 check_runtime_helper_usage
@@ -1874,6 +1900,7 @@ check_pinned_utility_images_and_docs
 check_wizard_cli
 check_quickstart_review_fixes
 check_quickstart_lib_consolidation
+check_deterministic_proxy_factory_address_consistency
 
 if [ "$FAILURES" -ne 0 ]; then
   printf '[quickstart-static] %s failure(s)\n' "$FAILURES" >&2

--- a/docs/getting-started/lineth-stack/scripts/internal/deploy-deterministic-deployment-proxy.ts
+++ b/docs/getting-started/lineth-stack/scripts/internal/deploy-deterministic-deployment-proxy.ts
@@ -1,0 +1,29 @@
+// Deploys the EIP-7997 / Arachnid deterministic deployment proxy on L2 for the
+// lineth-stack quickstart. Thin entrypoint over the shared helper so the same
+// fund-then-broadcast logic serves both this scaffold and the forge-deployer.
+//
+// Emits `contract=DeterministicDeploymentProxy deployed: address=...` so the
+// 04-deploy-contracts.sh extract_address/verify_address helpers work unchanged.
+import { ensureAndDescribeDeterministicDeploymentProxy } from "contracts/common/helpers/deterministicDeploymentProxy";
+import { resolveL2DeployFeeOverrides } from "contracts/common/helpers/feeOverrides";
+import { JsonRpcProvider, Wallet } from "ethers";
+
+import { requiredProcessEnv } from "./lib/env";
+import { sanitizeExternalError } from "./lib/errors";
+
+async function main() {
+  const rpcUrl = requiredProcessEnv("L2_RPC_URL");
+  const provider = new JsonRpcProvider(rpcUrl);
+  const wallet = new Wallet(requiredProcessEnv("L2_DEPLOYER_PRIVATE_KEY"), provider);
+  const fees = resolveL2DeployFeeOverrides();
+  const nonce = await provider.getTransactionCount(wallet.address, "pending");
+
+  const { formattedRecord } = await ensureAndDescribeDeterministicDeploymentProxy({ provider, wallet, fees, nonce });
+  console.log(formattedRecord);
+  provider.destroy();
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`${sanitizeExternalError(error)}\n`);
+  process.exit(1);
+});

--- a/docs/getting-started/lineth-stack/scripts/phases/04-deploy-contracts.sh
+++ b/docs/getting-started/lineth-stack/scripts/phases/04-deploy-contracts.sh
@@ -895,6 +895,46 @@ step4_token_bridge_l2() {
   export L2_TOKEN_BRIDGE_ADDRESS
 }
 
+# Step 5 — deterministic deployment proxy (EIP-7997 / Arachnid Create2Factory)
+#
+# The factory lives at the well-known constant address below (not a nonce-derived
+# CREATE address), and the deployment transaction is a pre-signed keyless
+# broadcast. The L2 deployer only funds the keyless signer with exactly 0.01 ETH.
+# See contracts/common/helpers/deterministicDeploymentProxy.ts for the logic.
+DETERMINISTIC_PROXY_FACTORY="0x4e59b44847b379578588920cA78FbF26c0B4956C"
+step5_deterministic_proxy() {
+  step "Step 5: deploy L2 deterministic deployment proxy (Create2Factory)"
+  local logfile="$LOG_DIR/step5-deterministic-proxy.log"
+
+  # Idempotent skip: the factory is already installed when code exists at the
+  # well-known address (mirrors step_already_done_with_code, without a nonce
+  # guard — the address is not nonce-derived). Anvil-type dev chains preinstall it.
+  local existing_code
+  existing_code="$(cast code "$DETERMINISTIC_PROXY_FACTORY" --rpc-url "$L2_RPC_URL" 2>/dev/null || true)"
+  if [[ "$existing_code" =~ ^0x[0-9a-fA-F]+$ && "$existing_code" != "0x" ]]; then
+    log "Step 5: factory code already present at $DETERMINISTIC_PROXY_FACTORY — skipping"
+    return 0
+  fi
+
+  # Resolve the funding-transfer fee the same way as the other L2 deploys: the
+  # fixed local EIP-1559 model from resolveL2DeployFeeOverrides() (no forced
+  # gas price). The quickstart Besu enforces a minimum gas price, so a zero
+  # gas price is rejected. Note: the 0.01 ETH funding is still required — the
+  # pre-signed broadcast hardcodes a 100 gwei gas price regardless of the
+  # chain's configured minimum.
+  L2_DEPLOYER_PRIVATE_KEY="$L2_DEPLOYER_PRIVATE_KEY" \
+  L2_RPC_URL="$L2_RPC_URL" \
+  TS_NODE_TRANSPILE_ONLY=1 \
+  TS_NODE_COMPILER_OPTIONS='{"module":"CommonJS","moduleResolution":"Node"}' \
+    pnpm -s exec ts-node /scripts/internal/deploy-deterministic-deployment-proxy.ts 2>&1 | tee "$logfile"
+
+  verify_address \
+    "$(extract_required_address "$logfile" "DeterministicDeploymentProxy")" \
+    "$DETERMINISTIC_PROXY_FACTORY" \
+    "DeterministicDeploymentProxy"
+  log "Deterministic deployment proxy ready at $DETERMINISTIC_PROXY_FACTORY"
+}
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Run all steps in order
 # ─────────────────────────────────────────────────────────────────────────────
@@ -903,6 +943,7 @@ step1_l1_rollup
 step2_l2_message_service
 step3_token_bridge_l1
 step4_token_bridge_l2
+step5_deterministic_proxy
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Fund generated runtime accounts


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes on-chain L2 bootstrap (funding + presigned broadcast), checkpoint identity/schema migration, and operator-trusted bootstrap scripts that sign and submit with deployer keys.
> 
> **Overview**
> Adds a **fifth core L2 boot step** that installs the well-known EIP-7997 / Arachnid deterministic deployment proxy (`Create2Factory` at `0x4e59…956C`) via shared logic in `deterministicDeploymentProxy.ts`, wired through forge-deployer, local deploy make targets, and quickstart **Step 5** in `04-deploy-contracts.sh`. The step is idempotent (bytecode hash check, **adopt** when genesis/preinstall already has the factory) and only the funding transfer uses an L2 deployer nonce.
> 
> **Checkpoint schema bumps to v3**: `bootstrapHash` in identity, per-item `bootstrap.*` records, public `deterministic-deployment-proxy` address, and stricter compatibility checks. **Optional custom bootstrap** after the five steps when `BOOTSTRAP_MANIFEST_FILE` is set—manifest items (`sign`, `presigned`, `script`) run in a child with durable IPC acks; the Docker image bundles **ethers** for script children via `BOOTSTRAP_LIB_NODE_PATH`.
> 
> Supporting refactors: shared **`sendAndAwaitAck`** for deployment/bootstrap IPC, **`runChildScript`** / **`runBootstrapScript`**, async **`decideStepAction`** with well-known bytecode verification, and **`feeOverrides`** treating `0n` as a valid gas price for gas-free L2s. CI/docs/static checks and integration tests cover the new step and bootstrap rerun behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0f74ece674ca887970a2a6816a2eb939e510a29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->