### PR TITLE
feat(sequencer): stop bespoke tracing at configured timestamp

### DIFF
--- a/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/lineth/plugin/acc/test/rpc/linea/BespokeTracingCutoffTest.kt
+++ b/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/lineth/plugin/acc/test/rpc/linea/BespokeTracingCutoffTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package lineth.plugin.acc.test.rpc.linea
+
+import lineth.plugin.acc.test.LineaPluginPoSTestBase
+import lineth.plugin.acc.test.TestCommandLineOptionsBuilder
+import org.assertj.core.api.Assertions.assertThat
+import org.hyperledger.besu.tests.acceptance.dsl.account.Accounts
+import org.junit.jupiter.api.Test
+import org.web3j.crypto.Credentials
+import org.web3j.crypto.RawTransaction
+import org.web3j.crypto.TransactionEncoder
+import org.web3j.tx.gas.DefaultGasProvider
+import org.web3j.utils.Numeric
+import java.math.BigInteger
+import java.nio.charset.StandardCharsets
+
+class BespokeTracingCutoffTest : LineaPluginPoSTestBase() {
+
+  override fun getTestCliOptions(): List<String> {
+    return TestCommandLineOptionsBuilder()
+      .set(
+        "--plugin-linea-module-limit-file-path=",
+        getResourcePath("/moduleLimitsLimitless.toml"),
+      )
+      .set("--plugin-linea-limitless-enabled=", "true")
+      .set("--plugin-linea-tx-pool-simulation-check-api-enabled=", "true")
+      .set("--plugin-linea-tracing-end-timestamp=", "0")
+      .build()
+  }
+
+  @Test
+  fun transactionOverModuleLineCountIsAdmittedAndSelectedAfterCutoff() {
+    val excludedPrecompiles = deployExcludedPrecompiles()
+    val overLimitTransaction = RawTransaction.createTransaction(
+      CHAIN_ID,
+      BigInteger.ZERO,
+      DefaultGasProvider.GAS_LIMIT.divide(BigInteger.TEN),
+      excludedPrecompiles.contractAddress,
+      BigInteger.ZERO,
+      excludedPrecompiles
+        .callRIPEMD160("cutoff control".toByteArray(StandardCharsets.UTF_8))
+        .encodeFunctionCall(),
+      GAS_PRICE,
+      GAS_PRICE.multiply(BigInteger.TEN).add(BigInteger.ONE),
+    )
+    val signedOverLimitTransaction = TransactionEncoder.signMessage(
+      overLimitTransaction,
+      Credentials.create(Accounts.GENESIS_ACCOUNT_TWO_PRIVATE_KEY),
+    )
+
+    val sendTransactionResponse = minerNode.nodeRequests().eth()
+      .ethSendRawTransaction(Numeric.toHexString(signedOverLimitTransaction))
+      .send()
+
+    assertThat(sendTransactionResponse.hasError()).isFalse()
+    minerNode.verify(
+      eth.expectSuccessfulTransactionReceipt(sendTransactionResponse.transactionHash),
+    )
+  }
+
+  @Test
+  fun estimateGasOverModuleLineCountSucceedsAfterCutoff() {
+    val bls12MapFpToG1 = deployBLS12_MAP_FP_TO_G1()
+    val overflowCallParameters = EstimateGasTest.CallParams(
+      chainId = null,
+      from = accounts.secondaryBenefactor.address,
+      nonce = null,
+      to = bls12MapFpToG1.contractAddress,
+      value = null,
+      data = BlsMapFpToG1OverflowSetup.encodeOverflowCall(bls12MapFpToG1),
+      gas = "0",
+      gasPrice = DefaultGasProvider.GAS_PRICE.toString(),
+      maxFeePerGas = null,
+      maxPriorityFeePerGas = null,
+    )
+
+    val estimateGasResponse = EstimateGasTest.LineaEstimateGasRequest(overflowCallParameters)
+      .execute(minerNode.nodeRequests())
+
+    assertThat(estimateGasResponse.hasError()).isFalse()
+    assertThat(estimateGasResponse.result.gasLimit).isNotBlank()
+  }
+
+  companion object {
+    private val GAS_PRICE = BigInteger.TEN.pow(11)
+  }
+}

--- a/linea-besu/plugins/linea-sequencer/docs/plugins.md
+++ b/linea-besu/plugins/linea-sequencer/docs/plugins.md
@@ -35,6 +35,13 @@ It is used in:
 |-------------------------------------------------------|----------------------|
 | `--plugin-linea-module-limit-file-path`               | moduleLimitFile.toml |
 | `--plugin-linea-over-line-count-limit-cache-size`     | 10_000               |
+| `--plugin-linea-tracing-end-timestamp`                | not set              |
+
+`--plugin-linea-tracing-end-timestamp` is an optional Unix epoch timestamp in seconds. Bespoke
+tracing and module-line-limit validation are enabled when the next pending block timestamp is
+strictly less than the configured value, and disabled when it is equal to or greater than the
+configured value. A value of `0` disables bespoke tracing for all normal blocks. When the option is
+not set, tracing remains enabled.
 
 
 ### L1<>L2 bridge

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/AbstractLineaSharedPrivateOptionsPlugin.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/AbstractLineaSharedPrivateOptionsPlugin.java
@@ -171,7 +171,8 @@ public abstract class AbstractLineaSharedPrivateOptionsPlugin
     return new LineaTracerConfiguration(
         tracerLineLimitConfig.moduleLimitsFilePath(),
         tracerLineLimitConfig.moduleLimitsMap(),
-        tracerSharedConfig.isLimitless());
+        tracerSharedConfig.isLimitless(),
+        tracerLineLimitConfig.tracingEndTimestamp());
   }
 
   public LineaRejectedTxReportingConfiguration rejectedTxReportingConfiguration() {

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/config/LineaTracerCliOptions.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/config/LineaTracerCliOptions.java
@@ -9,6 +9,7 @@
 package lineth.config;
 
 import com.google.common.base.MoreObjects;
+import java.util.OptionalLong;
 import lineth.sequencer.modulelimit.ModuleLineCountValidator;
 import net.consensys.linea.plugins.LineaCliOptions;
 import picocli.CommandLine;
@@ -18,6 +19,7 @@ public class LineaTracerCliOptions implements LineaCliOptions {
 
   public static final String MODULE_LIMIT_FILE_PATH = "--plugin-linea-module-limit-file-path";
   public static final String DEFAULT_MODULE_LIMIT_FILE_PATH = "moduleLimitFile.toml";
+  public static final String TRACING_END_TIMESTAMP = "--plugin-linea-tracing-end-timestamp";
 
   @CommandLine.Option(
       names = {MODULE_LIMIT_FILE_PATH},
@@ -26,6 +28,13 @@ public class LineaTracerCliOptions implements LineaCliOptions {
       description =
           "Path to the toml file containing the module limits (default: ${DEFAULT-VALUE})")
   private String moduleLimitFilePath = DEFAULT_MODULE_LIMIT_FILE_PATH;
+
+  @CommandLine.Option(
+      names = {TRACING_END_TIMESTAMP},
+      paramLabel = "<UNIX_EPOCH_SECONDS>",
+      description =
+          "Stop sequencer bespoke tracing at this pending block timestamp (default: unset)")
+  private Long tracingEndTimestamp;
 
   private LineaTracerCliOptions() {}
 
@@ -47,6 +56,8 @@ public class LineaTracerCliOptions implements LineaCliOptions {
   public static LineaTracerCliOptions fromConfig(final LineaTracerConfiguration config) {
     final LineaTracerCliOptions options = create();
     options.moduleLimitFilePath = config.moduleLimitsFilePath();
+    options.tracingEndTimestamp =
+        config.tracingEndTimestamp().isPresent() ? config.tracingEndTimestamp().getAsLong() : null;
     return options;
   }
 
@@ -57,9 +68,17 @@ public class LineaTracerCliOptions implements LineaCliOptions {
    */
   @Override
   public LineaTracerLineLimitConfiguration toDomainObject() {
+    if (tracingEndTimestamp != null && tracingEndTimestamp < 0) {
+      throw new IllegalArgumentException(TRACING_END_TIMESTAMP + " must be zero or greater");
+    }
+
     return LineaTracerLineLimitConfiguration.builder()
         .moduleLimitsFilePath(moduleLimitFilePath)
         .moduleLimitsMap(ModuleLineCountValidator.createLimitModules(moduleLimitFilePath))
+        .tracingEndTimestamp(
+            tracingEndTimestamp == null
+                ? OptionalLong.empty()
+                : OptionalLong.of(tracingEndTimestamp))
         .build();
   }
 
@@ -67,6 +86,7 @@ public class LineaTracerCliOptions implements LineaCliOptions {
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add(MODULE_LIMIT_FILE_PATH, moduleLimitFilePath)
+        .add(TRACING_END_TIMESTAMP, tracingEndTimestamp)
         .toString();
   }
 }

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/config/LineaTracerConfiguration.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/config/LineaTracerConfiguration.java
@@ -10,11 +10,21 @@
 package lineth.config;
 
 import java.util.Map;
+import java.util.OptionalLong;
 import lombok.Builder;
 import net.consensys.linea.plugins.LineaOptionsConfiguration;
 
 /** The Linea tracer configuration. */
 @Builder(toBuilder = true)
 public record LineaTracerConfiguration(
-    String moduleLimitsFilePath, Map<String, Integer> moduleLimitsMap, boolean isLimitless)
-    implements LineaOptionsConfiguration {}
+    String moduleLimitsFilePath,
+    Map<String, Integer> moduleLimitsMap,
+    boolean isLimitless,
+    OptionalLong tracingEndTimestamp)
+    implements LineaOptionsConfiguration {
+  public LineaTracerConfiguration {
+    if (tracingEndTimestamp == null) {
+      tracingEndTimestamp = OptionalLong.empty();
+    }
+  }
+}

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/config/LineaTracerLineLimitConfiguration.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/config/LineaTracerLineLimitConfiguration.java
@@ -10,11 +10,20 @@
 package lineth.config;
 
 import java.util.Map;
+import java.util.OptionalLong;
 import lombok.Builder;
 import net.consensys.linea.plugins.LineaOptionsConfiguration;
 
 /** The Linea tracer line limit configuration. */
 @Builder(toBuilder = true)
 public record LineaTracerLineLimitConfiguration(
-    String moduleLimitsFilePath, Map<String, Integer> moduleLimitsMap)
-    implements LineaOptionsConfiguration {}
+    String moduleLimitsFilePath,
+    Map<String, Integer> moduleLimitsMap,
+    OptionalLong tracingEndTimestamp)
+    implements LineaOptionsConfiguration {
+  public LineaTracerLineLimitConfiguration {
+    if (tracingEndTimestamp == null) {
+      tracingEndTimestamp = OptionalLong.empty();
+    }
+  }
+}

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/rpc/methods/LineaEstimateGas.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/rpc/methods/LineaEstimateGas.java
@@ -11,7 +11,6 @@ package lineth.rpc.methods;
 
 import static lineth.sequencer.modulelimit.ModuleLineCountValidator.ModuleLineCountResult.MODULE_NOT_DEFINED;
 import static lineth.sequencer.modulelimit.ModuleLineCountValidator.ModuleLineCountResult.TX_MODULE_LINE_COUNT_OVERFLOW;
-import static net.consensys.linea.zktracer.Fork.fromMainnetHardforkIdToTracerFork;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity.create;
 import static org.hyperledger.besu.plugin.services.TransactionSimulationService.SimulationParameters.ALLOW_FUTURE_NONCE;
 
@@ -20,7 +19,6 @@ import com.google.common.annotations.VisibleForTesting;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
-import java.time.Instant;
 import java.util.EnumSet;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -31,19 +29,16 @@ import lineth.config.LineaTracerConfiguration;
 import lineth.config.LineaTransactionPoolValidatorConfiguration;
 import lineth.sequencer.modulelimit.ModuleLimitsValidationResult;
 import lineth.sequencer.modulelimit.ModuleLineCountValidator;
+import lineth.sequencer.tracing.LineaTracerFactory;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
-import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.LineCountingTracer;
-import net.consensys.linea.zktracer.ZkCounter;
-import net.consensys.linea.zktracer.ZkTracer;
 import org.apache.tuweni.bytes.Bytes;
 import org.bouncycastle.asn1.sec.SECNamedCurves;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.crypto.params.ECDomainParameters;
 import org.hyperledger.besu.crypto.SECPSignature;
 import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.datatypes.StateOverrideMap;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
@@ -54,6 +49,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.transaction.CallParameter;
 import org.hyperledger.besu.ethereum.transaction.ImmutableCallParameter;
+import org.hyperledger.besu.evm.tracing.OperationTracer;
 import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
 import org.hyperledger.besu.plugin.services.BesuConfiguration;
 import org.hyperledger.besu.plugin.services.BlockchainService;
@@ -95,8 +91,7 @@ public class LineaEstimateGas {
   private LineaTransactionPoolValidatorConfiguration txValidatorConf;
   private LineaProfitabilityConfiguration profitabilityConf;
   private TransactionProfitabilityCalculator txProfitabilityCalculator;
-  private LineaL1L2BridgeSharedConfiguration l1L2BridgeConfiguration;
-  private LineaTracerConfiguration tracerConfiguration;
+  private LineaTracerFactory tracerFactory;
   private ModuleLineCountValidator moduleLineCountValidator;
 
   public LineaEstimateGas(
@@ -122,8 +117,9 @@ public class LineaEstimateGas {
     this.txValidatorConf = transactionValidatorConfiguration;
     this.profitabilityConf = profitabilityConf;
     this.txProfitabilityCalculator = transactionProfitabilityCalculator;
-    this.l1L2BridgeConfiguration = l1L2BridgeConfiguration;
-    this.tracerConfiguration = tracerConfiguration;
+    this.tracerFactory =
+        LineaTracerFactory.fromBlockchainService(
+            blockchainService, tracerConfiguration, l1L2BridgeConfiguration);
     this.moduleLineCountValidator =
         new ModuleLineCountValidator(tracerConfiguration.moduleLimitsMap());
     this.worldStateService = worldStateService;
@@ -266,22 +262,30 @@ public class LineaEstimateGas {
       final long logId) {
 
     final var pendingBlockHeader = transactionSimulationService.simulatePendingBlockHeader();
-    final var lineCountingTracer = createLineCountingTracer(pendingBlockHeader, blockchainService);
+    final var lineCountingTracer = tracerFactory.create(pendingBlockHeader.getTimestamp());
+    lineCountingTracer.ifPresent(tracer -> initializeTracer(tracer, pendingBlockHeader));
+    final OperationTracer operationTracer =
+        lineCountingTracer
+            .<OperationTracer>map(tracer -> tracer)
+            .orElse(OperationTracer.NO_TRACING);
 
     final var maybeSimulationResults =
         transactionSimulationService.simulate(
             callParameter,
             maybeStateOverrides,
             pendingBlockHeader,
-            lineCountingTracer,
+            operationTracer,
             EnumSet.of(ALLOW_FUTURE_NONCE));
 
-    ModuleLimitsValidationResult moduleLimit =
-        moduleLineCountValidator.validate(lineCountingTracer.getModulesLineCount());
-
-    if (moduleLimit.getResult() != ModuleLineCountValidator.ModuleLineCountResult.VALID) {
-      handleModuleOverLimit(moduleLimit);
-    }
+    lineCountingTracer.ifPresent(
+        tracer -> {
+          ModuleLimitsValidationResult moduleLimitResult =
+              moduleLineCountValidator.validate(tracer.getModulesLineCount());
+          if (moduleLimitResult.getResult()
+              != ModuleLineCountValidator.ModuleLineCountResult.VALID) {
+            handleModuleOverLimit(moduleLimitResult);
+          }
+        });
 
     maybeSimulationResults.ifPresentOrElse(
         r -> {
@@ -436,22 +440,12 @@ public class LineaEstimateGas {
         .orElse(0L);
   }
 
-  private LineCountingTracer createLineCountingTracer(
-      final ProcessableBlockHeader pendingBlockHeader, final BlockchainService blockchainService) {
-    final Fork forkId =
-        fromMainnetHardforkIdToTracerFork(
-            (HardforkId.MainnetHardforkId)
-                blockchainService.getNextBlockHardforkId(
-                    blockchainService.getChainHeadHeader(), Instant.now().getEpochSecond()));
-
-    final var lineCountingTracer =
-        tracerConfiguration.isLimitless()
-            ? new ZkCounter(l1L2BridgeConfiguration, forkId)
-            : new ZkTracer(forkId, l1L2BridgeConfiguration, blockchainService.getChainId().get());
+  private void initializeTracer(
+      final LineCountingTracer lineCountingTracer,
+      final ProcessableBlockHeader pendingBlockHeader) {
     lineCountingTracer.traceStartConflation(1L);
     lineCountingTracer.traceStartBlock(
         worldStateService.getWorldView(), pendingBlockHeader, pendingBlockHeader.getCoinbase());
-    return lineCountingTracer;
   }
 
   private void handleModuleOverLimit(ModuleLimitsValidationResult moduleLimitResult) {

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/sequencer/tracing/BespokeTracingActivationPolicy.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/sequencer/tracing/BespokeTracingActivationPolicy.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package lineth.sequencer.tracing;
+
+import java.util.OptionalLong;
+
+/** Determines whether bespoke tracing is active for a pending block. */
+public record BespokeTracingActivationPolicy(OptionalLong tracingEndTimestamp) {
+  public BespokeTracingActivationPolicy {
+    if (tracingEndTimestamp == null) {
+      tracingEndTimestamp = OptionalLong.empty();
+    }
+    if (tracingEndTimestamp.isPresent() && tracingEndTimestamp.getAsLong() < 0) {
+      throw new IllegalArgumentException("Tracing end timestamp must be zero or greater");
+    }
+  }
+
+  public boolean shouldTrace(final long pendingBlockTimestamp) {
+    return tracingEndTimestamp.isEmpty() || pendingBlockTimestamp < tracingEndTimestamp.getAsLong();
+  }
+}

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/sequencer/tracing/LineaTracerFactory.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/sequencer/tracing/LineaTracerFactory.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package lineth.sequencer.tracing;
+
+import static net.consensys.linea.zktracer.Fork.fromMainnetHardforkIdToTracerFork;
+
+import java.math.BigInteger;
+import java.util.Optional;
+import java.util.function.Supplier;
+import lineth.config.LineaTracerConfiguration;
+import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
+import net.consensys.linea.zktracer.Fork;
+import net.consensys.linea.zktracer.LineCountingTracer;
+import net.consensys.linea.zktracer.ZkCounter;
+import net.consensys.linea.zktracer.ZkTracer;
+import org.hyperledger.besu.datatypes.HardforkId;
+import org.hyperledger.besu.plugin.services.BlockchainService;
+
+/** Creates sequencer bespoke tracers while their activation policy is enabled. */
+public class LineaTracerFactory {
+  @FunctionalInterface
+  public interface HardforkResolver {
+    Fork resolve(long pendingBlockTimestamp);
+  }
+
+  private final BespokeTracingActivationPolicy activationPolicy;
+  private final LineaTracerConfiguration tracerConfiguration;
+  private final LineaL1L2BridgeSharedConfiguration bridgeConfiguration;
+  private final Supplier<BigInteger> chainIdSupplier;
+  private final HardforkResolver hardforkResolver;
+
+  public LineaTracerFactory(
+      final BespokeTracingActivationPolicy activationPolicy,
+      final LineaTracerConfiguration tracerConfiguration,
+      final LineaL1L2BridgeSharedConfiguration bridgeConfiguration,
+      final Supplier<BigInteger> chainIdSupplier,
+      final HardforkResolver hardforkResolver) {
+    this.activationPolicy = activationPolicy;
+    this.tracerConfiguration = tracerConfiguration;
+    this.bridgeConfiguration = bridgeConfiguration;
+    this.chainIdSupplier = chainIdSupplier;
+    this.hardforkResolver = hardforkResolver;
+  }
+
+  public static LineaTracerFactory fromBlockchainService(
+      final BlockchainService blockchainService,
+      final LineaTracerConfiguration tracerConfiguration,
+      final LineaL1L2BridgeSharedConfiguration bridgeConfiguration) {
+    return new LineaTracerFactory(
+        new BespokeTracingActivationPolicy(tracerConfiguration.tracingEndTimestamp()),
+        tracerConfiguration,
+        bridgeConfiguration,
+        () ->
+            blockchainService
+                .getChainId()
+                .orElseThrow(
+                    () ->
+                        new IllegalStateException("Failed to get chain ID from BlockchainService")),
+        pendingBlockTimestamp ->
+            fromMainnetHardforkIdToTracerFork(
+                (HardforkId.MainnetHardforkId)
+                    blockchainService.getNextBlockHardforkId(
+                        blockchainService.getChainHeadHeader(), pendingBlockTimestamp)));
+  }
+
+  public Optional<LineCountingTracer> create(final long pendingBlockTimestamp) {
+    if (!activationPolicy.shouldTrace(pendingBlockTimestamp)) {
+      return Optional.empty();
+    }
+
+    final Fork fork = hardforkResolver.resolve(pendingBlockTimestamp);
+    return Optional.of(
+        tracerConfiguration.isLimitless()
+            ? new ZkCounter(bridgeConfiguration, fork)
+            : new ZkTracer(fork, bridgeConfiguration, chainIdSupplier.get()));
+  }
+}

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/sequencer/txpoolvalidation/LineaTransactionPoolValidatorFactory.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/sequencer/txpoolvalidation/LineaTransactionPoolValidatorFactory.java
@@ -19,6 +19,7 @@ import lineth.config.LineaTracerConfiguration;
 import lineth.config.LineaTransactionPoolValidatorConfiguration;
 import lineth.config.LineaTransactionValidatorConfiguration;
 import lineth.jsonrpc.JsonRpcManager;
+import lineth.sequencer.tracing.BespokeTracingActivationPolicy;
 import lineth.sequencer.txpoolvalidation.validators.CalldataValidator;
 import lineth.sequencer.txpoolvalidation.validators.DeniedAddressValidator;
 import lineth.sequencer.txpoolvalidation.validators.GasLimitValidator;
@@ -121,7 +122,11 @@ public class LineaTransactionPoolValidatorFactory implements PluginTransactionPo
     if (!blockTransactionValidatorActive) {
       validators.add(new TransactionTypeValidator(txValidatorConf));
     }
-    validators.add(new TraceLineLimitValidator(invalidTransactionByLineCountCache));
+    validators.add(
+        new TraceLineLimitValidator(
+            invalidTransactionByLineCountCache,
+            new BespokeTracingActivationPolicy(tracerConfiguration.tracingEndTimestamp()),
+            () -> transactionSimulationService.simulatePendingBlockHeader().getTimestamp()));
     validators.add(new DeniedAddressValidator(deniedAddresses));
     validators.add(new PrecompileAddressValidator());
     validators.add(new GasLimitValidator(txPoolValidatorConf.maxTxGasLimit()));

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/sequencer/txpoolvalidation/validators/SimulationValidator.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/sequencer/txpoolvalidation/validators/SimulationValidator.java
@@ -10,7 +10,6 @@ package lineth.sequencer.txpoolvalidation.validators;
 
 import static lineth.sequencer.modulelimit.ModuleLineCountValidator.ModuleLineCountResult.MODULE_NOT_DEFINED;
 import static lineth.sequencer.modulelimit.ModuleLineCountValidator.ModuleLineCountResult.TX_MODULE_LINE_COUNT_OVERFLOW;
-import static net.consensys.linea.zktracer.Fork.fromMainnetHardforkIdToTracerFork;
 import static org.hyperledger.besu.plugin.services.TransactionSimulationService.SimulationParameters.ALLOW_FUTURE_NONCE;
 
 import java.time.Instant;
@@ -23,15 +22,13 @@ import lineth.jsonrpc.JsonRpcManager;
 import lineth.jsonrpc.JsonRpcRequestBuilder;
 import lineth.sequencer.modulelimit.ModuleLimitsValidationResult;
 import lineth.sequencer.modulelimit.ModuleLineCountValidator;
+import lineth.sequencer.tracing.LineaTracerFactory;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
-import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.LineCountingTracer;
-import net.consensys.linea.zktracer.ZkCounter;
-import net.consensys.linea.zktracer.ZkTracer;
 import net.consensys.linea.zktracer.exceptions.TracingExceptions;
-import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.datatypes.Transaction;
+import org.hyperledger.besu.evm.tracing.OperationTracer;
 import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
 import org.hyperledger.besu.plugin.data.TransactionSimulationResult;
 import org.hyperledger.besu.plugin.services.BlockchainService;
@@ -45,12 +42,11 @@ import org.hyperledger.besu.plugin.services.txvalidator.PluginTransactionPoolVal
  */
 @Slf4j
 public class SimulationValidator implements PluginTransactionPoolValidator {
-  private final BlockchainService blockchainService;
   private final WorldStateService worldStateService;
   private final TransactionSimulationService transactionSimulationService;
   private final LineaTransactionPoolValidatorConfiguration txPoolValidatorConf;
-  private final LineaL1L2BridgeSharedConfiguration l1L2BridgeConfiguration;
   private final LineaTracerConfiguration tracerConfiguration;
+  private final LineaTracerFactory tracerFactory;
   private final Optional<JsonRpcManager> rejectedTxJsonRpcManager;
 
   public SimulationValidator(
@@ -61,12 +57,13 @@ public class SimulationValidator implements PluginTransactionPoolValidator {
       final LineaTracerConfiguration tracerConfiguration,
       final LineaL1L2BridgeSharedConfiguration l1L2BridgeConfiguration,
       final Optional<JsonRpcManager> rejectedTxJsonRpcManager) {
-    this.blockchainService = blockchainService;
     this.worldStateService = worldStateService;
     this.transactionSimulationService = transactionSimulationService;
     this.txPoolValidatorConf = txPoolValidatorConf;
-    this.l1L2BridgeConfiguration = l1L2BridgeConfiguration;
     this.tracerConfiguration = tracerConfiguration;
+    this.tracerFactory =
+        LineaTracerFactory.fromBlockchainService(
+            blockchainService, tracerConfiguration, l1L2BridgeConfiguration);
     this.rejectedTxJsonRpcManager = rejectedTxJsonRpcManager;
   }
 
@@ -90,32 +87,45 @@ public class SimulationValidator implements PluginTransactionPoolValidator {
       final ModuleLineCountValidator moduleLineCountValidator =
           new ModuleLineCountValidator(tracerConfiguration.moduleLimitsMap());
       final var pendingBlockHeader = transactionSimulationService.simulatePendingBlockHeader();
-
-      final var lineCountingTracer =
-          createLineCountingTracer(pendingBlockHeader, blockchainService);
+      final var lineCountingTracer = tracerFactory.create(pendingBlockHeader.getTimestamp());
+      lineCountingTracer.ifPresent(tracer -> initializeTracer(tracer, pendingBlockHeader));
+      final OperationTracer operationTracer =
+          lineCountingTracer
+              .<OperationTracer>map(tracer -> tracer)
+              .orElse(OperationTracer.NO_TRACING);
       final var maybeSimulationResults =
           transactionSimulationService.simulate(
               transaction,
               Optional.empty(),
               pendingBlockHeader,
-              lineCountingTracer,
+              operationTracer,
               EnumSet.of(ALLOW_FUTURE_NONCE));
 
-      ModuleLimitsValidationResult moduleLimitResult;
-      try {
-        moduleLimitResult =
-            moduleLineCountValidator.validate(lineCountingTracer.getModulesLineCount());
-      } catch (TracingExceptions e) {
-        log.warn(
-            "Tracer failed during simulation of tx {}: {}", transaction.getHash(), e.getMessage());
-        return Optional.of("Tracer error during simulation: " + e.getMessage());
+      final Optional<ModuleLimitsValidationResult> moduleLimitResult;
+      if (lineCountingTracer.isPresent()) {
+        try {
+          moduleLimitResult =
+              Optional.of(
+                  moduleLineCountValidator.validate(
+                      lineCountingTracer.get().getModulesLineCount()));
+        } catch (TracingExceptions e) {
+          log.warn(
+              "Tracer failed during simulation of tx {}: {}",
+              transaction.getHash(),
+              e.getMessage());
+          return Optional.of("Tracer error during simulation: " + e.getMessage());
+        }
+      } else {
+        moduleLimitResult = Optional.empty();
       }
 
       logSimulationResult(
           transaction, isLocal, hasPriority, maybeSimulationResults, moduleLimitResult);
 
-      if (moduleLimitResult.getResult() != ModuleLineCountValidator.ModuleLineCountResult.VALID) {
-        final String reason = handleModuleOverLimit(transaction, moduleLimitResult);
+      if (moduleLimitResult.isPresent()
+          && moduleLimitResult.get().getResult()
+              != ModuleLineCountValidator.ModuleLineCountResult.VALID) {
+        final String reason = handleModuleOverLimit(transaction, moduleLimitResult.orElseThrow());
         reportRejectedTransaction(transaction, reason);
         return Optional.of(reason);
       }
@@ -163,7 +173,7 @@ public class SimulationValidator implements PluginTransactionPoolValidator {
       final boolean isLocal,
       final boolean hasPriority,
       final Optional<TransactionSimulationResult> maybeSimulationResults,
-      final ModuleLimitsValidationResult moduleLimitResult) {
+      final Optional<ModuleLimitsValidationResult> moduleLimitResult) {
     log.atTrace()
         .setMessage(
             "Result of simulation validation for tx with hash={}, isLocal={}, hasPriority={}, is {}, module line counts {}")
@@ -175,22 +185,12 @@ public class SimulationValidator implements PluginTransactionPoolValidator {
         .log();
   }
 
-  private LineCountingTracer createLineCountingTracer(
-      final ProcessableBlockHeader pendingBlockHeader, BlockchainService blockchainService) {
-    final Fork forkId =
-        fromMainnetHardforkIdToTracerFork(
-            (HardforkId.MainnetHardforkId)
-                blockchainService.getNextBlockHardforkId(
-                    blockchainService.getChainHeadHeader(), Instant.now().getEpochSecond()));
-
-    final LineCountingTracer lineCountingTracer =
-        tracerConfiguration.isLimitless()
-            ? new ZkCounter(l1L2BridgeConfiguration, forkId)
-            : new ZkTracer(forkId, l1L2BridgeConfiguration, blockchainService.getChainId().get());
+  private void initializeTracer(
+      final LineCountingTracer lineCountingTracer,
+      final ProcessableBlockHeader pendingBlockHeader) {
     lineCountingTracer.traceStartConflation(1L);
     lineCountingTracer.traceStartBlock(
         worldStateService.getWorldView(), pendingBlockHeader, pendingBlockHeader.getCoinbase());
-    return lineCountingTracer;
   }
 
   private String handleModuleOverLimit(

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/sequencer/txpoolvalidation/validators/TraceLineLimitValidator.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/sequencer/txpoolvalidation/validators/TraceLineLimitValidator.java
@@ -9,6 +9,8 @@
 package lineth.sequencer.txpoolvalidation.validators;
 
 import java.util.Optional;
+import java.util.function.LongSupplier;
+import lineth.sequencer.tracing.BespokeTracingActivationPolicy;
 import lineth.sequencer.txselection.InvalidTransactionByLineCountCache;
 import lombok.extern.slf4j.Slf4j;
 import org.hyperledger.besu.datatypes.Transaction;
@@ -23,27 +25,44 @@ import org.hyperledger.besu.plugin.services.txvalidator.PluginTransactionPoolVal
 public class TraceLineLimitValidator implements PluginTransactionPoolValidator {
 
   private final InvalidTransactionByLineCountCache invalidTransactionByLineCountCache;
+  private final BespokeTracingActivationPolicy activationPolicy;
+  private final LongSupplier pendingBlockTimestampSupplier;
 
   public TraceLineLimitValidator(
-      final InvalidTransactionByLineCountCache invalidTransactionByLineCountCache) {
+      final InvalidTransactionByLineCountCache invalidTransactionByLineCountCache,
+      final BespokeTracingActivationPolicy activationPolicy,
+      final LongSupplier pendingBlockTimestampSupplier) {
     this.invalidTransactionByLineCountCache = invalidTransactionByLineCountCache;
+    this.activationPolicy = activationPolicy;
+    this.pendingBlockTimestampSupplier = pendingBlockTimestampSupplier;
   }
 
   @Override
   public Optional<String> validateTransaction(
       final Transaction transaction, final boolean isLocal, final boolean hasPriority) {
 
-    if (invalidTransactionByLineCountCache.contains(transaction.getHash())) {
-      final String reason =
-          String.format(
-              "Transaction %s was already identified to go over line count limit",
-              transaction.getHash());
-
-      log.trace(reason);
-
-      return Optional.of(reason);
+    if (!invalidTransactionByLineCountCache.contains(transaction.getHash())) {
+      return Optional.empty();
     }
 
-    return Optional.empty();
+    try {
+      if (!activationPolicy.shouldTrace(pendingBlockTimestampSupplier.getAsLong())) {
+        return Optional.empty();
+      }
+    } catch (RuntimeException e) {
+      log.warn(
+          "Unable to determine pending block timestamp for cached line-count validation of transaction {}",
+          transaction.getHash(),
+          e);
+    }
+
+    final String reason =
+        String.format(
+            "Transaction %s was already identified to go over line count limit",
+            transaction.getHash());
+
+    log.trace(reason);
+
+    return Optional.of(reason);
   }
 }

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/sequencer/txselection/LineaTransactionSelectorFactory.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/sequencer/txselection/LineaTransactionSelectorFactory.java
@@ -32,6 +32,7 @@ import lineth.jsonrpc.JsonRpcManager;
 import lineth.metrics.HistogramMetrics;
 import lineth.sequencer.forced.ForcedTransactionPoolService;
 import lineth.sequencer.liveness.LivenessService;
+import lineth.sequencer.tracing.LineaTracerFactory;
 import lineth.sequencer.txselection.selectors.LineaTransactionSelector;
 import lineth.sequencer.txselection.selectors.TransactionEventFilter;
 import lineth.utils.TransactionCompressor;
@@ -58,9 +59,9 @@ public class LineaTransactionSelectorFactory implements PluginTransactionSelecto
   private final BlockchainService blockchainService;
   private final Optional<JsonRpcManager> rejectedTxJsonRpcManager;
   private final LineaTransactionSelectorConfiguration txSelectorConfiguration;
-  private final LineaL1L2BridgeSharedConfiguration l1L2BridgeConfiguration;
   private final LineaProfitabilityConfiguration profitabilityConfiguration;
   private final LineaTracerConfiguration tracerConfiguration;
+  private final LineaTracerFactory tracerFactory;
   private final Optional<HistogramMetrics> maybeProfitabilityMetrics;
   private final BundlePoolService bundlePoolService;
   private final ForcedTransactionPoolService forcedTransactionPoolService;
@@ -95,9 +96,11 @@ public class LineaTransactionSelectorFactory implements PluginTransactionSelecto
       final BlobCompressorSelectorByTimestamp blobCompressorSelectorByTimestamp) {
     this.blockchainService = blockchainService;
     this.txSelectorConfiguration = txSelectorConfiguration;
-    this.l1L2BridgeConfiguration = l1L2BridgeConfiguration;
     this.profitabilityConfiguration = profitabilityConfiguration;
     this.tracerConfiguration = tracerConfiguration;
+    this.tracerFactory =
+        LineaTracerFactory.fromBlockchainService(
+            blockchainService, tracerConfiguration, l1L2BridgeConfiguration);
     this.rejectedTxJsonRpcManager = rejectedTxJsonRpcManager;
     this.maybeProfitabilityMetrics = maybeProfitabilityMetrics;
     this.bundlePoolService = bundlePoolService;
@@ -127,9 +130,9 @@ public class LineaTransactionSelectorFactory implements PluginTransactionSelecto
             selectorsStateManager,
             blockchainService,
             txSelectorConfiguration,
-            l1L2BridgeConfiguration,
             profitabilityConfiguration,
             tracerConfiguration,
+            tracerFactory.create(pendingBlockHeader.getTimestamp()),
             rejectedTxJsonRpcManager,
             maybeProfitabilityMetrics,
             invalidTransactionByLineCountCache,
@@ -282,12 +285,12 @@ public class LineaTransactionSelectorFactory implements PluginTransactionSelecto
   }
 
   private void commit(final BlockTransactionSelectionService bts) {
-    currSelector.get().getOperationTracer().commitTransactionBundle();
+    currSelector.get().commitTransactionBundle();
     bts.commit();
   }
 
   private void rollback(final BlockTransactionSelectionService bts) {
-    currSelector.get().getOperationTracer().popTransactionBundle();
+    currSelector.get().popTransactionBundle();
     bts.rollback();
   }
 

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/sequencer/txselection/selectors/LineaTransactionSelector.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/sequencer/txselection/selectors/LineaTransactionSelector.java
@@ -26,12 +26,12 @@ import lineth.metrics.HistogramMetrics;
 import lineth.sequencer.txselection.InvalidTransactionByLineCountCache;
 import lineth.utils.TransactionCompressor;
 import lombok.extern.slf4j.Slf4j;
-import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
 import net.consensys.linea.zktracer.LineCountingTracer;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.plugin.data.TransactionProcessingResult;
 import org.hyperledger.besu.plugin.data.TransactionSelectionResult;
 import org.hyperledger.besu.plugin.services.BlockchainService;
+import org.hyperledger.besu.plugin.services.tracer.BlockAwareOperationTracer;
 import org.hyperledger.besu.plugin.services.txselection.PluginTransactionSelector;
 import org.hyperledger.besu.plugin.services.txselection.SelectorsStateManager;
 import org.hyperledger.besu.plugin.services.txselection.TransactionEvaluationContext;
@@ -43,7 +43,7 @@ public class LineaTransactionSelector implements PluginTransactionSelector {
   private static final Set<String> REJECTED_TX_STATUS_NAMES =
       Set.of("TX_MODULE_LINE_COUNT_OVERFLOW", "TX_MODULE_LINE_COUNT_OVERFLOW_CACHED");
 
-  private TraceLineLimitTransactionSelector traceLineLimitTransactionSelector;
+  private Optional<TraceLineLimitTransactionSelector> traceLineLimitTransactionSelector;
   private final List<PluginTransactionSelector> selectors;
   private final Optional<JsonRpcManager> rejectedTxJsonRpcManager;
 
@@ -51,9 +51,9 @@ public class LineaTransactionSelector implements PluginTransactionSelector {
       final SelectorsStateManager selectorsStateManager,
       final BlockchainService blockchainService,
       final LineaTransactionSelectorConfiguration txSelectorConfiguration,
-      final LineaL1L2BridgeSharedConfiguration l1L2BridgeConfiguration,
       final LineaProfitabilityConfiguration profitabilityConfiguration,
       final LineaTracerConfiguration tracerConfiguration,
+      final Optional<LineCountingTracer> lineCountingTracer,
       final Optional<JsonRpcManager> rejectedTxJsonRpcManager,
       final Optional<HistogramMetrics> maybeProfitabilityMetrics,
       final InvalidTransactionByLineCountCache invalidTransactionByLineCountCache,
@@ -70,9 +70,9 @@ public class LineaTransactionSelector implements PluginTransactionSelector {
             selectorsStateManager,
             blockchainService,
             txSelectorConfiguration,
-            l1L2BridgeConfiguration,
             profitabilityConfiguration,
             tracerConfiguration,
+            lineCountingTracer,
             maybeProfitabilityMetrics,
             invalidTransactionByLineCountCache,
             deniedEvents,
@@ -102,9 +102,9 @@ public class LineaTransactionSelector implements PluginTransactionSelector {
       final SelectorsStateManager selectorsStateManager,
       final BlockchainService blockchainService,
       final LineaTransactionSelectorConfiguration txSelectorConfiguration,
-      final LineaL1L2BridgeSharedConfiguration l1L2BridgeConfiguration,
       final LineaProfitabilityConfiguration profitabilityConfiguration,
       final LineaTracerConfiguration tracerConfiguration,
+      final Optional<LineCountingTracer> lineCountingTracer,
       final Optional<HistogramMetrics> maybeProfitabilityMetrics,
       final InvalidTransactionByLineCountCache invalidTransactionByLineCountCache,
       final Map<Address, Set<TransactionEventFilter>> deniedEvents,
@@ -115,12 +115,13 @@ public class LineaTransactionSelector implements PluginTransactionSelector {
       final BlobCompressorSelectorByTimestamp blobCompressorSelectorByTimestamp) {
 
     traceLineLimitTransactionSelector =
-        new TraceLineLimitTransactionSelector(
-            selectorsStateManager,
-            blockchainService,
-            l1L2BridgeConfiguration,
-            tracerConfiguration,
-            invalidTransactionByLineCountCache);
+        lineCountingTracer.map(
+            tracer ->
+                new TraceLineLimitTransactionSelector(
+                    selectorsStateManager,
+                    tracerConfiguration,
+                    invalidTransactionByLineCountCache,
+                    tracer));
 
     final List<PluginTransactionSelector> selectorsList = new ArrayList<>();
     selectorsList.add(new AllowedAddressTransactionSelector(deniedAddresses));
@@ -156,7 +157,7 @@ public class LineaTransactionSelector implements PluginTransactionSelector {
     selectorsList.add(
         new MaxBundleGasPerBlockTransactionSelector(
             selectorsStateManager, txSelectorConfiguration.maxBundleGasPerBlock()));
-    selectorsList.add(traceLineLimitTransactionSelector);
+    traceLineLimitTransactionSelector.ifPresent(selectorsList::add);
     selectorsList.add(new TransactionEventSelector(deniedEvents, deniedBundleEvents));
 
     return List.copyOf(selectorsList);
@@ -214,7 +215,7 @@ public class LineaTransactionSelector implements PluginTransactionSelector {
 
     // if pending tx is not from a bundle, then we need to commit now
     if (!(evaluationContext.getPendingTransaction() instanceof TransactionBundle.PendingBundleTx)) {
-      getOperationTracer().commitTransactionBundle();
+      commitTransactionBundle();
     }
 
     selectors.forEach(
@@ -234,7 +235,7 @@ public class LineaTransactionSelector implements PluginTransactionSelector {
 
     // if pending tx is not from a bundle, then we need to rollback now
     if (!(evaluationContext.getPendingTransaction() instanceof TransactionBundle.PendingBundleTx)) {
-      getOperationTracer().popTransactionBundle();
+      popTransactionBundle();
     }
 
     selectors.forEach(
@@ -263,8 +264,20 @@ public class LineaTransactionSelector implements PluginTransactionSelector {
    * @return the operation tracer
    */
   @Override
-  public LineCountingTracer getOperationTracer() {
-    return traceLineLimitTransactionSelector.getOperationTracer();
+  public BlockAwareOperationTracer getOperationTracer() {
+    return traceLineLimitTransactionSelector
+        .<BlockAwareOperationTracer>map(TraceLineLimitTransactionSelector::getOperationTracer)
+        .orElse(BlockAwareOperationTracer.NO_TRACING);
+  }
+
+  public void commitTransactionBundle() {
+    traceLineLimitTransactionSelector.ifPresent(
+        selector -> selector.getOperationTracer().commitTransactionBundle());
+  }
+
+  public void popTransactionBundle() {
+    traceLineLimitTransactionSelector.ifPresent(
+        selector -> selector.getOperationTracer().popTransactionBundle());
   }
 
   /**

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/sequencer/txselection/selectors/TraceLineLimitTransactionSelector.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/lineth/sequencer/txselection/selectors/TraceLineLimitTransactionSelector.java
@@ -12,11 +12,9 @@ import static lineth.txselection.LineaTransactionSelectionResult.BLOCK_MODULE_LI
 import static lineth.txselection.LineaTransactionSelectionResult.TX_MODULE_LINE_INVALID_COUNT;
 import static lineth.txselection.LineaTransactionSelectionResult.txModuleLineCountOverflow;
 import static lineth.txselection.LineaTransactionSelectionResult.txModuleLineCountOverflowCached;
-import static net.consensys.linea.zktracer.Fork.fromMainnetHardforkIdToTracerFork;
 import static org.hyperledger.besu.plugin.data.TransactionSelectionResult.SELECTED;
 import static org.hyperledger.besu.plugin.data.TransactionSelectionResult.SELECTION_CANCELLED;
 
-import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -28,15 +26,10 @@ import lineth.sequencer.modulelimit.ModuleLimitsValidationResult;
 import lineth.sequencer.modulelimit.ModuleLineCountValidator;
 import lineth.sequencer.txselection.InvalidTransactionByLineCountCache;
 import lombok.extern.slf4j.Slf4j;
-import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
-import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.LineCountingTracer;
-import net.consensys.linea.zktracer.ZkCounter;
-import net.consensys.linea.zktracer.ZkTracer;
 import net.consensys.linea.zktracer.container.module.Module;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Log;
 import org.hyperledger.besu.datatypes.Transaction;
@@ -50,7 +43,6 @@ import org.hyperledger.besu.plugin.data.BlockHeader;
 import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
 import org.hyperledger.besu.plugin.data.TransactionProcessingResult;
 import org.hyperledger.besu.plugin.data.TransactionSelectionResult;
-import org.hyperledger.besu.plugin.services.BlockchainService;
 import org.hyperledger.besu.plugin.services.txselection.AbstractStatefulPluginTransactionSelector;
 import org.hyperledger.besu.plugin.services.txselection.SelectorsStateManager;
 import org.hyperledger.besu.plugin.services.txselection.TransactionEvaluationContext;
@@ -73,10 +65,9 @@ public class TraceLineLimitTransactionSelector
 
   public TraceLineLimitTransactionSelector(
       final SelectorsStateManager stateManager,
-      final BlockchainService blockchainService,
-      final LineaL1L2BridgeSharedConfiguration l1L2BridgeConfiguration,
       final LineaTracerConfiguration tracerConfiguration,
-      final InvalidTransactionByLineCountCache invalidTransactionByLineCountCache) {
+      final InvalidTransactionByLineCountCache invalidTransactionByLineCountCache,
+      final LineCountingTracer lineCountingTracer) {
     super(
         stateManager,
         tracerConfiguration.moduleLimitsMap().keySet().stream()
@@ -86,17 +77,15 @@ public class TraceLineLimitTransactionSelector
     this.tracerConfiguration = tracerConfiguration;
     this.invalidTransactionByLineCountCache = invalidTransactionByLineCountCache;
 
-    lineCountingTracer =
-        new LineCountingTracerWithLog(
-            tracerConfiguration, l1L2BridgeConfiguration, blockchainService);
-    for (Module m : lineCountingTracer.getModulesToCount()) {
+    this.lineCountingTracer = new LineCountingTracerWithLog(lineCountingTracer);
+    for (Module m : this.lineCountingTracer.getModulesToCount()) {
       if (!tracerConfiguration.moduleLimitsMap().containsKey(m.moduleKey().name())) {
         throw new IllegalStateException(
             "Limit for module %s not defined in %s"
                 .formatted(m.moduleKey(), tracerConfiguration.moduleLimitsFilePath()));
       }
     }
-    lineCountingTracer.traceStartConflation(1L);
+    this.lineCountingTracer.traceStartConflation(1L);
     moduleLineCountValidator = new ModuleLineCountValidator(tracerConfiguration.moduleLimitsMap());
   }
 
@@ -242,21 +231,8 @@ public class TraceLineLimitTransactionSelector
   private class LineCountingTracerWithLog implements LineCountingTracer {
     private final LineCountingTracer delegate;
 
-    public LineCountingTracerWithLog(
-        final LineaTracerConfiguration tracerConfiguration,
-        final LineaL1L2BridgeSharedConfiguration bridgeConfiguration,
-        final BlockchainService blockchainService) {
-
-      final Fork forkId =
-          fromMainnetHardforkIdToTracerFork(
-              (HardforkId.MainnetHardforkId)
-                  blockchainService.getNextBlockHardforkId(
-                      blockchainService.getChainHeadHeader(), Instant.now().getEpochSecond()));
-
-      this.delegate =
-          tracerConfiguration.isLimitless()
-              ? new ZkCounter(bridgeConfiguration, forkId)
-              : new ZkTracer(forkId, bridgeConfiguration, blockchainService.getChainId().get());
+    public LineCountingTracerWithLog(final LineCountingTracer delegate) {
+      this.delegate = delegate;
     }
 
     @Override

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/test/java/lineth/config/LineaTracerCliOptionsTest.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/test/java/lineth/config/LineaTracerCliOptionsTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package lineth.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.hyperledger.besu.services.PicoCLIOptionsImpl;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+class LineaTracerCliOptionsTest {
+  private static final String MODULE_LINE_LIMITS_RESOURCE_NAME = "/sequencer/line-limits.toml";
+
+  @Command
+  static final class TestLineaBesuCommand {}
+
+  @TempDir static Path tempDir;
+  private static Path lineLimitsConfPath;
+
+  private CommandLine commandLine;
+  private LineaTracerCliOptions tracerCliOptions;
+
+  @BeforeAll
+  static void beforeAll() throws IOException {
+    lineLimitsConfPath = tempDir.resolve("line-limits.toml");
+    Files.copy(
+        LineaTracerCliOptionsTest.class.getResourceAsStream(MODULE_LINE_LIMITS_RESOURCE_NAME),
+        lineLimitsConfPath);
+  }
+
+  @BeforeEach
+  void setUp() {
+    commandLine = new CommandLine(new TestLineaBesuCommand());
+    tracerCliOptions = LineaTracerCliOptions.create();
+    new PicoCLIOptionsImpl(commandLine).addPicoCLIOptions("linea", tracerCliOptions);
+  }
+
+  @Test
+  void shouldLeaveTracingCutoffUnsetByDefault() {
+    parseWithModuleLimits();
+
+    assertThat(tracerCliOptions.toDomainObject().tracingEndTimestamp()).isEmpty();
+  }
+
+  @Test
+  void shouldAcceptZeroTracingCutoff() {
+    parseWithModuleLimits(LineaTracerCliOptions.TRACING_END_TIMESTAMP, "0");
+
+    assertThat(tracerCliOptions.toDomainObject().tracingEndTimestamp()).hasValue(0L);
+  }
+
+  @Test
+  void shouldRejectNegativeTracingCutoff() {
+    parseWithModuleLimits(LineaTracerCliOptions.TRACING_END_TIMESTAMP, "-1");
+
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(tracerCliOptions::toDomainObject)
+        .withMessageContaining("must be zero or greater");
+  }
+
+  @Test
+  void shouldRejectMalformedTracingCutoff() {
+    assertThatExceptionOfType(CommandLine.ParameterException.class)
+        .isThrownBy(
+            () -> parseWithModuleLimits(LineaTracerCliOptions.TRACING_END_TIMESTAMP, "tomorrow"));
+  }
+
+  @Test
+  void shouldRejectOverflowingTracingCutoff() {
+    assertThatExceptionOfType(CommandLine.ParameterException.class)
+        .isThrownBy(
+            () ->
+                parseWithModuleLimits(
+                    LineaTracerCliOptions.TRACING_END_TIMESTAMP, "9223372036854775808"));
+  }
+
+  private void parseWithModuleLimits(final String... additionalArguments) {
+    final String[] arguments = new String[additionalArguments.length + 2];
+    arguments[0] = LineaTracerCliOptions.MODULE_LIMIT_FILE_PATH;
+    arguments[1] = lineLimitsConfPath.toString();
+    System.arraycopy(additionalArguments, 0, arguments, 2, additionalArguments.length);
+    commandLine.parseArgs(arguments);
+  }
+}

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/test/java/lineth/sequencer/tracing/BespokeTracingActivationPolicyTest.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/test/java/lineth/sequencer/tracing/BespokeTracingActivationPolicyTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package lineth.sequencer.tracing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import java.util.OptionalLong;
+import org.junit.jupiter.api.Test;
+
+class BespokeTracingActivationPolicyTest {
+  @Test
+  void shouldAlwaysTraceWhenCutoffIsUnset() {
+    final var policy = new BespokeTracingActivationPolicy(OptionalLong.empty());
+
+    assertThat(policy.shouldTrace(Long.MAX_VALUE)).isTrue();
+  }
+
+  @Test
+  void shouldTraceOnlyBeforeCutoff() {
+    final var policy = new BespokeTracingActivationPolicy(OptionalLong.of(100L));
+
+    assertThat(policy.shouldTrace(99L)).isTrue();
+    assertThat(policy.shouldTrace(100L)).isFalse();
+    assertThat(policy.shouldTrace(101L)).isFalse();
+  }
+
+  @Test
+  void shouldDisableTracingImmediatelyAtZero() {
+    final var policy = new BespokeTracingActivationPolicy(OptionalLong.of(0L));
+
+    assertThat(policy.shouldTrace(0L)).isFalse();
+  }
+
+  @Test
+  void shouldRejectNegativeCutoff() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> new BespokeTracingActivationPolicy(OptionalLong.of(-1L)))
+        .withMessage("Tracing end timestamp must be zero or greater");
+  }
+}

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/test/java/lineth/sequencer/tracing/LineaTracerFactoryTest.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/test/java/lineth/sequencer/tracing/LineaTracerFactoryTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package lineth.sequencer.tracing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigInteger;
+import java.util.Map;
+import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import lineth.config.LineaTracerConfiguration;
+import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
+import net.consensys.linea.zktracer.Fork;
+import net.consensys.linea.zktracer.ZkCounter;
+import net.consensys.linea.zktracer.ZkTracer;
+import org.apache.tuweni.bytes.Bytes32;
+import org.hyperledger.besu.datatypes.Address;
+import org.junit.jupiter.api.Test;
+
+class LineaTracerFactoryTest {
+  private static final LineaL1L2BridgeSharedConfiguration BRIDGE_CONFIGURATION =
+      LineaL1L2BridgeSharedConfiguration.builder()
+          .contract(Address.fromHexString("0xdeadbeef"))
+          .topic(Bytes32.fromHexString("0xc0ffee"))
+          .build();
+
+  @Test
+  void shouldResolveHardforkUsingPendingBlockTimestampBeforeCutoff() {
+    final AtomicLong resolvedPendingBlockTimestamp = new AtomicLong(-1L);
+    final var factory =
+        factory(
+            OptionalLong.of(100L),
+            true,
+            () -> BigInteger.ONE,
+            pendingBlockTimestamp -> {
+              resolvedPendingBlockTimestamp.set(pendingBlockTimestamp);
+              return Fork.OSAKA;
+            });
+
+    assertThat(factory.create(99L)).isPresent();
+    assertThat(resolvedPendingBlockTimestamp).hasValue(99L);
+  }
+
+  @Test
+  void shouldNotResolveTracerDependenciesAtOrAfterCutoff() {
+    final var factory =
+        factory(
+            OptionalLong.of(100L),
+            true,
+            () -> {
+              throw new AssertionError("Chain ID must not be resolved after cutoff");
+            },
+            pendingBlockTimestamp -> {
+              throw new AssertionError("Hardfork resolver must not be called after cutoff");
+            });
+
+    assertThat(factory.create(100L)).isEmpty();
+    assertThat(factory.create(101L)).isEmpty();
+  }
+
+  @Test
+  void shouldNotResolveChainIdForLimitlessTracer() {
+    final var factory =
+        factory(
+            OptionalLong.empty(),
+            true,
+            () -> {
+              throw new AssertionError("Chain ID must not be resolved for ZkCounter");
+            },
+            pendingBlockTimestamp -> Fork.OSAKA);
+
+    assertThat(factory.create(0L))
+        .hasValueSatisfying(tracer -> assertThat(tracer).isInstanceOf(ZkCounter.class));
+  }
+
+  @Test
+  void shouldResolveChainIdWhenCreatingZkTracer() {
+    final AtomicReference<BigInteger> resolvedChainId = new AtomicReference<>();
+    final Supplier<BigInteger> chainIdSupplier =
+        () -> {
+          final BigInteger chainId = BigInteger.valueOf(59144L);
+          resolvedChainId.set(chainId);
+          return chainId;
+        };
+    final var factory =
+        factory(OptionalLong.empty(), false, chainIdSupplier, pendingBlockTimestamp -> Fork.OSAKA);
+
+    assertThat(factory.create(0L))
+        .hasValueSatisfying(tracer -> assertThat(tracer).isInstanceOf(ZkTracer.class));
+    assertThat(resolvedChainId).hasValue(BigInteger.valueOf(59144L));
+  }
+
+  private LineaTracerFactory factory(
+      final OptionalLong tracingEndTimestamp,
+      final boolean limitless,
+      final Supplier<BigInteger> chainIdSupplier,
+      final LineaTracerFactory.HardforkResolver hardforkResolver) {
+    final var configuration =
+        LineaTracerConfiguration.builder()
+            .moduleLimitsFilePath("unused.toml")
+            .moduleLimitsMap(Map.of())
+            .isLimitless(limitless)
+            .tracingEndTimestamp(tracingEndTimestamp)
+            .build();
+    return new LineaTracerFactory(
+        new BespokeTracingActivationPolicy(tracingEndTimestamp),
+        configuration,
+        BRIDGE_CONFIGURATION,
+        chainIdSupplier,
+        hardforkResolver);
+  }
+}

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/test/java/lineth/sequencer/txpoolvalidation/validators/TraceLineLimitValidatorTest.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/test/java/lineth/sequencer/txpoolvalidation/validators/TraceLineLimitValidatorTest.java
@@ -9,123 +9,98 @@
 package lineth.sequencer.txpoolvalidation.validators;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.function.LongSupplier;
+import lineth.sequencer.tracing.BespokeTracingActivationPolicy;
 import lineth.sequencer.txselection.InvalidTransactionByLineCountCache;
-import org.apache.tuweni.bytes.Bytes32;
-import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
 import org.hyperledger.besu.datatypes.Transaction;
+import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class TraceLineLimitValidatorTest {
-
+class TraceLineLimitValidatorTest {
   private InvalidTransactionByLineCountCache cache;
-  private TraceLineLimitValidator validator;
-  private Transaction mockTransaction;
-  private Hash transactionHash;
+  private Transaction transaction;
 
   @BeforeEach
   void setUp() {
     cache = new InvalidTransactionByLineCountCache(10);
-    validator = new TraceLineLimitValidator(cache);
-    mockTransaction = mock(Transaction.class);
-    transactionHash = Hash.wrap(Bytes32.random());
-    when(mockTransaction.getHash()).thenReturn(transactionHash);
+    transaction =
+        new TransactionTestFixture()
+            .nonce(0L)
+            .gasLimit(21_000L)
+            .createTransaction(SignatureAlgorithmFactory.getInstance().generateKeyPair());
   }
 
   @Test
-  void shouldAcceptTransactionNotInCache() {
-    // Given: transaction is not in cache
-    assertThat(cache.contains(transactionHash)).isFalse();
+  void shouldNotRequestPendingTimestampForCacheMiss() {
+    final var timestampSupplier = new RecordingPendingBlockTimestampSupplier(100L);
+    final var validator = validator(100L, timestampSupplier);
 
-    // When: validating transaction
-    Optional<String> result = validator.validateTransaction(mockTransaction, true, false);
-
-    // Then: transaction should be accepted (no validation error)
-    assertThat(result).isEmpty();
+    assertThat(validator.validateTransaction(transaction, true, false)).isEmpty();
+    assertThat(timestampSupplier.calls()).isZero();
   }
 
   @Test
-  void shouldRejectTransactionInCache() {
-    // Given: transaction is in cache (marked as exceeding line count limit)
-    cache.remember(transactionHash, "EXT");
-    assertThat(cache.contains(transactionHash)).isTrue();
+  void shouldRejectCachedTransactionBeforeCutoff() {
+    cache.remember(transaction.getHash(), "EXT");
+    final var validator = validator(100L, new RecordingPendingBlockTimestampSupplier(99L));
 
-    // When: validating transaction
-    Optional<String> result = validator.validateTransaction(mockTransaction, true, false);
-
-    // Then: transaction should be rejected with appropriate error message
-    assertThat(result).isPresent();
-    assertThat(result.get()).contains("was already identified to go over line count limit");
-    assertThat(result.get()).contains(transactionHash.getBytes().toHexString());
+    assertThat(validator.validateTransaction(transaction, true, false))
+        .hasValueSatisfying(
+            reason ->
+                assertThat(reason)
+                    .contains("was already identified to go over line count limit")
+                    .contains(transaction.getHash().getBytes().toHexString()));
   }
 
   @Test
-  void shouldRejectTransactionInCache_LocalTransaction() {
-    // Given: transaction is in cache
-    cache.remember(transactionHash, "EXT");
+  void shouldAcceptCachedTransactionAtCutoff() {
+    cache.remember(transaction.getHash(), "EXT");
+    final var validator = validator(100L, new RecordingPendingBlockTimestampSupplier(100L));
 
-    // When: validating local transaction
-    Optional<String> result = validator.validateTransaction(mockTransaction, true, false);
-
-    // Then: transaction should be rejected regardless of local status
-    assertThat(result).isPresent();
+    assertThat(validator.validateTransaction(transaction, true, false)).isEmpty();
   }
 
   @Test
-  void shouldRejectTransactionInCache_RemoteTransaction() {
-    // Given: transaction is in cache
-    cache.remember(transactionHash, "EXT");
+  void shouldRejectCachedTransactionWhenPendingTimestampIsUnavailable() {
+    cache.remember(transaction.getHash(), "EXT");
+    final var validator =
+        validator(
+            100L,
+            () -> {
+              throw new IllegalStateException("pending header unavailable");
+            });
 
-    // When: validating remote transaction
-    Optional<String> result = validator.validateTransaction(mockTransaction, false, false);
-
-    // Then: transaction should be rejected regardless of remote status
-    assertThat(result).isPresent();
+    assertThat(validator.validateTransaction(transaction, true, false)).isPresent();
   }
 
-  @Test
-  void shouldRejectTransactionInCache_PriorityTransaction() {
-    // Given: transaction is in cache
-    cache.remember(transactionHash, "EXT");
-
-    // When: validating priority transaction
-    Optional<String> result = validator.validateTransaction(mockTransaction, false, true);
-
-    // Then: transaction should be rejected regardless of priority status
-    assertThat(result).isPresent();
+  private TraceLineLimitValidator validator(
+      final long tracingEndTimestamp, final LongSupplier pendingBlockTimestampSupplier) {
+    return new TraceLineLimitValidator(
+        cache,
+        new BespokeTracingActivationPolicy(OptionalLong.of(tracingEndTimestamp)),
+        pendingBlockTimestampSupplier);
   }
 
-  @Test
-  void shouldHandleMultipleTransactionsCorrectly() {
-    // Given: multiple transactions, some in cache
-    Hash hash1 = Hash.wrap(Bytes32.random());
-    Hash hash2 = Hash.wrap(Bytes32.random());
-    Hash hash3 = Hash.wrap(Bytes32.random());
+  private static final class RecordingPendingBlockTimestampSupplier implements LongSupplier {
+    private final long pendingBlockTimestamp;
+    private int calls;
 
-    Transaction tx1 = mock(Transaction.class);
-    Transaction tx2 = mock(Transaction.class);
-    Transaction tx3 = mock(Transaction.class);
+    private RecordingPendingBlockTimestampSupplier(final long pendingBlockTimestamp) {
+      this.pendingBlockTimestamp = pendingBlockTimestamp;
+    }
 
-    when(tx1.getHash()).thenReturn(hash1);
-    when(tx2.getHash()).thenReturn(hash2);
-    when(tx3.getHash()).thenReturn(hash3);
+    @Override
+    public long getAsLong() {
+      calls++;
+      return pendingBlockTimestamp;
+    }
 
-    // Add only tx1 and tx3 to cache
-    cache.remember(hash1, "EXT");
-    cache.remember(hash3, "RAM");
-
-    // When: validating all transactions
-    Optional<String> result1 = validator.validateTransaction(tx1, true, false);
-    Optional<String> result2 = validator.validateTransaction(tx2, true, false);
-    Optional<String> result3 = validator.validateTransaction(tx3, true, false);
-
-    // Then: only cached transactions should be rejected
-    assertThat(result1).isPresent(); // tx1 is in cache - rejected
-    assertThat(result2).isEmpty(); // tx2 is not in cache - accepted
-    assertThat(result3).isPresent(); // tx3 is in cache - rejected
+    private int calls() {
+      return calls;
+    }
   }
 }

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/test/java/lineth/sequencer/txselection/TraceLineLimitCacheIntegrationTest.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/test/java/lineth/sequencer/txselection/TraceLineLimitCacheIntegrationTest.java
@@ -22,8 +22,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Optional;
+import java.util.OptionalLong;
 import lineth.config.LineaTracerConfiguration;
 import lineth.sequencer.modulelimit.ModuleLineCountValidator;
+import lineth.sequencer.tracing.BespokeTracingActivationPolicy;
+import lineth.sequencer.tracing.LineaTracerFactory;
 import lineth.sequencer.txpoolvalidation.validators.TraceLineLimitValidator;
 import lineth.sequencer.txselection.selectors.TestTransactionEvaluationContext;
 import lineth.sequencer.txselection.selectors.TraceLineLimitTransactionSelector;
@@ -98,18 +101,24 @@ public class TraceLineLimitCacheIntegrationTest {
     transactionSelector =
         new TraceLineLimitTransactionSelector(
             stateManager,
-            blockchainService,
-            LineaL1L2BridgeSharedConfiguration.builder()
-                .contract(Address.fromHexString("0xdeadbeef"))
-                .topic(Bytes32.fromHexString("0xc0ffee"))
-                .build(),
             tracerConfiguration,
-            sharedCache);
+            sharedCache,
+            LineaTracerFactory.fromBlockchainService(
+                    blockchainService,
+                    tracerConfiguration,
+                    LineaL1L2BridgeSharedConfiguration.builder()
+                        .contract(Address.fromHexString("0xdeadbeef"))
+                        .topic(Bytes32.fromHexString("0xc0ffee"))
+                        .build())
+                .create(0)
+                .orElseThrow());
 
     stateManager.blockSelectionStarted();
 
     // Create transaction pool validator using the same shared cache
-    transactionPoolValidator = new TraceLineLimitValidator(sharedCache);
+    transactionPoolValidator =
+        new TraceLineLimitValidator(
+            sharedCache, new BespokeTracingActivationPolicy(OptionalLong.empty()), () -> 0L);
   }
 
   @Test

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/test/java/lineth/sequencer/txselection/selectors/TraceLineLimitTransactionSelectorTest.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/test/java/lineth/sequencer/txselection/selectors/TraceLineLimitTransactionSelectorTest.java
@@ -23,8 +23,10 @@ import java.util.HashMap;
 import java.util.Optional;
 import lineth.config.LineaTracerConfiguration;
 import lineth.sequencer.modulelimit.ModuleLineCountValidator;
+import lineth.sequencer.tracing.LineaTracerFactory;
 import lineth.sequencer.txselection.InvalidTransactionByLineCountCache;
 import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
+import net.consensys.linea.zktracer.LineCountingTracer;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.datatypes.Address;
@@ -87,9 +89,17 @@ public class TraceLineLimitTransactionSelectorTest {
     final var selector =
         new TestableTraceLineLimitTransactionSelector(
             selectorsStateManager,
-            blockchainService,
             tracerConfiguration,
-            invalidTransactionByLineCountCache);
+            invalidTransactionByLineCountCache,
+            LineaTracerFactory.fromBlockchainService(
+                    blockchainService,
+                    tracerConfiguration,
+                    LineaL1L2BridgeSharedConfiguration.builder()
+                        .contract(Address.fromHexString("0xDEADBEEF"))
+                        .topic(Bytes32.fromHexString("0x012345"))
+                        .build())
+                .create(0)
+                .orElseThrow());
     selectorsStateManager.blockSelectionStarted();
     return selector;
   }
@@ -265,18 +275,14 @@ public class TraceLineLimitTransactionSelectorTest {
 
     TestableTraceLineLimitTransactionSelector(
         final SelectorsStateManager selectorsStateManager,
-        final BlockchainService blockchainService,
         final LineaTracerConfiguration lineaTracerConfiguration,
-        final InvalidTransactionByLineCountCache invalidTransactionByLineCountCache) {
+        final InvalidTransactionByLineCountCache invalidTransactionByLineCountCache,
+        final LineCountingTracer lineCountingTracer) {
       super(
           selectorsStateManager,
-          blockchainService,
-          LineaL1L2BridgeSharedConfiguration.builder()
-              .contract(Address.fromHexString("0xDEADBEEF"))
-              .topic(Bytes32.fromHexString("0x012345"))
-              .build(),
           lineaTracerConfiguration,
-          invalidTransactionByLineCountCache);
+          invalidTransactionByLineCountCache,
+          lineCountingTracer);
       this.testCache = invalidTransactionByLineCountCache;
     }
 


### PR DESCRIPTION
Adds `--plugin-linea-tracing-end-timestamp`, an optional Unix timestamp that controls when the sequencer stops bespoke tracing. Pending blocks before the configured timestamp continue to use the bespoke tracer, while pending blocks at or after it run without bespoke tracing. Leaving the option unset preserves the current behavior.

Routes transaction selection, transaction pool simulation, cached line limit validation, and `linea_estimateGas` through a shared tracing activation policy and tracer factory. After the cutoff, these paths skip tracer-specific line count enforcement while continuing their normal transaction simulation and processing behavior. The change also documents the option and covers its boundary behavior, tracer dependency resolution, transaction admission, and gas estimation.

Closes #3824