### PR TITLE
feat(coordinator): support finalization on validium chains

### DIFF
--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/CoordinatorApp.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/CoordinatorApp.kt
@@ -89,7 +89,7 @@ class CoordinatorApp(
         configs.smartContractErrors.size,
         configs.smartContractErrors,
       )
-      configs.l1Submission?.dynamicGasPriceCap?.let { dgc ->
+      configs.l1Submission.dynamicGasPriceCap.let { dgc ->
         log.trace("dynamicGasPriceCap.timeOfDayMultipliers: {}", dgc.timeOfDayMultipliers)
         log.trace(
           "dynamicGasPriceCap.gasPriceCapCalculation.timeOfTheDayMultipliers: {}",
@@ -148,7 +148,7 @@ class CoordinatorApp(
         BlobsPostgresDao(
           config =
           BlobsPostgresDao.Config(
-            maxBlobsToReturn = configs.l1Submission?.blob?.dbMaxBlobsToReturn ?: 50u,
+            maxBlobsToReturn = configs.l1Submission.blob.dbMaxBlobsToReturn,
           ),
           connection = sqlClient,
         ),
@@ -167,15 +167,11 @@ class CoordinatorApp(
       ),
     )
 
-  // The data-availability mode decides which L1 contract client the read path uses, so l1Submission is
-  // now mandatory for every coordinator (the TOML [l1-submission] section always provides it). Fail
-  // loudly naming the missing key rather than silently defaulting to ROLLUP on a validium chain.
-  private val dataAvailability: L1SubmissionConfig.DataAvailability =
-    requireNotNull(configs.l1Submission) {
-      "l1Submission config is required to determine the L1 data-availability mode (rollup vs validium)"
-    }.dataAvailability
+  // The data-availability mode decides which L1 contract client the read path uses. l1Submission is
+  // non-nullable in CoordinatorConfig (the TOML [l1-submission] section always provides it).
+  private val dataAvailability: L1SubmissionConfig.DataAvailability = configs.l1Submission.dataAvailability
 
-  // Forced transactions are unsupported under validium, so the DAO must be disabled there too — not just
+  // Forced transactions are unsupported under validium, so the DAO must be disabled there too, not just
   // the ForcedTransactionsApp. ConflationAppHelper is the single source of truth for that decision.
   private val forcedTransactionsDao = run {
     if (!ConflationAppHelper.forcedTransactionsEnabled(configs.forcedTransactions, dataAvailability)) {
@@ -280,20 +276,18 @@ class CoordinatorApp(
     // decision (shared with the forced-transactions DAO selection above).
     // KNOWN LIMITATION: the validium V2 contract itself enforces forced-transaction inclusion at
     // finalization, so storing a forced transaction on such a deployment halts finalization until
-    // coordinator support is added — do not use FORCED_TRANSACTION_SENDER_ROLE with this coordinator.
-    val ftxEnabled = ConflationAppHelper.forcedTransactionsEnabled(configs.forcedTransactions, dataAvailability)
-    if (!ftxEnabled && configs.forcedTransactions?.disabled == false) {
-      log.warn(
-        "Forced transactions are enabled in config but the coordinator does not support them on validium " +
-          "chains yet; disabling. Storing a forced transaction on a validium V2 contract halts finalization.",
-      )
-    }
-    if (!ftxEnabled) {
+    // coordinator support is added. Do not use FORCED_TRANSACTION_SENDER_ROLE with this coordinator.
+    val ftxConfig = configs.forcedTransactions
+    if (ftxConfig == null || !ConflationAppHelper.forcedTransactionsEnabled(ftxConfig, dataAvailability)) {
+      // If we get here with forced transactions enabled in config, the chain must be running in validium mode.
+      if (ftxConfig?.disabled == false) {
+        log.warn(
+          "Forced transactions are enabled in config but the coordinator does not support them on validium " +
+            "chains yet; disabling. Storing a forced transaction on a validium V2 contract halts finalization.",
+        )
+      }
       ForcedTransactionsApp.createDisabled()
     } else {
-      val ftxConfig = requireNotNull(configs.forcedTransactions) {
-        "forcedTransactions config must be present when forced transactions are enabled"
-      }
       val l1EthClient = createEthApiClient(
         rpcUrl = ftxConfig.l1Endpoint.toString(),
         log = LogManager.getLogger("clients.l1.eth.ftx"),
@@ -450,7 +444,7 @@ class CoordinatorApp(
     if (configs.l1Submission.isEnabled()) {
       L1RelayingAppV1(
         configs = configs,
-        l1SubmissionConfig = configs.l1Submission!!,
+        l1SubmissionConfig = configs.l1Submission,
         vertx = vertx,
         l1ChainId = l1ChainId,
         lastFinalizedBlock = lastFinalizedBlock,

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/CoordinatorApp.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/CoordinatorApp.kt
@@ -8,6 +8,8 @@ import io.vertx.sqlclient.SqlClient
 import linea.DisabledService
 import linea.LongRunningService
 import linea.clients.StateManagerV1JsonRpcClient
+import linea.contract.l1.FinalizedStateDataClientReadOnly
+import linea.contract.l1.Web3JLineaValidiumSmartContractClientReadOnly
 import linea.contract.l1.Web3JLinethRollupSmartContractClientReadOnly
 import linea.domain.BlockParameter
 import linea.domain.RetryConfig
@@ -18,6 +20,7 @@ import linea.persistence.db.PersistenceRetryer
 import linea.web3j.createWeb3jHttpClient
 import linea.web3j.ethapi.createEthApiClient
 import lineth.coordinator.api.Api
+import lineth.coordinator.app.conflation.ConflationAppHelper
 import lineth.coordinator.app.conflation.ConflationAppV1
 import lineth.coordinator.app.conflation.ConflationAppV2
 import lineth.coordinator.app.conflation.TracesClientFactory.createTracesClients
@@ -28,6 +31,7 @@ import lineth.coordinator.clients.prover.ProverClientFactory
 import lineth.coordinator.config.toJsonRpcRetry
 import lineth.coordinator.config.v2.CoordinatorConfig
 import lineth.coordinator.config.v2.DatabaseConfig
+import lineth.coordinator.config.v2.L1SubmissionConfig
 import lineth.coordinator.config.v2.isEnabled
 import lineth.coordinator.config.v2.logPretty
 import lineth.coordinator.extensions.CoordinatorContext
@@ -162,8 +166,19 @@ class CoordinatorApp(
         persistenceRetryer = persistenceRetryer,
       ),
     )
+
+  // The data-availability mode decides which L1 contract client the read path uses, so l1Submission is
+  // now mandatory for every coordinator (the TOML [l1-submission] section always provides it). Fail
+  // loudly naming the missing key rather than silently defaulting to ROLLUP on a validium chain.
+  private val dataAvailability: L1SubmissionConfig.DataAvailability =
+    requireNotNull(configs.l1Submission) {
+      "l1Submission config is required to determine the L1 data-availability mode (rollup vs validium)"
+    }.dataAvailability
+
+  // Forced transactions are unsupported under validium, so the DAO must be disabled there too — not just
+  // the ForcedTransactionsApp. ConflationAppHelper is the single source of truth for that decision.
   private val forcedTransactionsDao = run {
-    if (configs.forcedTransactions?.disabled ?: true) {
+    if (!ConflationAppHelper.forcedTransactionsEnabled(configs.forcedTransactions, dataAvailability)) {
       DisabledForcedTransactionsDao()
     } else {
       RetryingPostgresForcedTransactionsDao(
@@ -187,30 +202,45 @@ class CoordinatorApp(
     ),
   ).ethChainId().get()
 
-  private val linethRollupClientForFinalizationMonitor = run {
+  // The finalization monitor reads the L1 contract, so its client must match the deployed contract
+  // flavour: a rollup client pointed at a validium contract fails version detection and the
+  // coordinator cannot start.
+  private val finalizationMonitorClient: FinalizedStateDataClientReadOnly = run {
     val web3j = createWeb3jHttpClient(
       rpcUrl = configs.l1FinalizationMonitor.l1Endpoint.toString(),
       log = LogManager.getLogger("clients.l1.eth.finalization-monitor"),
     )
-    Web3JLinethRollupSmartContractClientReadOnly(
-      contractAddress = configs.protocol.l1.contractAddress,
-      web3j = web3j,
-      ethLogsSearcher = EthLogsSearcherImpl(
-        vertx = vertx,
-        ethApiClient = createEthApiClient(
-          web3jClient = web3j,
-          requestRetryConfig = configs.l1FinalizationMonitor.l1RequestRetries,
-          vertx = vertx,
-        ),
-      ),
-      finalizedStateSearchInitialBlockParameter = configs.protocol.l1.contractDeploymentBlockNumber
-        ?: BlockParameter.Tag.EARLIEST,
-    )
+    when (dataAvailability) {
+      L1SubmissionConfig.DataAvailability.ROLLUP ->
+        Web3JLinethRollupSmartContractClientReadOnly(
+          contractAddress = configs.protocol.l1.contractAddress,
+          web3j = web3j,
+          ethLogsSearcher = EthLogsSearcherImpl(
+            vertx = vertx,
+            ethApiClient = createEthApiClient(
+              web3jClient = web3j,
+              requestRetryConfig = configs.l1FinalizationMonitor.l1RequestRetries,
+              vertx = vertx,
+            ),
+          ),
+          finalizedStateSearchInitialBlockParameter = configs.protocol.l1.contractDeploymentBlockNumber
+            ?: BlockParameter.Tag.EARLIEST,
+        )
+
+      L1SubmissionConfig.DataAvailability.VALIDIUM ->
+        // No logs searcher / l1FinalizationMonitor.l1RequestRetries here: the validium client has no
+        // event search yet. When getFinalizedStateData's V2 branch adds the FinalizedStateUpdated
+        // search, the searcher + those retries must be wired in here too.
+        Web3JLineaValidiumSmartContractClientReadOnly(
+          contractAddress = configs.protocol.l1.contractAddress,
+          web3j = web3j,
+        )
+    }
   }
 
   private val lastFinalizedBlock: ULong = L1BasedLastFinalizedBlockProvider(
     vertx,
-    linethRollupSmartContractClient = linethRollupClientForFinalizationMonitor,
+    lineaSmartContractClient = finalizationMonitorClient,
     consistentNumberOfBlocksOnL1 = configs.conflation.consistentNumberOfBlocksOnL1ToWait,
   ).getLastFinalizedBlock().get()
 
@@ -244,10 +274,26 @@ class CoordinatorApp(
   )
 
   private val forcedTransactionsApp: ForcedTransactionsApp = run {
-    if (configs.forcedTransactions == null || configs.forcedTransactions.disabled) {
+    // The coordinator does not support forced transactions on validium chains yet: ForcedTransactionsApp
+    // reads the contract through the rollup client, which fails version detection against a validium
+    // contract. ConflationAppHelper.forcedTransactionsEnabled is the single source of truth for this
+    // decision (shared with the forced-transactions DAO selection above).
+    // KNOWN LIMITATION: the validium V2 contract itself enforces forced-transaction inclusion at
+    // finalization, so storing a forced transaction on such a deployment halts finalization until
+    // coordinator support is added — do not use FORCED_TRANSACTION_SENDER_ROLE with this coordinator.
+    val ftxEnabled = ConflationAppHelper.forcedTransactionsEnabled(configs.forcedTransactions, dataAvailability)
+    if (!ftxEnabled && configs.forcedTransactions?.disabled == false) {
+      log.warn(
+        "Forced transactions are enabled in config but the coordinator does not support them on validium " +
+          "chains yet; disabling. Storing a forced transaction on a validium V2 contract halts finalization.",
+      )
+    }
+    if (!ftxEnabled) {
       ForcedTransactionsApp.createDisabled()
     } else {
-      val ftxConfig = configs.forcedTransactions
+      val ftxConfig = requireNotNull(configs.forcedTransactions) {
+        "forcedTransactions config must be present when forced transactions are enabled"
+      }
       val l1EthClient = createEthApiClient(
         rpcUrl = ftxConfig.l1Endpoint.toString(),
         log = LogManager.getLogger("clients.l1.eth.ftx"),
@@ -384,7 +430,7 @@ class CoordinatorApp(
     configs = configs,
     vertx = vertx,
     httpJsonRpcClientFactory = httpJsonRpcClientFactory,
-    finalizedStateDataProvider = linethRollupClientForFinalizationMonitor,
+    finalizedStateDataProvider = finalizationMonitorClient,
     lastFinalizedBlock = lastFinalizedBlock,
     batchesRepository = batchesRepository,
     blobsRepository = blobsRepository,

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/CoordinatorApp.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/CoordinatorApp.kt
@@ -89,13 +89,12 @@ class CoordinatorApp(
         configs.smartContractErrors.size,
         configs.smartContractErrors,
       )
-      configs.l1Submission.dynamicGasPriceCap.let { dgc ->
-        log.trace("dynamicGasPriceCap.timeOfDayMultipliers: {}", dgc.timeOfDayMultipliers)
-        log.trace(
-          "dynamicGasPriceCap.gasPriceCapCalculation.timeOfTheDayMultipliers: {}",
-          dgc.gasPriceCapCalculation.timeOfTheDayMultipliers,
-        )
-      }
+      val dgc = configs.l1Submission.dynamicGasPriceCap
+      log.trace("dynamicGasPriceCap.timeOfDayMultipliers: {}", dgc.timeOfDayMultipliers)
+      log.trace(
+        "dynamicGasPriceCap.gasPriceCapCalculation.timeOfTheDayMultipliers: {}",
+        dgc.gasPriceCapCalculation.timeOfTheDayMultipliers,
+      )
 
       Vertx.vertx(vertxConfig)
     }
@@ -167,12 +166,10 @@ class CoordinatorApp(
       ),
     )
 
-  // The data-availability mode decides which L1 contract client the read path uses. l1Submission is
-  // non-nullable in CoordinatorConfig (the TOML [l1-submission] section always provides it).
+  // The data-availability mode decides which L1 contract client the read path uses.
   private val dataAvailability: L1SubmissionConfig.DataAvailability = configs.l1Submission.dataAvailability
 
-  // Forced transactions are unsupported under validium, so the DAO must be disabled there too, not just
-  // the ForcedTransactionsApp. ConflationAppHelper is the single source of truth for that decision.
+  // Must agree with the forcedTransactionsApp wiring below; see ConflationAppHelper.forcedTransactionsEnabled.
   private val forcedTransactionsDao = run {
     if (!ConflationAppHelper.forcedTransactionsEnabled(configs.forcedTransactions, dataAvailability)) {
       DisabledForcedTransactionsDao()
@@ -270,13 +267,7 @@ class CoordinatorApp(
   )
 
   private val forcedTransactionsApp: ForcedTransactionsApp = run {
-    // The coordinator does not support forced transactions on validium chains yet: ForcedTransactionsApp
-    // reads the contract through the rollup client, which fails version detection against a validium
-    // contract. ConflationAppHelper.forcedTransactionsEnabled is the single source of truth for this
-    // decision (shared with the forced-transactions DAO selection above).
-    // KNOWN LIMITATION: the validium V2 contract itself enforces forced-transaction inclusion at
-    // finalization, so storing a forced transaction on such a deployment halts finalization until
-    // coordinator support is added. Do not use FORCED_TRANSACTION_SENDER_ROLE with this coordinator.
+    // Forced transactions are rollup-only for now; see ConflationAppHelper.forcedTransactionsEnabled.
     val ftxConfig = configs.forcedTransactions
     if (ftxConfig == null || !ConflationAppHelper.forcedTransactionsEnabled(ftxConfig, dataAvailability)) {
       // If we get here with forced transactions enabled in config, the chain must be running in validium mode.

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/L1RelayingAppV1.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/L1RelayingAppV1.kt
@@ -54,7 +54,7 @@ import kotlin.time.Clock
 open class L1RelayingAppV1(
   private val configs: CoordinatorConfig,
   // Note/Todo: l1SubmissionConfig should be the only necessary one, however requires deeper refactor
-  private val l1SubmissionConfig: L1SubmissionConfig = configs.l1Submission!!,
+  private val l1SubmissionConfig: L1SubmissionConfig = configs.l1Submission,
   private val vertx: Vertx,
   private val l1ChainId: ULong,
   private val lastFinalizedBlock: ULong,

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/LastFinalizedBlockProvider.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/LastFinalizedBlockProvider.kt
@@ -1,7 +1,7 @@
 package lineth.coordinator.app
 
 import io.vertx.core.Vertx
-import linea.contract.l1.LinethRollupSmartContractClientReadOnly
+import linea.contract.l1.LineaSmartContractClientReadOnly
 import linea.domain.BlockParameter
 import net.consensys.linea.async.AsyncRetryer
 import org.apache.logging.log4j.LogManager
@@ -24,7 +24,7 @@ interface LastFinalizedBlockProvider {
  */
 class L1BasedLastFinalizedBlockProvider(
   private val vertx: Vertx,
-  private val linethRollupSmartContractClient: LinethRollupSmartContractClientReadOnly,
+  private val lineaSmartContractClient: LineaSmartContractClientReadOnly,
   private val consistentNumberOfBlocksOnL1: UInt,
   private val numberOfRetries: UInt = Int.MAX_VALUE.toUInt(),
   private val pollingInterval: Duration = 2.seconds,
@@ -56,7 +56,7 @@ class L1BasedLastFinalizedBlockProvider(
       backoffDelay = pollingInterval,
       stopRetriesPredicate = isConsistentEnough,
     ) {
-      linethRollupSmartContractClient.finalizedL2BlockNumber(
+      lineaSmartContractClient.finalizedL2BlockNumber(
         blockParameter = BlockParameter.Tag.LATEST,
       )
     }

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppHelper.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppHelper.kt
@@ -2,12 +2,27 @@ package lineth.coordinator.app.conflation
 
 import linea.domain.toBlockParameter
 import linea.ethapi.EthApiClient
+import lineth.coordinator.config.v2.ForcedTransactionsConfig
+import lineth.coordinator.config.v2.L1SubmissionConfig
 import lineth.persistence.AggregationsRepository
 import lineth.persistence.BatchesRepository
 import lineth.persistence.BlobsRepository
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 
 object ConflationAppHelper {
+  /**
+   * Forced transactions are a rollup-only feature in the coordinator today: ForcedTransactionsApp reads
+   * the contract through the rollup client, which fails against a validium contract. They are therefore
+   * disabled under VALIDIUM even when enabled in config. Single source of truth for both the
+   * ForcedTransactionsApp guard and the forced-transactions DAO selection.
+   */
+  internal fun forcedTransactionsEnabled(
+    forcedTransactions: ForcedTransactionsConfig?,
+    dataAvailability: L1SubmissionConfig.DataAvailability,
+  ): Boolean =
+    forcedTransactions?.disabled == false &&
+      dataAvailability != L1SubmissionConfig.DataAvailability.VALIDIUM
+
   /**
    * Returns the last block number inclusive upto which we have consecutive proven blobs or the last finalized block
    * number inclusive

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppHelper.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/app/conflation/ConflationAppHelper.kt
@@ -13,8 +13,12 @@ object ConflationAppHelper {
   /**
    * Forced transactions are a rollup-only feature in the coordinator today: ForcedTransactionsApp reads
    * the contract through the rollup client, which fails against a validium contract. They are therefore
-   * disabled under VALIDIUM even when enabled in config. Single source of truth for both the
-   * ForcedTransactionsApp guard and the forced-transactions DAO selection.
+   * disabled under VALIDIUM even when enabled in config. Both the ForcedTransactionsApp guard and the
+   * forced-transactions DAO selection in CoordinatorApp go through this, so the two always agree.
+   *
+   * The validium V2 contract itself enforces forced-transaction inclusion at finalization, so storing
+   * a forced transaction on such a deployment halts finalization until coordinator support is added.
+   * Do not grant FORCED_TRANSACTION_SENDER_ROLE on a validium chain with this coordinator.
    */
   internal fun forcedTransactionsEnabled(
     forcedTransactions: ForcedTransactionsConfig?,

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/config/v2/CoordinatorConfig.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/config/v2/CoordinatorConfig.kt
@@ -12,7 +12,7 @@ data class CoordinatorConfig(
   val stateManager: StateManagerConfig,
   val type2StateProofProvider: Type2StateProofManagerConfig,
   val l1FinalizationMonitor: L1FinalizationMonitorConfig,
-  val l1Submission: L1SubmissionConfig? = null,
+  val l1Submission: L1SubmissionConfig,
   val forcedTransactions: ForcedTransactionsConfig? = null,
   val messageAnchoring: MessageAnchoringConfig? = null,
   val l2NetworkGasPricing: L2NetworkGasPricingConfig? = null,

--- a/coordinator/app/src/main/kotlin/lineth/coordinator/config/v2/toml/CoordinatorConfigFilesToml.kt
+++ b/coordinator/app/src/main/kotlin/lineth/coordinator/config/v2/toml/CoordinatorConfigFilesToml.kt
@@ -31,7 +31,11 @@ data class CoordinatorConfigFileToml(
   val l1FinalizationMonitor: L1FinalizationMonitorConfigToml,
   @param:ConfigSection("L1 blob/aggregation submission (data availability and finalization) settings.")
   val l1Submission: L1SubmissionConfigToml,
-  @param:ConfigSection("Forced transactions handling settings; omit the section to disable the feature.")
+  @param:ConfigSection(
+    "Forced transactions handling settings; omit the section to disable the feature. Ignored on " +
+      "validium deployments: the coordinator does not support forced transactions there yet and " +
+      "disables them with a warning.",
+  )
   val forcedTransactions: ForcedTransactionsConfigToml? = null,
   @param:ConfigSection("L1 to L2 message anchoring settings.")
   val messageAnchoring: MessageAnchoringConfigToml,

--- a/coordinator/app/src/test/kotlin/lineth/coordinator/app/ConflationAppTest.kt
+++ b/coordinator/app/src/test/kotlin/lineth/coordinator/app/ConflationAppTest.kt
@@ -1,7 +1,10 @@
 package lineth.coordinator.app
 
 import lineth.coordinator.app.conflation.ConflationAppHelper.cleanupDbDataAfterBlockNumbers
+import lineth.coordinator.app.conflation.ConflationAppHelper.forcedTransactionsEnabled
 import lineth.coordinator.app.conflation.ConflationAppHelper.resumeConflationFrom
+import lineth.coordinator.config.v2.ForcedTransactionsConfig
+import lineth.coordinator.config.v2.L1SubmissionConfig
 import lineth.persistence.AggregationsRepository
 import lineth.persistence.BatchesRepository
 import lineth.persistence.BlobsRepository
@@ -12,8 +15,25 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.whenever
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.net.URI
 
 class ConflationAppTest {
+  @Test
+  fun `forced transactions are enabled only when configured and not on validium`() {
+    val enabledConfig = ForcedTransactionsConfig(
+      disabled = false,
+      l1Endpoint = URI.create("http://l1").toURL(),
+      sequencerEndpoint = URI.create("http://sequencer").toURL(),
+    )
+    val rollup = L1SubmissionConfig.DataAvailability.ROLLUP
+    val validium = L1SubmissionConfig.DataAvailability.VALIDIUM
+
+    assertThat(forcedTransactionsEnabled(null, rollup)).isFalse()
+    assertThat(forcedTransactionsEnabled(enabledConfig.copy(disabled = true), rollup)).isFalse()
+    assertThat(forcedTransactionsEnabled(enabledConfig, validium)).isFalse()
+    assertThat(forcedTransactionsEnabled(enabledConfig, rollup)).isTrue()
+  }
+
   @Test
   fun `test resume conflation from uses lastFinalizedBlock + 1 for db queries`() {
     val aggregationsRepository = mock<AggregationsRepository>()

--- a/coordinator/app/src/test/kotlin/lineth/coordinator/app/L1BasedLastFinalizedBlockProviderTest.kt
+++ b/coordinator/app/src/test/kotlin/lineth/coordinator/app/L1BasedLastFinalizedBlockProviderTest.kt
@@ -1,7 +1,7 @@
 package lineth.coordinator.app
 
 import io.vertx.core.Vertx
-import linea.contract.l1.LinethRollupSmartContractClientReadOnly
+import linea.contract.l1.LineaSmartContractClientReadOnly
 import linea.domain.BlockParameter
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -14,18 +14,18 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture
 import kotlin.time.Duration.Companion.milliseconds
 
 class L1BasedLastFinalizedBlockProviderTest {
-  private lateinit var linethRollupClient: LinethRollupSmartContractClientReadOnly
+  private lateinit var lineaClient: LineaSmartContractClientReadOnly
 
   @BeforeEach
   fun beforeEach() {
-    linethRollupClient =
-      mock<LinethRollupSmartContractClientReadOnly>(defaultAnswer = Mockito.RETURNS_DEEP_STUBS)
+    lineaClient =
+      mock<LineaSmartContractClientReadOnly>(defaultAnswer = Mockito.RETURNS_DEEP_STUBS)
   }
 
   @Test
   fun `shall wait number of blocks before returning for consistency`() {
     val replies = listOf(100UL, 100UL, 101UL, 101UL, 101UL, 101UL)
-    whenever(linethRollupClient.finalizedL2BlockNumber(eq(BlockParameter.Tag.LATEST)))
+    whenever(lineaClient.finalizedL2BlockNumber(eq(BlockParameter.Tag.LATEST)))
       .thenReturn(
         SafeFuture.completedFuture(replies[0]),
         *replies.subList(1, replies.size).map { SafeFuture.completedFuture(it) }.toTypedArray(),
@@ -34,7 +34,7 @@ class L1BasedLastFinalizedBlockProviderTest {
     val resumerCalculator =
       L1BasedLastFinalizedBlockProvider(
         Vertx.vertx(),
-        linethRollupClient,
+        lineaClient,
         consistentNumberOfBlocksOnL1 = 3u,
         numberOfRetries = 50u,
         pollingInterval = 10.milliseconds,

--- a/coordinator/clients/smart-contract-client/src/main/kotlin/lineth/contract/l1/Web3JLineaValidiumFunctionBuilders.kt
+++ b/coordinator/clients/smart-contract-client/src/main/kotlin/lineth/contract/l1/Web3JLineaValidiumFunctionBuilders.kt
@@ -1,9 +1,11 @@
 package lineth.contract.l1
 
 import linea.contract.ValidiumV1
+import linea.contract.ValidiumV2
 import linea.contract.l1.LineaValidiumContractVersion
 import linea.domain.BlobRecord
 import linea.domain.ProofToFinalize
+import linea.kotlin.encodeHex
 import linea.kotlin.toBigInteger
 import org.web3j.abi.TypeReference
 import org.web3j.abi.datatypes.DynamicBytes
@@ -16,7 +18,10 @@ import java.util.Arrays
 internal object Web3JLineaValidiumFunctionBuilders {
   fun buildAcceptShnarfDataFunction(version: LineaValidiumContractVersion, blobs: List<BlobRecord>): Function {
     return when (version) {
-      LineaValidiumContractVersion.V1 -> buildAcceptShnarfDataFunctionV1(blobs)
+      // acceptShnarfData is byte-identical in V1 and V2, so both use the V1 encoding.
+      LineaValidiumContractVersion.V1,
+      LineaValidiumContractVersion.V2,
+      -> buildAcceptShnarfDataFunctionV1(blobs)
     }
   }
 
@@ -49,6 +54,15 @@ internal object Web3JLineaValidiumFunctionBuilders {
     when (version) {
       LineaValidiumContractVersion.V1 -> {
         return buildFinalizeBlockFunctionV1(
+          aggregationProof,
+          aggregationLastBlob,
+          parentL1RollingHash,
+          parentL1RollingHashMessageNumber,
+        )
+      }
+
+      LineaValidiumContractVersion.V2 -> {
+        return buildFinalizeBlockFunctionV2(
           aggregationProof,
           aggregationLastBlob,
           parentL1RollingHash,
@@ -127,5 +141,85 @@ internal object Web3JLineaValidiumFunctionBuilders {
         emptyList<TypeReference<*>>(),
       )
     return function
+  }
+
+  fun buildFinalizeBlockFunctionV2(
+    aggregationProof: ProofToFinalize,
+    aggregationLastBlob: BlobRecord,
+    parentL1RollingHash: ByteArray,
+    parentL1RollingHashMessageNumber: Long,
+  ): Function {
+    val compressionProof = requireNotNull(aggregationLastBlob.blobCompressionProof) {
+      "aggregationLastBlob.blobCompressionProof must be set when building the finalization function"
+    }
+    val aggregationEndBlobInfo =
+      ValidiumV2.ShnarfData(
+        // parentShnarf
+        compressionProof.prevShnarf,
+        // snarkHash
+        compressionProof.snarkHash,
+        // finalStateRootHash
+        compressionProof.finalStateRootHash,
+        // dataEvaluationPoint
+        compressionProof.expectedX,
+        // dataEvaluationClaim
+        compressionProof.expectedY,
+      )
+
+    // V2's FinalizationDataV4 = V1's FinalizationDataV3 + forced-transaction fields (after
+    // l2MerkleTreesDepth) + filteredAddresses (between l2MerkleRoots and l2MessagingBlocksOffsets).
+    // Field order mirrors the rollup V8 builder (FunctionBuildersV8), which uses the same tuple.
+    val finalizationData =
+      ValidiumV2.FinalizationDataV4(
+        // parentStateRootHash
+        aggregationProof.parentStateRootHash,
+        // endBlockNumber
+        aggregationProof.endBlockNumber.toBigInteger(),
+        // shnarfData
+        aggregationEndBlobInfo,
+        // lastFinalizedTimestamp
+        aggregationProof.parentAggregationLastBlockTimestamp.epochSeconds.toBigInteger(),
+        // finalTimestamp
+        aggregationProof.finalTimestamp.epochSeconds.toBigInteger(),
+        // lastFinalizedL1RollingHash
+        parentL1RollingHash,
+        // l1RollingHash
+        aggregationProof.l1RollingHash,
+        // lastFinalizedL1RollingHashMessageNumber
+        parentL1RollingHashMessageNumber.toBigInteger(),
+        // l1RollingHashMessageNumber
+        aggregationProof.l1RollingHashMessageNumber.toBigInteger(),
+        // l2MerkleTreesDepth
+        aggregationProof.l2MerkleTreesDepth.toBigInteger(),
+        // lastFinalizedForcedTransactionNumber
+        aggregationProof.parentAggregationFtxNumber.toBigInteger(),
+        // finalForcedTransactionNumber
+        aggregationProof.finalFtxNumber.toBigInteger(),
+        // lastFinalizedForcedTransactionRollingHash
+        aggregationProof.parentAggregationFtxRollingHash,
+        // l2MerkleRoots
+        aggregationProof.l2MerkleRoots,
+        // filteredAddresses
+        aggregationProof.filteredAddresses.map { it.encodeHex() },
+        // l2MessagingBlocksOffsets
+        aggregationProof.l2MessagingBlocksOffsets,
+      )
+
+    /**
+     *  function finalizeBlocks(
+     *     bytes calldata _aggregatedProof,
+     *     uint256 _proofType,
+     *     FinalizationDataV4 calldata _finalizationData
+     *   )
+     */
+    return Function(
+      ValidiumV2.FUNC_FINALIZEBLOCKS,
+      Arrays.asList<Type<*>>(
+        DynamicBytes(aggregationProof.aggregatedProof),
+        Uint256(aggregationProof.aggregatedVerifierIndex.toLong()),
+        finalizationData,
+      ),
+      emptyList<TypeReference<*>>(),
+    )
   }
 }

--- a/coordinator/clients/smart-contract-client/src/test/kotlin/lineth/contract/l1/FinalizationFunctionBuildersTest.kt
+++ b/coordinator/clients/smart-contract-client/src/test/kotlin/lineth/contract/l1/FinalizationFunctionBuildersTest.kt
@@ -66,7 +66,7 @@ class FinalizationFunctionBuildersTest {
   @Test
   fun `Validium V2 finalization parameters encode identically to rollup V8`() {
     // Validium V2's FinalizationDataV4 is the same tuple as rollup V8's, so the (positionally
-    // encoded) parameter payload must match the battle-tested V8 builder byte for byte — this
+    // encoded) parameter payload must match the battle-tested V8 builder byte for byte. This
     // pins the struct field ORDER, the one thing that can silently corrupt the calldata.
     // Every V4-specific field gets a DISTINCT non-zero value so a swapped or substituted argument
     // (e.g. the two ftx numbers, or the parent vs final ftx rolling hash) changes the encoding.

--- a/coordinator/clients/smart-contract-client/src/test/kotlin/lineth/contract/l1/FinalizationFunctionBuildersTest.kt
+++ b/coordinator/clients/smart-contract-client/src/test/kotlin/lineth/contract/l1/FinalizationFunctionBuildersTest.kt
@@ -1,5 +1,7 @@
 package lineth.contract.l1
 
+import linea.contract.ValidiumV1
+import linea.contract.ValidiumV2
 import linea.contract.l1.LineaValidiumContractVersion
 import linea.contract.l1.LinethRollupContractVersion
 import linea.domain.createBlobRecord
@@ -7,6 +9,7 @@ import linea.domain.createProofToFinalize
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.web3j.abi.FunctionEncoder
 
 class FinalizationFunctionBuildersTest {
   private val blob = createBlobRecord(startBlockNumber = 1UL, endBlockNumber = 2UL)
@@ -48,6 +51,68 @@ class FinalizationFunctionBuildersTest {
         0L,
       ),
     ).isNotNull()
+    assertThat(
+      Web3JLineaValidiumFunctionBuilders.buildFinalizeBlocksFunction(
+        LineaValidiumContractVersion.V2,
+        aggregation,
+        blob,
+        ByteArray(32),
+        0L,
+      ),
+    ).isNotNull()
+  }
+
+  @Test
+  fun `Validium V2 finalization parameters encode identically to rollup V8`() {
+    // Validium V2's FinalizationDataV4 is the same tuple as rollup V8's, so the (positionally
+    // encoded) parameter payload must match the battle-tested V8 builder byte for byte — this
+    // pins the struct field ORDER, the one thing that can silently corrupt the calldata.
+    // Every V4-specific field gets a DISTINCT non-zero value so a swapped or substituted argument
+    // (e.g. the two ftx numbers, or the parent vs final ftx rolling hash) changes the encoding.
+    val distinctlyPopulatedAggregation = createProofToFinalize(
+      firstBlockNumber = 1L,
+      finalBlockNumber = 2L,
+      parentAggregationFtxNumber = 7UL,
+      finalFtxNumber = 9UL,
+      parentAggregationFtxRollingHash = ByteArray(32) { 0x0a },
+      finalFtxRollingHash = ByteArray(32) { 0x0b },
+      filteredAddresses = listOf(ByteArray(20) { 0x0c }, ByteArray(20) { 0x0d }),
+    ).copy(
+      // createProofToFinalize leaves these zero; make them distinct too so a swap of the adjacent
+      // uint256(0) members (l1RollingHashMessageNumber vs l2MerkleTreesDepth) can't pass silently.
+      aggregatedVerifierIndex = 1,
+      l1RollingHash = ByteArray(32) { 0x0f },
+      l1RollingHashMessageNumber = 4L,
+      l2MerkleTreesDepth = 5,
+    )
+    val parentL1RollingHash = ByteArray(32) { 0x0e }
+    val parentL1RollingHashMessageNumber = 3L
+
+    val v2 = FunctionEncoder.encode(
+      Web3JLineaValidiumFunctionBuilders.buildFinalizeBlockFunctionV2(
+        distinctlyPopulatedAggregation,
+        blob,
+        parentL1RollingHash,
+        parentL1RollingHashMessageNumber,
+      ),
+    )
+    val v8 = FunctionEncoder.encode(
+      FunctionBuildersV8.buildFinalizeBlocksFunctionV8(
+        distinctlyPopulatedAggregation,
+        blob,
+        parentL1RollingHash,
+        parentL1RollingHashMessageNumber,
+      ),
+    )
+    // strip the 4-byte selectors ("0x" + 8 hex chars); the parameter encoding must be identical
+    assertThat(v2.substring(10)).isEqualTo(v8.substring(10))
+  }
+
+  @Test
+  fun `Validium acceptShnarfData is unchanged between V1 and V2`() {
+    // We reuse the V1 encoding for V2 because acceptShnarfData is identical in both ABIs. Check that
+    // against the independently-generated V1 and V2 wrappers, not against ourselves.
+    assertThat(ValidiumV2.FUNC_ACCEPTSHNARFDATA).isEqualTo(ValidiumV1.FUNC_ACCEPTSHNARFDATA)
   }
 
   @Test
@@ -75,6 +140,15 @@ class FinalizationFunctionBuildersTest {
       {
         Web3JLineaValidiumFunctionBuilders.buildFinalizeBlocksFunction(
           LineaValidiumContractVersion.V1,
+          aggregation,
+          unprovenBlob,
+          ByteArray(32),
+          0L,
+        )
+      },
+      {
+        Web3JLineaValidiumFunctionBuilders.buildFinalizeBlocksFunction(
+          LineaValidiumContractVersion.V2,
           aggregation,
           unprovenBlob,
           ByteArray(32),

--- a/coordinator/clients/smart-contract-client/src/test/kotlin/lineth/contract/l1/FinalizationFunctionBuildersTest.kt
+++ b/coordinator/clients/smart-contract-client/src/test/kotlin/lineth/contract/l1/FinalizationFunctionBuildersTest.kt
@@ -10,6 +10,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.web3j.abi.FunctionEncoder
+import org.web3j.tx.TransactionManager
 
 class FinalizationFunctionBuildersTest {
   private val blob = createBlobRecord(startBlockNumber = 1UL, endBlockNumber = 2UL)
@@ -110,9 +111,38 @@ class FinalizationFunctionBuildersTest {
 
   @Test
   fun `Validium acceptShnarfData is unchanged between V1 and V2`() {
-    // We reuse the V1 encoding for V2 because acceptShnarfData is identical in both ABIs. Check that
-    // against the independently-generated V1 and V2 wrappers, not against ourselves.
-    assertThat(ValidiumV2.FUNC_ACCEPTSHNARFDATA).isEqualTo(ValidiumV1.FUNC_ACCEPTSHNARFDATA)
+    // We reuse the V1 encoding for V2 because acceptShnarfData is identical in both ABIs. The wrapper
+    // FUNC_ constants only carry the function NAME, so comparing them would pass even if the argument
+    // lists diverged; compare full encoded calldata instead, using the independently-generated V1 and
+    // V2 wrappers as the reference encoders (encodeFunctionCall builds calldata without a connection).
+    val prevShnarf = ByteArray(32) { 0x0a }
+    val expectedShnarf = ByteArray(32) { 0x0b }
+    val finalStateRootHash = ByteArray(32) { 0x0c }
+
+    val zeroAddress = "0x0000000000000000000000000000000000000000"
+    val v1Reference = ValidiumV1.load(zeroAddress, null, null as TransactionManager?, null)
+      .acceptShnarfData(prevShnarf, expectedShnarf, finalStateRootHash)
+      .encodeFunctionCall()
+    val v2Reference = ValidiumV2.load(zeroAddress, null, null as TransactionManager?, null)
+      .acceptShnarfData(prevShnarf, expectedShnarf, finalStateRootHash)
+      .encodeFunctionCall()
+    // The two generated wrappers must agree (name, argument types and order), and our shared builder
+    // must produce those exact bytes for both versions.
+    assertThat(v2Reference).isEqualTo(v1Reference)
+
+    val blobWithDistinctShnarfData = blob.copy(
+      blobCompressionProof = blob.blobCompressionProof!!.copy(
+        prevShnarf = prevShnarf,
+        expectedShnarf = expectedShnarf,
+        finalStateRootHash = finalStateRootHash,
+      ),
+    )
+    listOf(LineaValidiumContractVersion.V1, LineaValidiumContractVersion.V2).forEach { version ->
+      val encoded = FunctionEncoder.encode(
+        Web3JLineaValidiumFunctionBuilders.buildAcceptShnarfDataFunction(version, listOf(blobWithDistinctShnarfData)),
+      )
+      assertThat(encoded).isEqualTo(v1Reference)
+    }
   }
 
   @Test

--- a/docs/tech/components/coordinator-config-reference.md
+++ b/docs/tech/components/coordinator-config-reference.md
@@ -100,7 +100,7 @@ Shared defaults (L1/L2 endpoints and retry policies) reused by coordinator servi
 
 ### `forced-transactions`
 
-Forced transactions handling settings; omit the section to disable the feature.
+Forced transactions handling settings; omit the section to disable the feature. Ignored on validium deployments: the coordinator does not support forced transactions there yet and disables them with a warning.
 
 | Key | Type | Required | Default | Status | Description |
 | --- | --- | --- | --- | --- | --- |

--- a/docs/tech/components/coordinator-config-schema.json
+++ b/docs/tech/components/coordinator-config-schema.json
@@ -747,7 +747,7 @@
         "section": true,
         "required": false,
         "default": null,
-        "description": "Forced transactions handling settings; omit the section to disable the feature.",
+        "description": "Forced transactions handling settings; omit the section to disable the feature. Ignored on validium deployments: the coordinator does not support forced transactions there yet and disables them with a warning.",
         "example": null,
         "deprecated": false,
         "replacement": null

--- a/jvm-libs/linea/clients/interfaces/src/main/kotlin/linea/contract/l1/LineaSmartContractClient.kt
+++ b/jvm-libs/linea/clients/interfaces/src/main/kotlin/linea/contract/l1/LineaSmartContractClient.kt
@@ -19,6 +19,12 @@ enum class LinethRollupContractVersion : Comparable<LinethRollupContractVersion>
 
 enum class LineaValidiumContractVersion : Comparable<LineaValidiumContractVersion> {
   V1,
+  V2, // forced transactions + address filter (FinalizationDataV4)
+  ;
+
+  companion object {
+    val latest: LineaValidiumContractVersion = entries.last()
+  }
 }
 
 interface LineaSmartContractClientReadOnly {
@@ -76,6 +82,15 @@ interface LinethRollupSmartContractClientReadOnlyFinalizedStateProvider {
 interface LineaValidiumSmartContractClientReadOnly :
   LineaSmartContractClientReadOnly,
   ContractVersionProvider<LineaValidiumContractVersion>
+
+/**
+ * A read-only client that also provides the finalized state data the finalization monitor consumes.
+ * Implemented by both the rollup and validium read-only clients so DA-aware wiring can use either
+ * without a runtime cast.
+ */
+interface FinalizedStateDataClientReadOnly :
+  LineaSmartContractClientReadOnly,
+  FinalizedStateDataProvider
 
 /**
  * Polls contract's version until contract's is equal or greater than target version.

--- a/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaValidiumSmartContractClientReadOnly.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaValidiumSmartContractClientReadOnly.kt
@@ -39,10 +39,9 @@ open class Web3JLineaValidiumSmartContractClientReadOnly(
 
   override fun getAddress(): String = contractAddress
 
-  // NOTE: this version cache is intentionally a copy of Web3JLinethRollupSmartContractClientReadOnly's,
-  // kept as-is to keep this PR narrow. Both version enums are now Comparable with a `latest`, so the two
-  // should be extracted into one shared generic, and the get-then-set below made atomic (updateAndGet),
-  // as a follow-up, in both clients together rather than diverging here.
+  // Deliberate copy of Web3JLinethRollupSmartContractClientReadOnly's version cache. Both version
+  // enums are Comparable with a `latest`, so the two could be extracted into one shared generic and
+  // the get-then-set below made atomic (updateAndGet), in both clients together rather than diverging.
   private data class CachedVersion(
     val version: LineaValidiumContractVersion,
     val fetchedAt: Instant,
@@ -118,12 +117,10 @@ open class Web3JLineaValidiumSmartContractClientReadOnly(
   override fun getFinalizedStateData(
     blockParameter: BlockParameter,
   ): SafeFuture<FinalizedStateDataProvider.FinalizedStateData> {
-    // Read the version even though both branches return zero today: the exhaustive `when` forces a
-    // conscious decision when V3 lands, and this is where the "coordinator doesn't support forced
-    // transactions on validium yet" limitation lives. Don't simplify this to just returning zero
-    // without the version check.
-    // Note: the version is read at LATEST while the finalized state uses blockParameter (mirrors the
-    // rollup client); harmless because the finalization monitor only ever queries LATEST.
+    // Both branches return zero today, but the exhaustive `when` forces a conscious decision when a
+    // new contract version lands. The version is read at LATEST while the finalized state uses
+    // blockParameter (mirrors the rollup client); harmless because the finalization monitor only
+    // ever queries LATEST.
     return getVersion()
       .thenCombine(finalizedL2BlockNumber(blockParameter)) { version, finalizedBlockNumber ->
         when (version) {

--- a/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaValidiumSmartContractClientReadOnly.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaValidiumSmartContractClientReadOnly.kt
@@ -7,15 +7,25 @@ import linea.kotlin.toBigInteger
 import linea.kotlin.toULong
 import linea.web3j.domain.toWeb3j
 import net.consensys.linea.async.toSafeFuture
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
 import org.web3j.protocol.Web3j
 import org.web3j.tx.gas.StaticGasProvider
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import java.math.BigInteger
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 
 open class Web3JLineaValidiumSmartContractClientReadOnly(
   val web3j: Web3j,
   val contractAddress: String,
-) : LineaValidiumSmartContractClientReadOnly {
+  private val versionRefreshInterval: Duration = 6.seconds,
+  private val clock: Clock = Clock.System,
+  private val log: Logger = LogManager.getLogger(Web3JLineaValidiumSmartContractClientReadOnly::class.java),
+) : LineaValidiumSmartContractClientReadOnly, FinalizedStateDataClientReadOnly {
   protected fun contractClientAtBlock(blockParameter: BlockParameter): ValidiumV1 {
     return ValidiumV1.load(
       contractAddress,
@@ -29,14 +39,113 @@ open class Web3JLineaValidiumSmartContractClientReadOnly(
 
   override fun getAddress(): String = contractAddress
 
-  override fun getVersion(blockParameter: BlockParameter): SafeFuture<LineaValidiumContractVersion> =
-    SafeFuture.completedFuture(LineaValidiumContractVersion.V1)
+  // NOTE: this version cache is intentionally a copy of Web3JLinethRollupSmartContractClientReadOnly's,
+  // kept as-is to keep this PR narrow. Both version enums are now Comparable with a `latest`, so the two
+  // should be extracted into one shared generic — and the get-then-set below made atomic (updateAndGet) —
+  // as a follow-up, in both clients together rather than diverging here.
+  private data class CachedVersion(
+    val version: LineaValidiumContractVersion,
+    val fetchedAt: Instant,
+  )
+
+  private val smartContractVersionCache = AtomicReference<CachedVersion>(null)
+
+  private fun getSmartContractVersion(): SafeFuture<LineaValidiumContractVersion> {
+    val cached = smartContractVersionCache.get()
+    return when {
+      // once upgraded, it's not downgraded
+      cached?.version == LineaValidiumContractVersion.latest ->
+        SafeFuture.completedFuture(LineaValidiumContractVersion.latest)
+
+      // below latest: serve from cache within the refresh interval so repeated getVersion calls
+      // don't refetch on every call, while still detecting an upgrade within versionRefreshInterval
+      cached != null && clock.now() < cached.fetchedAt + versionRefreshInterval ->
+        SafeFuture.completedFuture(cached.version)
+
+      else ->
+        fetchSmartContractVersion()
+          .thenPeek { fetchedVersion ->
+            val current = smartContractVersionCache.get()
+            // prevent inflight request to override and rollback
+            if (current == null || fetchedVersion >= current.version) {
+              smartContractVersionCache.set(CachedVersion(fetchedVersion, clock.now()))
+
+              if (current != null && fetchedVersion != current.version) {
+                log.info(
+                  "Validium smart contract upgraded: prevVersion={} upgradedVersion={}",
+                  current.version,
+                  fetchedVersion,
+                )
+              }
+            }
+          }
+    }
+  }
+
+  // CONTRACT_VERSION() exists on both V1 and V2, so the V1 wrapper can read it on either contract.
+  internal open fun fetchSmartContractVersion(
+    blockParameter: BlockParameter = BlockParameter.Tag.LATEST,
+  ): SafeFuture<LineaValidiumContractVersion> {
+    return contractClientAtBlock(blockParameter)
+      .CONTRACT_VERSION().sendAsync()
+      .toSafeFuture()
+      .thenApply(::parseContractVersion)
+  }
+
+  internal fun parseContractVersion(version: String): LineaValidiumContractVersion =
+    // Match on the major component so "10.0" is not misread as V1 by a bare "1" prefix.
+    when (version.substringBefore('.')) {
+      "1" -> LineaValidiumContractVersion.V1
+      "2" -> LineaValidiumContractVersion.V2
+      else -> throw IllegalStateException("Unsupported Validium contract version: $version")
+    }
+
+  override fun getVersion(blockParameter: BlockParameter): SafeFuture<LineaValidiumContractVersion> {
+    return if (blockParameter == BlockParameter.Tag.LATEST) {
+      getSmartContractVersion()
+    } else {
+      fetchSmartContractVersion(blockParameter)
+    }
+  }
 
   override fun finalizedL2BlockNumber(blockParameter: BlockParameter): SafeFuture<ULong> {
     return contractClientAtBlock(blockParameter)
       .currentL2BlockNumber().sendAsync()
       .thenApply { it.toULong() }
       .toSafeFuture()
+  }
+
+  override fun getFinalizedStateData(
+    blockParameter: BlockParameter,
+  ): SafeFuture<FinalizedStateDataProvider.FinalizedStateData> {
+    // Read the version even though both branches return zero today: the exhaustive `when` forces a
+    // conscious decision when V3 lands, and this is where the "coordinator doesn't support forced
+    // transactions on validium yet" limitation lives. Don't simplify this to just returning zero
+    // without the version check.
+    // Note: the version is read at LATEST while the finalized state uses blockParameter (mirrors the
+    // rollup client); harmless because the finalization monitor only ever queries LATEST.
+    return getVersion()
+      .thenCombine(finalizedL2BlockNumber(blockParameter)) { version, finalizedBlockNumber ->
+        when (version) {
+          // V1 contracts have no forced transactions, so the number is always the initial value (0),
+          // mirroring the rollup client's V6/V7 behaviour.
+          LineaValidiumContractVersion.V1 ->
+            FinalizedStateDataProvider.FinalizedStateData(
+              blockNumber = finalizedBlockNumber,
+              forcedTransactionNumber = 0UL,
+            )
+
+          // V2 contracts DO track forced transactions on-chain, but the coordinator does not support
+          // forced transactions on validium chains yet (they are disabled at app wiring). Once that
+          // support lands, this branch must read the FinalizedStateUpdated event like the rollup
+          // client's V8+ path instead of reporting the initial value.
+          LineaValidiumContractVersion.V2 ->
+            FinalizedStateDataProvider.FinalizedStateData(
+              blockNumber = finalizedBlockNumber,
+              forcedTransactionNumber = 0UL,
+            )
+        }
+      }
   }
 
   override fun getMessageRollingHash(blockParameter: BlockParameter, messageNumber: Long): SafeFuture<ByteArray> {

--- a/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaValidiumSmartContractClientReadOnly.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaValidiumSmartContractClientReadOnly.kt
@@ -41,7 +41,7 @@ open class Web3JLineaValidiumSmartContractClientReadOnly(
 
   // NOTE: this version cache is intentionally a copy of Web3JLinethRollupSmartContractClientReadOnly's,
   // kept as-is to keep this PR narrow. Both version enums are now Comparable with a `latest`, so the two
-  // should be extracted into one shared generic — and the get-then-set below made atomic (updateAndGet) —
+  // should be extracted into one shared generic, and the get-then-set below made atomic (updateAndGet),
   // as a follow-up, in both clients together rather than diverging here.
   private data class CachedVersion(
     val version: LineaValidiumContractVersion,

--- a/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLinethRollupSmartContractClientReadOnly.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLinethRollupSmartContractClientReadOnly.kt
@@ -38,7 +38,7 @@ open class Web3JLinethRollupSmartContractClientReadOnly(
   private val log: Logger = LogManager.getLogger(Web3JLinethRollupSmartContractClientReadOnly::class.java),
 ) : LinethRollupSmartContractClientReadOnly,
   LinethRollupSmartContractClientReadOnlyFinalizedStateProvider,
-  FinalizedStateDataProvider {
+  FinalizedStateDataClientReadOnly {
 
   protected fun contractClientV8AtBlock(blockParameter: BlockParameter): LinethRollupV8 {
     return contractClientAtBlock(blockParameter, LinethRollupV8::class.java)

--- a/jvm-libs/linea/clients/linea-contract-clients/src/test/kotlin/linea/contract/l1/Web3JLineaValidiumSmartContractClientReadOnlyTest.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/test/kotlin/linea/contract/l1/Web3JLineaValidiumSmartContractClientReadOnlyTest.kt
@@ -28,7 +28,7 @@ class Web3JLineaValidiumSmartContractClientReadOnlyTest {
       .isInstanceOf(IllegalStateException::class.java)
       .hasMessageContaining("Unsupported Validium contract version: 3.0")
 
-    // "10.0" must not be misread as V1 by a bare "1" prefix — it's unsupported, so reject it.
+    // "10.0" must not be misread as V1 by a bare "1" prefix. It is unsupported, so reject it.
     assertThatThrownBy { client.parseContractVersion("10.0") }
       .isInstanceOf(IllegalStateException::class.java)
       .hasMessageContaining("Unsupported Validium contract version: 10.0")
@@ -77,7 +77,7 @@ class Web3JLineaValidiumSmartContractClientReadOnlyTest {
   @Test
   fun `getFinalizedStateData reports the finalized block with a zero forced-transaction number`() {
     // V1 has no forced transactions; V2 has them on-chain but the coordinator does not support them
-    // on validium yet — both report the initial value (0) until that support lands.
+    // on validium yet, so both report the initial value (0) until that support lands.
     LineaValidiumContractVersion.entries.forEach { version ->
       val fakeClient = object : Web3JLineaValidiumSmartContractClientReadOnly(
         web3j = mock<Web3j>(),

--- a/jvm-libs/linea/clients/linea-contract-clients/src/test/kotlin/linea/contract/l1/Web3JLineaValidiumSmartContractClientReadOnlyTest.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/test/kotlin/linea/contract/l1/Web3JLineaValidiumSmartContractClientReadOnlyTest.kt
@@ -1,0 +1,103 @@
+package linea.contract.l1
+
+import linea.domain.BlockParameter
+import net.consensys.FakeFixedClock
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.web3j.protocol.Web3j
+import tech.pegasys.teku.infrastructure.async.SafeFuture
+import kotlin.time.Duration.Companion.seconds
+
+class Web3JLineaValidiumSmartContractClientReadOnlyTest {
+  private val contractAddress = "0x" + "aa".repeat(20)
+
+  private val client = Web3JLineaValidiumSmartContractClientReadOnly(
+    web3j = mock<Web3j>(), // not used by parseContractVersion
+    contractAddress = contractAddress,
+  )
+
+  @Test
+  fun `parseContractVersion maps major version prefixes and rejects unsupported versions`() {
+    assertThat(client.parseContractVersion("1.0")).isEqualTo(LineaValidiumContractVersion.V1)
+    assertThat(client.parseContractVersion("2.0")).isEqualTo(LineaValidiumContractVersion.V2)
+    assertThat(client.parseContractVersion("2.1.0-rc.1")).isEqualTo(LineaValidiumContractVersion.V2)
+
+    assertThatThrownBy { client.parseContractVersion("3.0") }
+      .isInstanceOf(IllegalStateException::class.java)
+      .hasMessageContaining("Unsupported Validium contract version: 3.0")
+
+    // "10.0" must not be misread as V1 by a bare "1" prefix — it's unsupported, so reject it.
+    assertThatThrownBy { client.parseContractVersion("10.0") }
+      .isInstanceOf(IllegalStateException::class.java)
+      .hasMessageContaining("Unsupported Validium contract version: 10.0")
+  }
+
+  @Test
+  fun `getVersion caches below-latest versions for the refresh interval and short-circuits at latest`() {
+    val fakeClock = FakeFixedClock()
+    var onChainVersion = LineaValidiumContractVersion.V1
+    var fetchCount = 0
+    val fakeClient = object : Web3JLineaValidiumSmartContractClientReadOnly(
+      web3j = mock<Web3j>(),
+      contractAddress = contractAddress,
+      versionRefreshInterval = 30.seconds,
+      clock = fakeClock,
+    ) {
+      override fun fetchSmartContractVersion(
+        blockParameter: BlockParameter,
+      ): SafeFuture<LineaValidiumContractVersion> {
+        fetchCount++
+        return SafeFuture.completedFuture(onChainVersion)
+      }
+    }
+
+    // first call fetches and caches
+    assertThat(fakeClient.getVersion().get()).isEqualTo(LineaValidiumContractVersion.V1)
+    assertThat(fetchCount).isEqualTo(1)
+
+    // within the refresh interval: served from cache, no RPC
+    fakeClock.advanceBy(29.seconds)
+    assertThat(fakeClient.getVersion().get()).isEqualTo(LineaValidiumContractVersion.V1)
+    assertThat(fetchCount).isEqualTo(1)
+
+    // after the refresh interval: refetches and detects the upgrade
+    fakeClock.advanceBy(2.seconds)
+    onChainVersion = LineaValidiumContractVersion.V2
+    assertThat(fakeClient.getVersion().get()).isEqualTo(LineaValidiumContractVersion.V2)
+    assertThat(fetchCount).isEqualTo(2)
+
+    // at the latest known version: short-circuits forever, even after the interval elapses
+    fakeClock.advanceBy(300.seconds)
+    assertThat(fakeClient.getVersion().get()).isEqualTo(LineaValidiumContractVersion.V2)
+    assertThat(fetchCount).isEqualTo(2)
+  }
+
+  @Test
+  fun `getFinalizedStateData reports the finalized block with a zero forced-transaction number`() {
+    // V1 has no forced transactions; V2 has them on-chain but the coordinator does not support them
+    // on validium yet — both report the initial value (0) until that support lands.
+    LineaValidiumContractVersion.entries.forEach { version ->
+      val fakeClient = object : Web3JLineaValidiumSmartContractClientReadOnly(
+        web3j = mock<Web3j>(),
+        contractAddress = contractAddress,
+      ) {
+        override fun fetchSmartContractVersion(
+          blockParameter: BlockParameter,
+        ): SafeFuture<LineaValidiumContractVersion> = SafeFuture.completedFuture(version)
+
+        override fun finalizedL2BlockNumber(blockParameter: BlockParameter): SafeFuture<ULong> =
+          SafeFuture.completedFuture(42UL)
+      }
+
+      assertThat(fakeClient.getFinalizedStateData(BlockParameter.Tag.LATEST).get())
+        .isEqualTo(
+          FinalizedStateDataProvider.FinalizedStateData(
+            blockNumber = 42UL,
+            forcedTransactionNumber = 0UL,
+          ),
+        )
+    }
+  }
+}

--- a/jvm-libs/linea/linea-contracts/l1-validium/build.gradle
+++ b/jvm-libs/linea/linea-contracts/l1-validium/build.gradle
@@ -20,9 +20,11 @@ dependencies {
 web3jContractWrappers {
   def contractsDir = layout.buildDirectory.dir("${rootProject.projectDir}/contracts/abi").get()
   def validiumV1Abi = contractsDir.file("ValidiumV1.0.abi").asFile.absolutePath
+  def validiumV2Abi = contractsDir.file("ValidiumV2.0.abi").asFile.absolutePath
 
   contractsPackage = "linea.contract"
   contracts = [
-    "$validiumV1Abi": "ValidiumV1"
+    "$validiumV1Abi": "ValidiumV1",
+    "$validiumV2Abi": "ValidiumV2",
   ]
 }


### PR DESCRIPTION
This PR implements issue(s) #3868

## Summary

- Lets the coordinator finalize **validium** chains. It previously crashed at startup with `IllegalStateException: Unsupported contract version: 2.0` and never finalized, for two reasons: the finalization-monitor and `L1BasedLastFinalizedBlockProvider` read paths were always wired with `Web3JLinethRollupSmartContractClientReadOnly` regardless of DA mode (its `parseContractVersion` rejects `"2.0"`), and `Web3JLineaValidiumSmartContractClientReadOnly.getVersion()` was hardcoded to `V1` while `deploy-validium` deploys the V2 contract — so once past the startup crash, `finalizeBlocks` would be built as V1 `FinalizationDataV3` and revert on-chain.
- The first commit adds validium V2 support in the client libraries: dynamic `CONTRACT_VERSION()` read (cached as in the rollup client), the generated `ValidiumV2` wrapper, and `finalizeBlocks` encoded as `FinalizationDataV4` (same tuple as rollup V8; parity tests assert the encoding is byte-identical, with distinct values in every V4-specific field). `acceptShnarfData` is unchanged between V1 and V2 (the checked-in V1 and V2 ABIs are identical for it) and reuses the V1 encoding.
- The second commit makes the L1 read path DA-aware: the finalization-monitor client is selected by `l1Submission.dataAvailability`, mirroring `createLineaContractClient`, and the `FinalizedStateDataClientReadOnly` combining interface keeps the monitor wiring cast-free.
- Forced transactions are disabled under validium; `ConflationAppHelper.forcedTransactionsEnabled` is the single source of truth for both the app guard and the DAO selection. The validium V2 contract enforces forced-transaction inclusion at finalization, so a stored forced transaction would halt finalization — `FORCED_TRANSACTION_SENDER_ROLE` should not be granted on validium until coordinator support is added (happy to file that as a follow-up issue).

## Validation

- `:coordinator:app` compiles with tests on current `main`; the `FinalizationFunctionBuildersTest` and `linea-contract-clients` suites pass; spotless is clean.
- Live-validated on a stack built entirely from current `main`, with only the coordinator image replaced by one built from this branch: `make start-env-with-validium-and-tracing-v2-ci` starts cleanly (no "Unsupported contract version" error), conflates, submits, and L1 finalization keeps pace with the L2 head continuously — observed finalized 181 vs head 184 after ~30 minutes, sweeping ~180 blocks including bursts of externally-driven application traffic on the L2.
- The `deploy-validium` target's env vars now match `deployPlonkVerifierAndValidiumV2.ts` on current `main`, so the mismatch mentioned in #3868's reproduction steps has since been fixed upstream and needs no action here.

Internally reviewed (thanks @mkrielza). The commits are structured so this can be split into (1) V2 client support and (2) the DA-aware read path if two smaller PRs are easier to review.

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this PR. *(validium e2e is currently workflow_dispatch-only; live dev-stack validation described above)*
* [x] I have informed the team of any breaking changes if there are any. *(None for rollup deployments; validium deployments previously could not finalize at all.)*
