### PR TITLE
docs(contracts): warn against FORCED_TRANSACTION_SENDER_ROLE on validium

### DIFF
--- a/contracts/docs/deployment/l1/validium.md
+++ b/contracts/docs/deployment/l1/validium.md
@@ -6,6 +6,8 @@
 
 The Validium contract is a permutation of LinethRollup that uses off-chain data availability. It shares the same base contract (same initial state root, block number, and genesis timestamp) but has its own operators and rate limits.
 
+> **Warning — forced transactions are not supported on validium yet.** The coordinator cannot process forced transactions on a validium chain ([#3868](https://github.com/LFDT-Lineth/lineth-monorepo/issues/3868)). The validium V2 contract still enforces forced-transaction inclusion at finalization, so if anyone submits a forced transaction on a validium chain, finalization will halt until coordinator support is added. Do not grant `FORCED_TRANSACTION_SENDER_ROLE` on a validium deployment until that support lands.
+
 Parameters that should be filled either in .env or passed as CLI arguments:
 
 | Parameter name        | Required | Input value | Description |

--- a/contracts/docs/workflows/administration/roleManagement.md
+++ b/contracts/docs/workflows/administration/roleManagement.md
@@ -80,6 +80,8 @@ Safe Member
 - `UNPAUSE_L2_BLOB_SUBMISSION_ROLE`
 - `FORCED_TRANSACTION_SENDER_ROLE`
 
+> **Warning — do not grant `FORCED_TRANSACTION_SENDER_ROLE` on a validium chain.** The coordinator does not support forced transactions on validium chains yet ([#3868](https://github.com/LFDT-Lineth/lineth-monorepo/issues/3868)). The validium V2 contract enforces forced-transaction inclusion at finalization, so a single forced transaction on a validium chain will halt finalization until coordinator support is added. On rollup chains, this role behaves as normal.
+
 ### 📗 L2 Message Service Roles
 
 - `DEFAULT_ADMIN_ROLE`


### PR DESCRIPTION
## Summary

- Adds a warning to the validium deployment doc and the role management doc that forced transactions are not supported by the coordinator on validium chains yet.
- The validium V2 contract enforces forced-transaction inclusion at finalization, so granting `FORCED_TRANSACTION_SENDER_ROLE` and submitting a forced transaction on a validium chain would halt finalization until coordinator support is added.
- On rollup chains, the role behaves as normal.

Refs: #3868

## Test plan

- [x] Docs-only change; no code, build, or test impact.

Made with [Cursor](https://cursor.com)