### PR TITLE
feat(prover-ray): export grandproduct.RowLimitAction for verifier-ray

### DIFF
--- a/prover-ray/wiop/compilers/grandproduct/actions.go
+++ b/prover-ray/wiop/compilers/grandproduct/actions.go
@@ -7,28 +7,33 @@ import (
 	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/wiop"
 )
 
-// rowLimitAction enforces the per-permutation row bound for a single
+// RowLimitAction enforces the per-permutation row bound for a single
 // permutation query on both sides of the protocol. As a prover action it panics
 // (the prover is trusted code about to build an unsound witness); as a verifier
 // action it returns an error so the verifier rejects the proof gracefully.
 //
-// limit is the effective per-side bound for this query: [wiop.MaxPermutationRows]
+// Limit is the effective per-side bound for this query: [wiop.MaxPermutationRows]
 // divided by the accumulator budget it shares with the permutations compiled
 // alongside it (see compilePermutations).
-type rowLimitAction struct {
-	query *wiop.TableRelationQuery
-	limit uint64
+//
+// Exported (with exported fields) so out-of-package consumers — notably the
+// verifier-ray codegen — can read the guarded permutation query (and, through
+// its A/B sides, the module partitioning) and the limit, the same way it
+// already reads [lookuptologderivsum.RowLimitVerifierAction] for lookups.
+type RowLimitAction struct {
+	Query *wiop.TableRelationQuery
+	Limit uint64
 }
 
 // Run implements [wiop.ProverAction]: it panics on an over-limit permutation.
-func (a *rowLimitAction) Run(rt *wiop.Runtime) {
-	a.query.CheckRowLimit(rt, a.limit)
+func (a *RowLimitAction) Run(rt *wiop.Runtime) {
+	a.Query.CheckRowLimit(rt, a.Limit)
 }
 
 // Check implements [wiop.VerifierAction]: it returns an error on an over-limit
 // permutation so the verifier rejects the proof.
-func (a *rowLimitAction) Check(rt *wiop.Runtime) error {
-	return a.query.ValidateRowLimit(rt, a.limit)
+func (a *RowLimitAction) Check(rt *wiop.Runtime) error {
+	return a.Query.ValidateRowLimit(rt, a.Limit)
 }
 
 // assignResultAction assigns the grand-product Result cell to the value the

--- a/prover-ray/wiop/compilers/grandproduct/permutation.go
+++ b/prover-ray/wiop/compilers/grandproduct/permutation.go
@@ -74,7 +74,7 @@ func compilePermutations(sys *wiop.System) {
 
 		// One instance serves both roles: it panics as a prover action and
 		// returns an error as a verifier action.
-		rowLimit := &rowLimitAction{query: q, limit: limit}
+		rowLimit := &RowLimitAction{Query: q, Limit: limit}
 		maxRound.RegisterAction(rowLimit)
 		maxRound.RegisterVerifierAction(rowLimit)
 	}

--- a/prover-ray/wiop/compilers/grandproduct/rowlimit_internal_test.go
+++ b/prover-ray/wiop/compilers/grandproduct/rowlimit_internal_test.go
@@ -91,15 +91,15 @@ func TestRowLimitAction_RegisteredOnWitnessRound(t *testing.T) {
 
 	var proverHits, verifierHits int
 	for _, a := range r0.ProverActions {
-		if rl, ok := a.(*rowLimitAction); ok {
+		if rl, ok := a.(*RowLimitAction); ok {
 			proverHits++
-			assert.Same(t, q, rl.query, "the action must guard the permutation query")
-			assert.Equal(t, wiop.MaxPermutationRows, rl.limit,
+			assert.Same(t, q, rl.Query, "the action must guard the permutation query")
+			assert.Equal(t, wiop.MaxPermutationRows, rl.Limit,
 				"the per-side budget must be MaxPermutationRows, undivided by the packing arity or the permutation count")
 		}
 	}
 	for _, a := range r0.VerifierActions {
-		if _, ok := a.(*rowLimitAction); ok {
+		if _, ok := a.(*RowLimitAction); ok {
 			verifierHits++
 		}
 	}
@@ -114,7 +114,7 @@ func TestRowLimitAction_RegisteredOnWitnessRound(t *testing.T) {
 // before any action is registered — is what makes the runtime path reachable.
 func TestRowLimitAction_RejectsOverLimitASide(t *testing.T) {
 	_, _, q, rt := buildRowLimitSystem(t, 1<<58, 0) // A at the budget; B dynamic and tiny.
-	action := &rowLimitAction{query: q, limit: wiop.MaxPermutationRows}
+	action := &RowLimitAction{Query: q, Limit: wiop.MaxPermutationRows}
 
 	err := action.Check(rt)
 	require.Error(t, err, "verifier must reject an over-limit A side")
@@ -127,7 +127,7 @@ func TestRowLimitAction_RejectsOverLimitASide(t *testing.T) {
 // over-limit B side.
 func TestRowLimitAction_RejectsOverLimitBSide(t *testing.T) {
 	_, _, q, rt := buildRowLimitSystem(t, 0, 1<<58) // B at the budget; A dynamic and tiny.
-	action := &rowLimitAction{query: q, limit: wiop.MaxPermutationRows}
+	action := &RowLimitAction{Query: q, Limit: wiop.MaxPermutationRows}
 
 	err := action.Check(rt)
 	require.Error(t, err, "verifier must reject an over-limit B side")
@@ -139,7 +139,7 @@ func TestRowLimitAction_RejectsOverLimitBSide(t *testing.T) {
 // in-budget permutation: Check returns nil and Run does not panic.
 func TestRowLimitAction_AcceptsWithinLimit(t *testing.T) {
 	_, _, q, rt := buildRowLimitSystem(t, 4, 4)
-	action := &rowLimitAction{query: q, limit: wiop.MaxPermutationRows}
+	action := &RowLimitAction{Query: q, Limit: wiop.MaxPermutationRows}
 
 	require.NoError(t, action.Check(rt), "an in-budget permutation must pass the verifier check")
 	assert.NotPanics(t, func() { action.Run(rt) }, "an in-budget permutation must not panic the prover")


### PR DESCRIPTION
## Summary
- Exports `grandproduct.RowLimitAction` (was `rowLimitAction`, unexported) by capitalizing its type and fields (`Query`, `Limit`), so out-of-package consumers can read the guarded permutation query and its row-limit — mirroring how `lookuptologderivsum.RowLimitVerifierAction` is already consumed externally.
- Updates the single call site in `compilePermutations` (permutation.go) and the existing internal test (rowlimit_internal_test.go) to the new exported names. No behavioral change — this is a pure rename/visibility change.
- Unblocks verifier-ray's codegen, which needs to enumerate `RowLimitAction` instances registered on a `wiop.System` to generate the Zig `rowlimit` sub-verifier's per-permutation checks (see the follow-up PR on `fix/grandproduct-rowlimit-allowlist`).

## Test plan
- [x] `go test ./wiop/compilers/grandproduct/...` passes (existing `RowLimitAction` prover/verifier tests updated for the rename)
- [x] `go build ./...` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rename and export-only change with no logic changes; tests still cover registration and row-limit enforcement.
> 
> **Overview**
> Exports **`grandproduct.RowLimitAction`** (previously unexported `rowLimitAction`) and its **`Query`** / **`Limit`** fields so verifier-ray codegen can inspect registered row-limit checks on a `wiop.System`, matching the existing pattern for lookup **`RowLimitVerifierAction`**.
> 
> **`compilePermutations`** and internal row-limit tests are updated to the new names only; prover panic and verifier error behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e6d9ca8705731f7672c3bcf26e74b2607d42f50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->