### PR TITLE
docs(config-docs): move Description to second column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ proving_key.bin
 .externalToolBuilders/
 .gradle/
 .idea/
+.kotlin/
 .next/
 .recommenders/
 .idea_modules/

--- a/docs/tech/components/coordinator-config-reference.md
+++ b/docs/tech/components/coordinator-config-reference.md
@@ -10,579 +10,579 @@ Main Coordinator configuration.
 
 Coordinator JSON-RPC and observability API settings.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `api.json-rpc-path` | `String` | no | `/` | active | HTTP path the JSON-RPC API is served on. |
-| `api.json-rpc-port` | `UInt` | no | `0` | active | Port serving the coordinator JSON-RPC API. 0 picks a random free port. |
-| `api.json-rpc-server-verticles` | `Int` | no | `1` | active | Number of Vert.x verticles serving the JSON-RPC API. |
-| `api.observability-port` | `UInt` | no | `9545` | active | Port serving observability endpoints (metrics/health). |
+| `api.json-rpc-path` | HTTP path the JSON-RPC API is served on. | `String` | no | `/` | active |
+| `api.json-rpc-port` | Port serving the coordinator JSON-RPC API. 0 picks a random free port. | `UInt` | no | `0` | active |
+| `api.json-rpc-server-verticles` | Number of Vert.x verticles serving the JSON-RPC API. | `Int` | no | `1` | active |
+| `api.observability-port` | Port serving observability endpoints (metrics/health). | `UInt` | no | `9545` | active |
 
 ### `conflation`
 
 Block conflation, blob compression, and proof aggregation settings.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `conflation.backtesting-directory` | `Path?` | no | - | active | Directory used to persist conflation backtesting data. Omit to disable backtesting output. Example: `/data/conflation-backtesting`. |
-| `conflation.blob-compression.batches-limit` | `UInt?` | no | - | active | Maximum number of batches per blob. Omit for no explicit limit. Example: `1`. |
-| `conflation.blob-compression.blob-compressor-version` | `BlobCompressorVersion` | no | `V3` | active | Blob compressor version to use. |
-| `conflation.blob-compression.blob-size-limit` | `UInt` | no | `102400` | active | Maximum compressed blob size in bytes before a blob is finalized. |
-| `conflation.blob-compression.handler-polling-interval` | `Duration` | no | `PT1S` | active | Interval between blob compression handler runs. |
-| `conflation.blocks-limit` | `UInt?` | no | - | active | Maximum number of L2 blocks in a single conflation. Omit for no block-count limit. Example: `2`. |
-| `conflation.conflation-deadline` | `Duration?` | no | - | active | Maximum time to wait before conflating available blocks even if limits are not reached. Omit to disable deadline-based conflation. Example: `PT6S`. |
-| `conflation.conflation-deadline-check-interval` | `Duration` | no | `PT30S` | active | How often to check whether the conflation deadline has elapsed. |
-| `conflation.conflation-deadline-last-block-confirmation-delay` | `Duration` | no | `PT30S` | active | Delay after the last block before confirming it, to absorb short reorgs. |
-| `conflation.consistent-number-of-blocks-on-l1-to-wait` | `UInt` | no | `32` | active | Number of L1 blocks to wait for consistency (finality safety margin); defaults to one epoch. |
-| `conflation.disabled` | `Boolean` | no | `false` | active | Whether conflation is disabled. |
-| `conflation.force-stop-conflation-at-block-inclusive` | `ULong?` | no | - | active | Inclusive L2 block number at which to stop conflating. Omit to conflate indefinitely. Example: `100000000`. |
-| `conflation.force-stop-conflation-at-block-timestamp-inclusive` | `Instant?` | no | - | active | Inclusive block timestamp at which to stop conflating. Omit to conflate indefinitely. Example: `2024-01-01T00:00:00Z`. |
-| `conflation.l2-endpoint` | `URL?` | no | - | active | L2 endpoint used for conflation. Falls back to defaults.l2-endpoint. Example: `http://sequencer:8545`. |
-| `conflation.l2-fetch-blocks-limit` | `UInt?` | no | - | active | Maximum number of L2 blocks to fetch that are unproven and held in memory. Omit for no limit. Example: `4000`. |
-| `conflation.l2-logs-endpoint` | `URL?` | no | - | active | L2 endpoint used for eth_getLogs during conflation. Falls back to l2-endpoint/defaults. Example: `http://sequencer:8545`. |
-| `conflation.l2-request-retries.backoff-delay` | `Duration` | no | `PT1S` | active | Delay between retry attempts. Example: `PT1S`. |
-| `conflation.l2-request-retries.failures-warning-threshold` | `UInt?` | no | - | active | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. |
-| `conflation.l2-request-retries.ignore-first-exceptions-until-time-elapsed` | `Duration?` | no | - | active | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. |
-| `conflation.l2-request-retries.max-retries` | `UInt?` | no | - | active | Maximum number of retry attempts. Omit for endless retries. Example: `3`. |
-| `conflation.l2-request-retries.timeout` | `Duration?` | no | - | active | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. |
-| `conflation.new-blocks-polling-interval` | `Duration` | no | `PT1S` | active | Interval between polls for new L2 blocks. |
-| `conflation.proof-aggregation.aggregation-size-multiple-of` | `UInt` | no | `1` | active | Aggregations are only closed when their size is a multiple of this value. |
-| `conflation.proof-aggregation.blobs-limit` | `UInt?` | no | - | active | Maximum number of blobs in a single aggregation. Omit for no explicit limit. Example: `6`. |
-| `conflation.proof-aggregation.coordinator-polling-interval` | `Duration` | no | `PT3S` | active | Interval between coordinator polls for new proofs to aggregate. |
-| `conflation.proof-aggregation.deadline` | `Duration?` | no | - | active | Maximum time to wait before aggregating available proofs. Omit to disable deadline-based aggregation (wait indefinitely). Example: `PT1M`. |
-| `conflation.proof-aggregation.deadline-check-interval` | `Duration` | no | `PT30S` | active | How often to check whether the aggregation deadline has elapsed. |
-| `conflation.proof-aggregation.proofs-limit` | `UInt` | no | `300` | active | Maximum number of proofs in a single aggregation. |
-| `conflation.proof-aggregation.target-end-blocks` | `List<ULong>?` | no | - | active | L2 block numbers that must end an aggregation (e.g. hard-fork boundaries). Omit for none. Example: `[]`. |
-| `conflation.proof-aggregation.timestamp-based-hard-forks` | `List<Instant>` | no | `[]` | active | Timestamps that force an aggregation boundary (e.g. timestamp-based hard forks). |
-| `conflation.proof-aggregation.wait-api-resume-after-target-block` | `Boolean` | no | `false` | active | Whether to wait for the API to resume after the target block before aggregating. |
-| `conflation.proof-aggregation.wait-for-no-l2-activity-to-trigger-aggregation` | `Boolean` | no | `false` | active | Whether to wait for a period of no L2 activity before triggering an aggregation. |
-| `conflation.proof-aggregation.wait-target-block-l1-finalization` | `Boolean` | no | `false` | active | Whether to wait for the target block to be finalized on L1 before aggregating. |
-| `conflation.riscv-starting-block-timestamp-inclusive` | `Instant?` | no | - | active | RISC-V starting block timestamp (inclusive). Example: `2027-01-01T00:00:00Z`. |
+| `conflation.backtesting-directory` | Directory used to persist conflation backtesting data. Omit to disable backtesting output. Example: `/data/conflation-backtesting`. | `Path?` | no | - | active |
+| `conflation.blob-compression.batches-limit` | Maximum number of batches per blob. Omit for no explicit limit. Example: `1`. | `UInt?` | no | - | active |
+| `conflation.blob-compression.blob-compressor-version` | Blob compressor version to use. | `BlobCompressorVersion` | no | `V3` | active |
+| `conflation.blob-compression.blob-size-limit` | Maximum compressed blob size in bytes before a blob is finalized. | `UInt` | no | `102400` | active |
+| `conflation.blob-compression.handler-polling-interval` | Interval between blob compression handler runs. | `Duration` | no | `PT1S` | active |
+| `conflation.blocks-limit` | Maximum number of L2 blocks in a single conflation. Omit for no block-count limit. Example: `2`. | `UInt?` | no | - | active |
+| `conflation.conflation-deadline` | Maximum time to wait before conflating available blocks even if limits are not reached. Omit to disable deadline-based conflation. Example: `PT6S`. | `Duration?` | no | - | active |
+| `conflation.conflation-deadline-check-interval` | How often to check whether the conflation deadline has elapsed. | `Duration` | no | `PT30S` | active |
+| `conflation.conflation-deadline-last-block-confirmation-delay` | Delay after the last block before confirming it, to absorb short reorgs. | `Duration` | no | `PT30S` | active |
+| `conflation.consistent-number-of-blocks-on-l1-to-wait` | Number of L1 blocks to wait for consistency (finality safety margin); defaults to one epoch. | `UInt` | no | `32` | active |
+| `conflation.disabled` | Whether conflation is disabled. | `Boolean` | no | `false` | active |
+| `conflation.force-stop-conflation-at-block-inclusive` | Inclusive L2 block number at which to stop conflating. Omit to conflate indefinitely. Example: `100000000`. | `ULong?` | no | - | active |
+| `conflation.force-stop-conflation-at-block-timestamp-inclusive` | Inclusive block timestamp at which to stop conflating. Omit to conflate indefinitely. Example: `2024-01-01T00:00:00Z`. | `Instant?` | no | - | active |
+| `conflation.l2-endpoint` | L2 endpoint used for conflation. Falls back to defaults.l2-endpoint. Example: `http://sequencer:8545`. | `URL?` | no | - | active |
+| `conflation.l2-fetch-blocks-limit` | Maximum number of L2 blocks to fetch that are unproven and held in memory. Omit for no limit. Example: `4000`. | `UInt?` | no | - | active |
+| `conflation.l2-logs-endpoint` | L2 endpoint used for eth_getLogs during conflation. Falls back to l2-endpoint/defaults. Example: `http://sequencer:8545`. | `URL?` | no | - | active |
+| `conflation.l2-request-retries.backoff-delay` | Delay between retry attempts. Example: `PT1S`. | `Duration` | no | `PT1S` | active |
+| `conflation.l2-request-retries.failures-warning-threshold` | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. | `UInt?` | no | - | active |
+| `conflation.l2-request-retries.ignore-first-exceptions-until-time-elapsed` | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. | `Duration?` | no | - | active |
+| `conflation.l2-request-retries.max-retries` | Maximum number of retry attempts. Omit for endless retries. Example: `3`. | `UInt?` | no | - | active |
+| `conflation.l2-request-retries.timeout` | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. | `Duration?` | no | - | active |
+| `conflation.new-blocks-polling-interval` | Interval between polls for new L2 blocks. | `Duration` | no | `PT1S` | active |
+| `conflation.proof-aggregation.aggregation-size-multiple-of` | Aggregations are only closed when their size is a multiple of this value. | `UInt` | no | `1` | active |
+| `conflation.proof-aggregation.blobs-limit` | Maximum number of blobs in a single aggregation. Omit for no explicit limit. Example: `6`. | `UInt?` | no | - | active |
+| `conflation.proof-aggregation.coordinator-polling-interval` | Interval between coordinator polls for new proofs to aggregate. | `Duration` | no | `PT3S` | active |
+| `conflation.proof-aggregation.deadline` | Maximum time to wait before aggregating available proofs. Omit to disable deadline-based aggregation (wait indefinitely). Example: `PT1M`. | `Duration?` | no | - | active |
+| `conflation.proof-aggregation.deadline-check-interval` | How often to check whether the aggregation deadline has elapsed. | `Duration` | no | `PT30S` | active |
+| `conflation.proof-aggregation.proofs-limit` | Maximum number of proofs in a single aggregation. | `UInt` | no | `300` | active |
+| `conflation.proof-aggregation.target-end-blocks` | L2 block numbers that must end an aggregation (e.g. hard-fork boundaries). Omit for none. Example: `[]`. | `List<ULong>?` | no | - | active |
+| `conflation.proof-aggregation.timestamp-based-hard-forks` | Timestamps that force an aggregation boundary (e.g. timestamp-based hard forks). | `List<Instant>` | no | `[]` | active |
+| `conflation.proof-aggregation.wait-api-resume-after-target-block` | Whether to wait for the API to resume after the target block before aggregating. | `Boolean` | no | `false` | active |
+| `conflation.proof-aggregation.wait-for-no-l2-activity-to-trigger-aggregation` | Whether to wait for a period of no L2 activity before triggering an aggregation. | `Boolean` | no | `false` | active |
+| `conflation.proof-aggregation.wait-target-block-l1-finalization` | Whether to wait for the target block to be finalized on L1 before aggregating. | `Boolean` | no | `false` | active |
+| `conflation.riscv-starting-block-timestamp-inclusive` | RISC-V starting block timestamp (inclusive). Example: `2027-01-01T00:00:00Z`. | `Instant?` | no | - | active |
 
 ### `database`
 
 Coordinator PostgreSQL persistence settings.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `database.hostname` | `String` | yes | - | active | PostgreSQL hostname used by the coordinator persistence layer. Example: `postgres`. |
-| `database.password` | `Masked` | yes | - | active | PostgreSQL password. Masked in logs. |
-| `database.persistence-retries.backoff-delay` | `Duration` | no | `PT1S` | active | Delay between retry attempts. Example: `PT1S`. |
-| `database.persistence-retries.failures-warning-threshold` | `UInt?` | no | - | active | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. |
-| `database.persistence-retries.ignore-first-exceptions-until-time-elapsed` | `Duration?` | no | - | active | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. |
-| `database.persistence-retries.max-retries` | `UInt?` | no | - | active | Maximum number of retry attempts. Omit for endless retries. Example: `3`. |
-| `database.persistence-retries.timeout` | `Duration?` | no | - | active | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. |
-| `database.port` | `UInt` | no | `5432` | active | PostgreSQL port. |
-| `database.read-pipelining-limit` | `Int` | no | `10` | active | Maximum number of read queries pipelined on a single connection. |
-| `database.read-pool-size` | `Int` | no | `10` | active | Connection pool size for read-only queries. |
-| `database.schema` | `String` | no | `linea_coordinator` | active | PostgreSQL schema (database) name. |
-| `database.schema-version` | `Int` | no | `4` | active | Expected database schema version; must match a supported migration version. |
-| `database.transactional-pool-size` | `Int` | no | `10` | active | Connection pool size for transactional (read-write) queries. |
-| `database.username` | `String` | yes | - | active | PostgreSQL username. Example: `postgres`. |
+| `database.hostname` | PostgreSQL hostname used by the coordinator persistence layer. Example: `postgres`. | `String` | yes | - | active |
+| `database.password` | PostgreSQL password. Masked in logs. | `Masked` | yes | - | active |
+| `database.persistence-retries.backoff-delay` | Delay between retry attempts. Example: `PT1S`. | `Duration` | no | `PT1S` | active |
+| `database.persistence-retries.failures-warning-threshold` | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. | `UInt?` | no | - | active |
+| `database.persistence-retries.ignore-first-exceptions-until-time-elapsed` | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. | `Duration?` | no | - | active |
+| `database.persistence-retries.max-retries` | Maximum number of retry attempts. Omit for endless retries. Example: `3`. | `UInt?` | no | - | active |
+| `database.persistence-retries.timeout` | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. | `Duration?` | no | - | active |
+| `database.port` | PostgreSQL port. | `UInt` | no | `5432` | active |
+| `database.read-pipelining-limit` | Maximum number of read queries pipelined on a single connection. | `Int` | no | `10` | active |
+| `database.read-pool-size` | Connection pool size for read-only queries. | `Int` | no | `10` | active |
+| `database.schema` | PostgreSQL schema (database) name. | `String` | no | `linea_coordinator` | active |
+| `database.schema-version` | Expected database schema version; must match a supported migration version. | `Int` | no | `4` | active |
+| `database.transactional-pool-size` | Connection pool size for transactional (read-write) queries. | `Int` | no | `10` | active |
+| `database.username` | PostgreSQL username. Example: `postgres`. | `String` | yes | - | active |
 
 ### `defaults`
 
 Shared defaults (L1/L2 endpoints and retry policies) reused by coordinator services.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `defaults.l1-endpoint` | `URL?` | no | - | active | Default L1 execution-layer JSON-RPC endpoint used by services that do not override it. Example: `http://l1-el-node:8545`. |
-| `defaults.l1-request-retries.backoff-delay` | `Duration` | no | `PT1S` | active | Delay between retry attempts. Example: `PT1S`. |
-| `defaults.l1-request-retries.failures-warning-threshold` | `UInt?` | no | - | active | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. |
-| `defaults.l1-request-retries.ignore-first-exceptions-until-time-elapsed` | `Duration?` | no | - | active | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. |
-| `defaults.l1-request-retries.max-retries` | `UInt?` | no | - | active | Maximum number of retry attempts. Omit for endless retries. Example: `3`. |
-| `defaults.l1-request-retries.timeout` | `Duration?` | no | - | active | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. |
-| `defaults.l2-endpoint` | `URL?` | no | - | active | Default L2 JSON-RPC endpoint used by services that do not override it. Example: `http://sequencer:8545`. |
-| `defaults.l2-request-retries.backoff-delay` | `Duration` | no | `PT1S` | active | Delay between retry attempts. Example: `PT1S`. |
-| `defaults.l2-request-retries.failures-warning-threshold` | `UInt?` | no | - | active | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. |
-| `defaults.l2-request-retries.ignore-first-exceptions-until-time-elapsed` | `Duration?` | no | - | active | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. |
-| `defaults.l2-request-retries.max-retries` | `UInt?` | no | - | active | Maximum number of retry attempts. Omit for endless retries. Example: `3`. |
-| `defaults.l2-request-retries.timeout` | `Duration?` | no | - | active | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. |
+| `defaults.l1-endpoint` | Default L1 execution-layer JSON-RPC endpoint used by services that do not override it. Example: `http://l1-el-node:8545`. | `URL?` | no | - | active |
+| `defaults.l1-request-retries.backoff-delay` | Delay between retry attempts. Example: `PT1S`. | `Duration` | no | `PT1S` | active |
+| `defaults.l1-request-retries.failures-warning-threshold` | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. | `UInt?` | no | - | active |
+| `defaults.l1-request-retries.ignore-first-exceptions-until-time-elapsed` | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. | `Duration?` | no | - | active |
+| `defaults.l1-request-retries.max-retries` | Maximum number of retry attempts. Omit for endless retries. Example: `3`. | `UInt?` | no | - | active |
+| `defaults.l1-request-retries.timeout` | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. | `Duration?` | no | - | active |
+| `defaults.l2-endpoint` | Default L2 JSON-RPC endpoint used by services that do not override it. Example: `http://sequencer:8545`. | `URL?` | no | - | active |
+| `defaults.l2-request-retries.backoff-delay` | Delay between retry attempts. Example: `PT1S`. | `Duration` | no | `PT1S` | active |
+| `defaults.l2-request-retries.failures-warning-threshold` | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. | `UInt?` | no | - | active |
+| `defaults.l2-request-retries.ignore-first-exceptions-until-time-elapsed` | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. | `Duration?` | no | - | active |
+| `defaults.l2-request-retries.max-retries` | Maximum number of retry attempts. Omit for endless retries. Example: `3`. | `UInt?` | no | - | active |
+| `defaults.l2-request-retries.timeout` | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. | `Duration?` | no | - | active |
 
 ### `forced-transactions`
 
 Forced transactions handling settings; omit the section to disable the feature.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `forced-transactions.disabled` | `Boolean` | no | `false` | active | Whether forced transactions handling is disabled. |
-| `forced-transactions.invalidity-proof-check-interval` | `Duration` | no | `PT2M` | active | Interval between checks for invalidity proofs of forced transactions. |
-| `forced-transactions.l1-endpoint` | `URL?` | no | - | active | L1 endpoint used to read forced transactions. Falls back to defaults.l1-endpoint. Example: `http://l1-el-node:8545`. |
-| `forced-transactions.l1-event-scraping.eth-logs-search-block-chunk-size` | `UInt` | no | `1000` | active | Number of blocks scanned per eth_getLogs chunk. |
-| `forced-transactions.l1-event-scraping.eth-logs-search-max-block-range` | `UInt` | no | `10000` | active | Maximum block range covered by a single eth_getLogs search. |
-| `forced-transactions.l1-event-scraping.eth-logs-search-success-backoff-delay` | `Duration` | no | `PT0.001S` | active | Backoff delay after a successful eth_getLogs search before the next one. |
-| `forced-transactions.l1-event-scraping.polling-interval` | `Duration` | no | `PT12S` | active | Interval between L1 log polling attempts. |
-| `forced-transactions.l1-event-scraping.polling-timeout` | `Duration` | no | `PT5S` | active | Timeout for each L1 log polling request. |
-| `forced-transactions.l1-highest-block-tag` | `BlockParameter` | no | `FINALIZED` | active | L1 block tag up to which forced-transaction events are read. |
-| `forced-transactions.l1-request-retries.backoff-delay` | `Duration` | no | `PT1S` | active | Delay between retry attempts. Example: `PT1S`. |
-| `forced-transactions.l1-request-retries.failures-warning-threshold` | `UInt?` | no | - | active | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. |
-| `forced-transactions.l1-request-retries.ignore-first-exceptions-until-time-elapsed` | `Duration?` | no | - | active | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. |
-| `forced-transactions.l1-request-retries.max-retries` | `UInt?` | no | - | active | Maximum number of retry attempts. Omit for endless retries. Example: `3`. |
-| `forced-transactions.l1-request-retries.timeout` | `Duration?` | no | - | active | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. |
-| `forced-transactions.processing-batch-size` | `UInt` | no | `10` | active | Number of forced transactions processed per batch. |
-| `forced-transactions.processing-delay` | `Duration` | no | `PT0S` | active | Delay before processing a forced transaction after it is detected. |
-| `forced-transactions.processing-tick-interval` | `Duration` | no | `PT2M` | active | Interval between forced-transaction processing ticks. |
-| `forced-transactions.sequencer-endpoint` | `URL` | yes | - | active | Sequencer endpoint to which forced transactions are submitted. Example: `http://sequencer:8545`. |
-| `forced-transactions.sequencer-request-retries.backoff-delay` | `Duration` | no | `PT1S` | active | Delay between retry attempts. Example: `PT1S`. |
-| `forced-transactions.sequencer-request-retries.failures-warning-threshold` | `UInt?` | no | - | active | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. |
-| `forced-transactions.sequencer-request-retries.ignore-first-exceptions-until-time-elapsed` | `Duration?` | no | - | active | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. |
-| `forced-transactions.sequencer-request-retries.max-retries` | `UInt?` | no | - | active | Maximum number of retry attempts. Omit for endless retries. Example: `3`. |
-| `forced-transactions.sequencer-request-retries.timeout` | `Duration?` | no | - | active | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. |
+| `forced-transactions.disabled` | Whether forced transactions handling is disabled. | `Boolean` | no | `false` | active |
+| `forced-transactions.invalidity-proof-check-interval` | Interval between checks for invalidity proofs of forced transactions. | `Duration` | no | `PT2M` | active |
+| `forced-transactions.l1-endpoint` | L1 endpoint used to read forced transactions. Falls back to defaults.l1-endpoint. Example: `http://l1-el-node:8545`. | `URL?` | no | - | active |
+| `forced-transactions.l1-event-scraping.eth-logs-search-block-chunk-size` | Number of blocks scanned per eth_getLogs chunk. | `UInt` | no | `1000` | active |
+| `forced-transactions.l1-event-scraping.eth-logs-search-max-block-range` | Maximum block range covered by a single eth_getLogs search. | `UInt` | no | `10000` | active |
+| `forced-transactions.l1-event-scraping.eth-logs-search-success-backoff-delay` | Backoff delay after a successful eth_getLogs search before the next one. | `Duration` | no | `PT0.001S` | active |
+| `forced-transactions.l1-event-scraping.polling-interval` | Interval between L1 log polling attempts. | `Duration` | no | `PT12S` | active |
+| `forced-transactions.l1-event-scraping.polling-timeout` | Timeout for each L1 log polling request. | `Duration` | no | `PT5S` | active |
+| `forced-transactions.l1-highest-block-tag` | L1 block tag up to which forced-transaction events are read. | `BlockParameter` | no | `FINALIZED` | active |
+| `forced-transactions.l1-request-retries.backoff-delay` | Delay between retry attempts. Example: `PT1S`. | `Duration` | no | `PT1S` | active |
+| `forced-transactions.l1-request-retries.failures-warning-threshold` | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. | `UInt?` | no | - | active |
+| `forced-transactions.l1-request-retries.ignore-first-exceptions-until-time-elapsed` | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. | `Duration?` | no | - | active |
+| `forced-transactions.l1-request-retries.max-retries` | Maximum number of retry attempts. Omit for endless retries. Example: `3`. | `UInt?` | no | - | active |
+| `forced-transactions.l1-request-retries.timeout` | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. | `Duration?` | no | - | active |
+| `forced-transactions.processing-batch-size` | Number of forced transactions processed per batch. | `UInt` | no | `10` | active |
+| `forced-transactions.processing-delay` | Delay before processing a forced transaction after it is detected. | `Duration` | no | `PT0S` | active |
+| `forced-transactions.processing-tick-interval` | Interval between forced-transaction processing ticks. | `Duration` | no | `PT2M` | active |
+| `forced-transactions.sequencer-endpoint` | Sequencer endpoint to which forced transactions are submitted. Example: `http://sequencer:8545`. | `URL` | yes | - | active |
+| `forced-transactions.sequencer-request-retries.backoff-delay` | Delay between retry attempts. Example: `PT1S`. | `Duration` | no | `PT1S` | active |
+| `forced-transactions.sequencer-request-retries.failures-warning-threshold` | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. | `UInt?` | no | - | active |
+| `forced-transactions.sequencer-request-retries.ignore-first-exceptions-until-time-elapsed` | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. | `Duration?` | no | - | active |
+| `forced-transactions.sequencer-request-retries.max-retries` | Maximum number of retry attempts. Omit for endless retries. Example: `3`. | `UInt?` | no | - | active |
+| `forced-transactions.sequencer-request-retries.timeout` | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. | `Duration?` | no | - | active |
 
 ### `l1-finalization-monitor`
 
 L1 finalization monitor polling settings.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `l1-finalization-monitor.l1-endpoint` | `URL?` | no | - | active | L1 endpoint for finalization monitoring. Falls back to defaults.l1-endpoint. Example: `http://l1-el-node:8545`. |
-| `l1-finalization-monitor.l1-polling-interval` | `Duration` | no | `PT6S` | active | Interval between L1 finalization polls. |
-| `l1-finalization-monitor.l1-query-block-tag` | `Tag` | no | `FINALIZED` | active | L1 block tag treated as finalized (e.g. FINALIZED, SAFE, LATEST). |
-| `l1-finalization-monitor.l1-request-retries.backoff-delay` | `Duration` | no | `PT1S` | active | Delay between retry attempts. Example: `PT1S`. |
-| `l1-finalization-monitor.l1-request-retries.failures-warning-threshold` | `UInt?` | no | - | active | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. |
-| `l1-finalization-monitor.l1-request-retries.ignore-first-exceptions-until-time-elapsed` | `Duration?` | no | - | active | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. |
-| `l1-finalization-monitor.l1-request-retries.max-retries` | `UInt?` | no | - | active | Maximum number of retry attempts. Omit for endless retries. Example: `3`. |
-| `l1-finalization-monitor.l1-request-retries.timeout` | `Duration?` | no | - | active | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. |
-| `l1-finalization-monitor.l2-endpoint` | `URL?` | no | - | active | L2 endpoint for finalization monitoring. Falls back to defaults.l2-endpoint. Example: `http://sequencer:8545`. |
-| `l1-finalization-monitor.l2-request-retries.backoff-delay` | `Duration` | no | `PT1S` | active | Delay between retry attempts. Example: `PT1S`. |
-| `l1-finalization-monitor.l2-request-retries.failures-warning-threshold` | `UInt?` | no | - | active | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. |
-| `l1-finalization-monitor.l2-request-retries.ignore-first-exceptions-until-time-elapsed` | `Duration?` | no | - | active | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. |
-| `l1-finalization-monitor.l2-request-retries.max-retries` | `UInt?` | no | - | active | Maximum number of retry attempts. Omit for endless retries. Example: `3`. |
-| `l1-finalization-monitor.l2-request-retries.timeout` | `Duration?` | no | - | active | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. |
+| `l1-finalization-monitor.l1-endpoint` | L1 endpoint for finalization monitoring. Falls back to defaults.l1-endpoint. Example: `http://l1-el-node:8545`. | `URL?` | no | - | active |
+| `l1-finalization-monitor.l1-polling-interval` | Interval between L1 finalization polls. | `Duration` | no | `PT6S` | active |
+| `l1-finalization-monitor.l1-query-block-tag` | L1 block tag treated as finalized (e.g. FINALIZED, SAFE, LATEST). | `Tag` | no | `FINALIZED` | active |
+| `l1-finalization-monitor.l1-request-retries.backoff-delay` | Delay between retry attempts. Example: `PT1S`. | `Duration` | no | `PT1S` | active |
+| `l1-finalization-monitor.l1-request-retries.failures-warning-threshold` | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. | `UInt?` | no | - | active |
+| `l1-finalization-monitor.l1-request-retries.ignore-first-exceptions-until-time-elapsed` | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. | `Duration?` | no | - | active |
+| `l1-finalization-monitor.l1-request-retries.max-retries` | Maximum number of retry attempts. Omit for endless retries. Example: `3`. | `UInt?` | no | - | active |
+| `l1-finalization-monitor.l1-request-retries.timeout` | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. | `Duration?` | no | - | active |
+| `l1-finalization-monitor.l2-endpoint` | L2 endpoint for finalization monitoring. Falls back to defaults.l2-endpoint. Example: `http://sequencer:8545`. | `URL?` | no | - | active |
+| `l1-finalization-monitor.l2-request-retries.backoff-delay` | Delay between retry attempts. Example: `PT1S`. | `Duration` | no | `PT1S` | active |
+| `l1-finalization-monitor.l2-request-retries.failures-warning-threshold` | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. | `UInt?` | no | - | active |
+| `l1-finalization-monitor.l2-request-retries.ignore-first-exceptions-until-time-elapsed` | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. | `Duration?` | no | - | active |
+| `l1-finalization-monitor.l2-request-retries.max-retries` | Maximum number of retry attempts. Omit for endless retries. Example: `3`. | `UInt?` | no | - | active |
+| `l1-finalization-monitor.l2-request-retries.timeout` | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. | `Duration?` | no | - | active |
 
 ### `l1-submission`
 
 L1 blob/aggregation submission (data availability and finalization) settings.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `l1-submission.aggregation.disabled` | `Boolean` | no | `false` | active | Whether aggregation submission is disabled. |
-| `l1-submission.aggregation.gas.fallback.priority-fee-per-gas-lower-bound` | `ULong` | yes | - | active | Lower bound for the fallback priority fee per gas. |
-| `l1-submission.aggregation.gas.fallback.priority-fee-per-gas-upper-bound` | `ULong` | yes | - | active | Upper bound for the fallback priority fee per gas. |
-| `l1-submission.aggregation.gas.gas-limit` | `ULong` | yes | - | active | Gas limit for L1 submission transactions. |
-| `l1-submission.aggregation.gas.max-fee-per-blob-gas-cap` | `ULong` | no | `0` | active | Cap on the max fee per blob gas for blob transactions. 0 disables the cap. |
-| `l1-submission.aggregation.gas.max-fee-per-gas-cap` | `ULong` | yes | - | active | Cap on the EIP-1559 max fee per gas for L1 submission transactions. |
-| `l1-submission.aggregation.gas.max-priority-fee-per-gas-cap` | `ULong` | yes | - | active | Cap on the EIP-1559 max priority fee per gas for L1 submission transactions. |
-| `l1-submission.aggregation.l1-endpoint` | `URL?` | no | - | active | L1 endpoint for aggregation submission. Falls back to defaults.l1-endpoint. Example: `http://l1-el-node:8545`. |
-| `l1-submission.aggregation.l1-request-retries.backoff-delay` | `Duration` | no | `PT1S` | active | Delay between retry attempts. Example: `PT1S`. |
-| `l1-submission.aggregation.l1-request-retries.failures-warning-threshold` | `UInt?` | no | - | active | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. |
-| `l1-submission.aggregation.l1-request-retries.ignore-first-exceptions-until-time-elapsed` | `Duration?` | no | - | active | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. |
-| `l1-submission.aggregation.l1-request-retries.max-retries` | `UInt?` | no | - | active | Maximum number of retry attempts. Omit for endless retries. Example: `3`. |
-| `l1-submission.aggregation.l1-request-retries.timeout` | `Duration?` | no | - | active | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. |
-| `l1-submission.aggregation.max-submissions-per-tick` | `UInt` | no | `1` | active | Maximum aggregation submissions sent per tick. |
-| `l1-submission.aggregation.signer.custom.name` | `String` | yes | - | active | Logical signer name resolved by the injected signer factory. |
-| `l1-submission.aggregation.signer.type` | `SignerType` | yes | - | active | Signer backend to use: WEB3J, WEB3SIGNER, or CUSTOM. Example: `web3signer`. |
-| `l1-submission.aggregation.signer.web3j.private-key` | `Masked` | yes | - | active | Hex-encoded 32-byte private key used to sign transactions. Masked in logs. |
-| `l1-submission.aggregation.signer.web3signer.endpoint` | `URL` | yes | - | active | Web3Signer HTTP endpoint. Example: `http://web3signer:9000`. |
-| `l1-submission.aggregation.signer.web3signer.keep-alive` | `Boolean` | no | `true` | active | Whether to keep Web3Signer HTTP connections alive. |
-| `l1-submission.aggregation.signer.web3signer.max-pool-size` | `Int` | no | `10` | active | Maximum size of the HTTP connection pool to Web3Signer. |
-| `l1-submission.aggregation.signer.web3signer.public-key` | `ByteArray` | yes | - | active | Hex-encoded 64-byte public key whose corresponding key Web3Signer holds. |
-| `l1-submission.aggregation.signer.web3signer.tls.key-store-password` | `Masked` | yes | - | active | Password for the client keystore. Masked in logs. |
-| `l1-submission.aggregation.signer.web3signer.tls.key-store-path` | `Path` | yes | - | active | Path to the client keystore used for mutual TLS with Web3Signer. Example: `/etc/coordinator/keystore.p12`. |
-| `l1-submission.aggregation.signer.web3signer.tls.trust-store-password` | `Masked` | yes | - | active | Password for the truststore. Masked in logs. |
-| `l1-submission.aggregation.signer.web3signer.tls.trust-store-path` | `Path` | yes | - | active | Path to the truststore used to validate the Web3Signer certificate. Example: `/etc/coordinator/truststore.p12`. |
-| `l1-submission.aggregation.submission-delay` | `Duration` | no | `PT0S` | active | Delay before submitting an aggregation after it becomes eligible. |
-| `l1-submission.aggregation.submission-tick-interval` | `Duration` | no | `PT24S` | active | Interval between aggregation submission ticks. |
-| `l1-submission.blob.db-max-blobs-to-return` | `UInt` | no | `100` | active | Maximum number of blobs read from the database per query. |
-| `l1-submission.blob.disabled` | `Boolean` | no | `false` | active | Whether blob submission is disabled. |
-| `l1-submission.blob.gas.fallback.priority-fee-per-gas-lower-bound` | `ULong` | yes | - | active | Lower bound for the fallback priority fee per gas. |
-| `l1-submission.blob.gas.fallback.priority-fee-per-gas-upper-bound` | `ULong` | yes | - | active | Upper bound for the fallback priority fee per gas. |
-| `l1-submission.blob.gas.gas-limit` | `ULong` | yes | - | active | Gas limit for L1 submission transactions. |
-| `l1-submission.blob.gas.max-fee-per-blob-gas-cap` | `ULong` | no | `0` | active | Cap on the max fee per blob gas for blob transactions. 0 disables the cap. |
-| `l1-submission.blob.gas.max-fee-per-gas-cap` | `ULong` | yes | - | active | Cap on the EIP-1559 max fee per gas for L1 submission transactions. |
-| `l1-submission.blob.gas.max-priority-fee-per-gas-cap` | `ULong` | yes | - | active | Cap on the EIP-1559 max priority fee per gas for L1 submission transactions. |
-| `l1-submission.blob.l1-endpoint` | `URL?` | no | - | active | L1 endpoint for blob submission. Falls back to defaults.l1-endpoint. Example: `http://l1-el-node:8545`. |
-| `l1-submission.blob.l1-request-retries.backoff-delay` | `Duration` | no | `PT1S` | active | Delay between retry attempts. Example: `PT1S`. |
-| `l1-submission.blob.l1-request-retries.failures-warning-threshold` | `UInt?` | no | - | active | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. |
-| `l1-submission.blob.l1-request-retries.ignore-first-exceptions-until-time-elapsed` | `Duration?` | no | - | active | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. |
-| `l1-submission.blob.l1-request-retries.max-retries` | `UInt?` | no | - | active | Maximum number of retry attempts. Omit for endless retries. Example: `3`. |
-| `l1-submission.blob.l1-request-retries.timeout` | `Duration?` | no | - | active | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. |
-| `l1-submission.blob.max-submission-transactions-per-tick` | `UInt` | no | `2` | active | Maximum blob submission transactions sent per tick. |
-| `l1-submission.blob.signer.custom.name` | `String` | yes | - | active | Logical signer name resolved by the injected signer factory. |
-| `l1-submission.blob.signer.type` | `SignerType` | yes | - | active | Signer backend to use: WEB3J, WEB3SIGNER, or CUSTOM. Example: `web3signer`. |
-| `l1-submission.blob.signer.web3j.private-key` | `Masked` | yes | - | active | Hex-encoded 32-byte private key used to sign transactions. Masked in logs. |
-| `l1-submission.blob.signer.web3signer.endpoint` | `URL` | yes | - | active | Web3Signer HTTP endpoint. Example: `http://web3signer:9000`. |
-| `l1-submission.blob.signer.web3signer.keep-alive` | `Boolean` | no | `true` | active | Whether to keep Web3Signer HTTP connections alive. |
-| `l1-submission.blob.signer.web3signer.max-pool-size` | `Int` | no | `10` | active | Maximum size of the HTTP connection pool to Web3Signer. |
-| `l1-submission.blob.signer.web3signer.public-key` | `ByteArray` | yes | - | active | Hex-encoded 64-byte public key whose corresponding key Web3Signer holds. |
-| `l1-submission.blob.signer.web3signer.tls.key-store-password` | `Masked` | yes | - | active | Password for the client keystore. Masked in logs. |
-| `l1-submission.blob.signer.web3signer.tls.key-store-path` | `Path` | yes | - | active | Path to the client keystore used for mutual TLS with Web3Signer. Example: `/etc/coordinator/keystore.p12`. |
-| `l1-submission.blob.signer.web3signer.tls.trust-store-password` | `Masked` | yes | - | active | Password for the truststore. Masked in logs. |
-| `l1-submission.blob.signer.web3signer.tls.trust-store-path` | `Path` | yes | - | active | Path to the truststore used to validate the Web3Signer certificate. Example: `/etc/coordinator/truststore.p12`. |
-| `l1-submission.blob.submission-delay` | `Duration` | no | `PT0S` | active | Delay before submitting a blob after it becomes eligible. |
-| `l1-submission.blob.submission-tick-interval` | `Duration` | no | `PT12S` | active | Interval between blob submission ticks. |
-| `l1-submission.blob.target-blobs-per-transaction` | `UInt` | no | `6` | active | Target number of blobs per submission transaction (EIP-4844/7594 network cap is 6). |
-| `l1-submission.data-availability` | `DataAvailability` | no | `ROLLUP` | active | Data availability mode: ROLLUP submits blobs to L1, VALIDIUM submits off-chain. |
-| `l1-submission.disabled` | `Boolean` | no | `false` | active | Whether L1 submission is disabled. |
-| `l1-submission.dynamic-gas-price-cap.disabled` | `Boolean` | no | `false` | active | Whether dynamic gas price cap calculation is disabled. |
-| `l1-submission.dynamic-gas-price-cap.fee-history-fetcher.fetch-interval` | `Duration` | no | `PT3S` | active | Interval between fee-history fetches. |
-| `l1-submission.dynamic-gas-price-cap.fee-history-fetcher.l1-endpoint` | `URL?` | no | - | active | L1 endpoint for fetching fee history. Falls back to defaults.l1-endpoint. Example: `http://l1-el-node:8545`. |
-| `l1-submission.dynamic-gas-price-cap.fee-history-fetcher.l1-request-retries.backoff-delay` | `Duration` | no | `PT1S` | active | Delay between retry attempts. Example: `PT1S`. |
-| `l1-submission.dynamic-gas-price-cap.fee-history-fetcher.l1-request-retries.failures-warning-threshold` | `UInt?` | no | - | active | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. |
-| `l1-submission.dynamic-gas-price-cap.fee-history-fetcher.l1-request-retries.ignore-first-exceptions-until-time-elapsed` | `Duration?` | no | - | active | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. |
-| `l1-submission.dynamic-gas-price-cap.fee-history-fetcher.l1-request-retries.max-retries` | `UInt?` | no | - | active | Maximum number of retry attempts. Omit for endless retries. Example: `3`. |
-| `l1-submission.dynamic-gas-price-cap.fee-history-fetcher.l1-request-retries.timeout` | `Duration?` | no | - | active | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. |
-| `l1-submission.dynamic-gas-price-cap.fee-history-fetcher.max-block-count` | `UInt` | no | `1000` | active | Maximum number of blocks requested per fee-history call. |
-| `l1-submission.dynamic-gas-price-cap.fee-history-fetcher.num-of-blocks-before-latest` | `UInt` | no | `4` | active | Number of blocks before the latest to stop at when fetching fee history. |
-| `l1-submission.dynamic-gas-price-cap.fee-history-fetcher.reward-percentiles` | `List<UInt>` | no | `[10, 20, 30, 40, 50, 60, 70, 80, 90, 100]` | active | Reward percentiles requested from eth_feeHistory. |
-| `l1-submission.dynamic-gas-price-cap.fee-history-fetcher.storage-period` | `Duration` | no | `PT240H` | active | How long fetched fee-history data is retained. |
-| `l1-submission.dynamic-gas-price-cap.gas-price-cap-calculation.adjustment-constant` | `UInt` | yes | - | active | Additive constant applied when adjusting the (execution) gas price cap. |
-| `l1-submission.dynamic-gas-price-cap.gas-price-cap-calculation.base-fee-per-gas-percentile` | `UInt` | yes | - | active | Percentile (1-100) of historical base fee per gas used in the calculation. |
-| `l1-submission.dynamic-gas-price-cap.gas-price-cap-calculation.base-fee-per-gas-percentile-window` | `Duration` | yes | - | active | Time window over which the base-fee-per-gas percentile is computed. |
-| `l1-submission.dynamic-gas-price-cap.gas-price-cap-calculation.base-fee-per-gas-percentile-window-leeway` | `Duration` | yes | - | active | Leeway subtracted from the base-fee-per-gas percentile window. |
-| `l1-submission.dynamic-gas-price-cap.gas-price-cap-calculation.blob-adjustment-constant` | `UInt` | yes | - | active | Additive constant applied when adjusting the blob gas price cap. |
-| `l1-submission.dynamic-gas-price-cap.gas-price-cap-calculation.finalization-target-max-delay` | `Duration` | yes | - | active | Maximum expected delay to finalization, used to scale the gas price cap. |
-| `l1-submission.dynamic-gas-price-cap.gas-price-cap-calculation.gas-price-caps-check-coefficient` | `Double` | yes | - | active | Coefficient applied when checking computed gas price caps. |
-| `l1-submission.dynamic-gas-price-cap.gas-price-cap-calculation.historic-avg-reward-constant` | `ULong` | yes | - | active | Constant used for the historical average reward calculation. |
-| `l1-submission.dynamic-gas-price-cap.gas-price-cap-calculation.historic-base-fee-per-blob-gas-lower-bound` | `ULong` | yes | - | active | Lower bound for the historical base fee per blob gas. |
-| `l1-submission.fallback-gas-price.fee-history-block-count` | `UInt` | yes | - | active | Number of blocks of fee history used to compute the fallback gas price. |
-| `l1-submission.fallback-gas-price.fee-history-reward-percentile` | `UInt` | yes | - | active | Reward percentile (1-100) used to compute the fallback gas price. |
+| `l1-submission.aggregation.disabled` | Whether aggregation submission is disabled. | `Boolean` | no | `false` | active |
+| `l1-submission.aggregation.gas.fallback.priority-fee-per-gas-lower-bound` | Lower bound for the fallback priority fee per gas. | `ULong` | yes | - | active |
+| `l1-submission.aggregation.gas.fallback.priority-fee-per-gas-upper-bound` | Upper bound for the fallback priority fee per gas. | `ULong` | yes | - | active |
+| `l1-submission.aggregation.gas.gas-limit` | Gas limit for L1 submission transactions. | `ULong` | yes | - | active |
+| `l1-submission.aggregation.gas.max-fee-per-blob-gas-cap` | Cap on the max fee per blob gas for blob transactions. 0 disables the cap. | `ULong` | no | `0` | active |
+| `l1-submission.aggregation.gas.max-fee-per-gas-cap` | Cap on the EIP-1559 max fee per gas for L1 submission transactions. | `ULong` | yes | - | active |
+| `l1-submission.aggregation.gas.max-priority-fee-per-gas-cap` | Cap on the EIP-1559 max priority fee per gas for L1 submission transactions. | `ULong` | yes | - | active |
+| `l1-submission.aggregation.l1-endpoint` | L1 endpoint for aggregation submission. Falls back to defaults.l1-endpoint. Example: `http://l1-el-node:8545`. | `URL?` | no | - | active |
+| `l1-submission.aggregation.l1-request-retries.backoff-delay` | Delay between retry attempts. Example: `PT1S`. | `Duration` | no | `PT1S` | active |
+| `l1-submission.aggregation.l1-request-retries.failures-warning-threshold` | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. | `UInt?` | no | - | active |
+| `l1-submission.aggregation.l1-request-retries.ignore-first-exceptions-until-time-elapsed` | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. | `Duration?` | no | - | active |
+| `l1-submission.aggregation.l1-request-retries.max-retries` | Maximum number of retry attempts. Omit for endless retries. Example: `3`. | `UInt?` | no | - | active |
+| `l1-submission.aggregation.l1-request-retries.timeout` | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. | `Duration?` | no | - | active |
+| `l1-submission.aggregation.max-submissions-per-tick` | Maximum aggregation submissions sent per tick. | `UInt` | no | `1` | active |
+| `l1-submission.aggregation.signer.custom.name` | Logical signer name resolved by the injected signer factory. | `String` | yes | - | active |
+| `l1-submission.aggregation.signer.type` | Signer backend to use: WEB3J, WEB3SIGNER, or CUSTOM. Example: `web3signer`. | `SignerType` | yes | - | active |
+| `l1-submission.aggregation.signer.web3j.private-key` | Hex-encoded 32-byte private key used to sign transactions. Masked in logs. | `Masked` | yes | - | active |
+| `l1-submission.aggregation.signer.web3signer.endpoint` | Web3Signer HTTP endpoint. Example: `http://web3signer:9000`. | `URL` | yes | - | active |
+| `l1-submission.aggregation.signer.web3signer.keep-alive` | Whether to keep Web3Signer HTTP connections alive. | `Boolean` | no | `true` | active |
+| `l1-submission.aggregation.signer.web3signer.max-pool-size` | Maximum size of the HTTP connection pool to Web3Signer. | `Int` | no | `10` | active |
+| `l1-submission.aggregation.signer.web3signer.public-key` | Hex-encoded 64-byte public key whose corresponding key Web3Signer holds. | `ByteArray` | yes | - | active |
+| `l1-submission.aggregation.signer.web3signer.tls.key-store-password` | Password for the client keystore. Masked in logs. | `Masked` | yes | - | active |
+| `l1-submission.aggregation.signer.web3signer.tls.key-store-path` | Path to the client keystore used for mutual TLS with Web3Signer. Example: `/etc/coordinator/keystore.p12`. | `Path` | yes | - | active |
+| `l1-submission.aggregation.signer.web3signer.tls.trust-store-password` | Password for the truststore. Masked in logs. | `Masked` | yes | - | active |
+| `l1-submission.aggregation.signer.web3signer.tls.trust-store-path` | Path to the truststore used to validate the Web3Signer certificate. Example: `/etc/coordinator/truststore.p12`. | `Path` | yes | - | active |
+| `l1-submission.aggregation.submission-delay` | Delay before submitting an aggregation after it becomes eligible. | `Duration` | no | `PT0S` | active |
+| `l1-submission.aggregation.submission-tick-interval` | Interval between aggregation submission ticks. | `Duration` | no | `PT24S` | active |
+| `l1-submission.blob.db-max-blobs-to-return` | Maximum number of blobs read from the database per query. | `UInt` | no | `100` | active |
+| `l1-submission.blob.disabled` | Whether blob submission is disabled. | `Boolean` | no | `false` | active |
+| `l1-submission.blob.gas.fallback.priority-fee-per-gas-lower-bound` | Lower bound for the fallback priority fee per gas. | `ULong` | yes | - | active |
+| `l1-submission.blob.gas.fallback.priority-fee-per-gas-upper-bound` | Upper bound for the fallback priority fee per gas. | `ULong` | yes | - | active |
+| `l1-submission.blob.gas.gas-limit` | Gas limit for L1 submission transactions. | `ULong` | yes | - | active |
+| `l1-submission.blob.gas.max-fee-per-blob-gas-cap` | Cap on the max fee per blob gas for blob transactions. 0 disables the cap. | `ULong` | no | `0` | active |
+| `l1-submission.blob.gas.max-fee-per-gas-cap` | Cap on the EIP-1559 max fee per gas for L1 submission transactions. | `ULong` | yes | - | active |
+| `l1-submission.blob.gas.max-priority-fee-per-gas-cap` | Cap on the EIP-1559 max priority fee per gas for L1 submission transactions. | `ULong` | yes | - | active |
+| `l1-submission.blob.l1-endpoint` | L1 endpoint for blob submission. Falls back to defaults.l1-endpoint. Example: `http://l1-el-node:8545`. | `URL?` | no | - | active |
+| `l1-submission.blob.l1-request-retries.backoff-delay` | Delay between retry attempts. Example: `PT1S`. | `Duration` | no | `PT1S` | active |
+| `l1-submission.blob.l1-request-retries.failures-warning-threshold` | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. | `UInt?` | no | - | active |
+| `l1-submission.blob.l1-request-retries.ignore-first-exceptions-until-time-elapsed` | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. | `Duration?` | no | - | active |
+| `l1-submission.blob.l1-request-retries.max-retries` | Maximum number of retry attempts. Omit for endless retries. Example: `3`. | `UInt?` | no | - | active |
+| `l1-submission.blob.l1-request-retries.timeout` | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. | `Duration?` | no | - | active |
+| `l1-submission.blob.max-submission-transactions-per-tick` | Maximum blob submission transactions sent per tick. | `UInt` | no | `2` | active |
+| `l1-submission.blob.signer.custom.name` | Logical signer name resolved by the injected signer factory. | `String` | yes | - | active |
+| `l1-submission.blob.signer.type` | Signer backend to use: WEB3J, WEB3SIGNER, or CUSTOM. Example: `web3signer`. | `SignerType` | yes | - | active |
+| `l1-submission.blob.signer.web3j.private-key` | Hex-encoded 32-byte private key used to sign transactions. Masked in logs. | `Masked` | yes | - | active |
+| `l1-submission.blob.signer.web3signer.endpoint` | Web3Signer HTTP endpoint. Example: `http://web3signer:9000`. | `URL` | yes | - | active |
+| `l1-submission.blob.signer.web3signer.keep-alive` | Whether to keep Web3Signer HTTP connections alive. | `Boolean` | no | `true` | active |
+| `l1-submission.blob.signer.web3signer.max-pool-size` | Maximum size of the HTTP connection pool to Web3Signer. | `Int` | no | `10` | active |
+| `l1-submission.blob.signer.web3signer.public-key` | Hex-encoded 64-byte public key whose corresponding key Web3Signer holds. | `ByteArray` | yes | - | active |
+| `l1-submission.blob.signer.web3signer.tls.key-store-password` | Password for the client keystore. Masked in logs. | `Masked` | yes | - | active |
+| `l1-submission.blob.signer.web3signer.tls.key-store-path` | Path to the client keystore used for mutual TLS with Web3Signer. Example: `/etc/coordinator/keystore.p12`. | `Path` | yes | - | active |
+| `l1-submission.blob.signer.web3signer.tls.trust-store-password` | Password for the truststore. Masked in logs. | `Masked` | yes | - | active |
+| `l1-submission.blob.signer.web3signer.tls.trust-store-path` | Path to the truststore used to validate the Web3Signer certificate. Example: `/etc/coordinator/truststore.p12`. | `Path` | yes | - | active |
+| `l1-submission.blob.submission-delay` | Delay before submitting a blob after it becomes eligible. | `Duration` | no | `PT0S` | active |
+| `l1-submission.blob.submission-tick-interval` | Interval between blob submission ticks. | `Duration` | no | `PT12S` | active |
+| `l1-submission.blob.target-blobs-per-transaction` | Target number of blobs per submission transaction (EIP-4844/7594 network cap is 6). | `UInt` | no | `6` | active |
+| `l1-submission.data-availability` | Data availability mode: ROLLUP submits blobs to L1, VALIDIUM submits off-chain. | `DataAvailability` | no | `ROLLUP` | active |
+| `l1-submission.disabled` | Whether L1 submission is disabled. | `Boolean` | no | `false` | active |
+| `l1-submission.dynamic-gas-price-cap.disabled` | Whether dynamic gas price cap calculation is disabled. | `Boolean` | no | `false` | active |
+| `l1-submission.dynamic-gas-price-cap.fee-history-fetcher.fetch-interval` | Interval between fee-history fetches. | `Duration` | no | `PT3S` | active |
+| `l1-submission.dynamic-gas-price-cap.fee-history-fetcher.l1-endpoint` | L1 endpoint for fetching fee history. Falls back to defaults.l1-endpoint. Example: `http://l1-el-node:8545`. | `URL?` | no | - | active |
+| `l1-submission.dynamic-gas-price-cap.fee-history-fetcher.l1-request-retries.backoff-delay` | Delay between retry attempts. Example: `PT1S`. | `Duration` | no | `PT1S` | active |
+| `l1-submission.dynamic-gas-price-cap.fee-history-fetcher.l1-request-retries.failures-warning-threshold` | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. | `UInt?` | no | - | active |
+| `l1-submission.dynamic-gas-price-cap.fee-history-fetcher.l1-request-retries.ignore-first-exceptions-until-time-elapsed` | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. | `Duration?` | no | - | active |
+| `l1-submission.dynamic-gas-price-cap.fee-history-fetcher.l1-request-retries.max-retries` | Maximum number of retry attempts. Omit for endless retries. Example: `3`. | `UInt?` | no | - | active |
+| `l1-submission.dynamic-gas-price-cap.fee-history-fetcher.l1-request-retries.timeout` | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. | `Duration?` | no | - | active |
+| `l1-submission.dynamic-gas-price-cap.fee-history-fetcher.max-block-count` | Maximum number of blocks requested per fee-history call. | `UInt` | no | `1000` | active |
+| `l1-submission.dynamic-gas-price-cap.fee-history-fetcher.num-of-blocks-before-latest` | Number of blocks before the latest to stop at when fetching fee history. | `UInt` | no | `4` | active |
+| `l1-submission.dynamic-gas-price-cap.fee-history-fetcher.reward-percentiles` | Reward percentiles requested from eth_feeHistory. | `List<UInt>` | no | `[10, 20, 30, 40, 50, 60, 70, 80, 90, 100]` | active |
+| `l1-submission.dynamic-gas-price-cap.fee-history-fetcher.storage-period` | How long fetched fee-history data is retained. | `Duration` | no | `PT240H` | active |
+| `l1-submission.dynamic-gas-price-cap.gas-price-cap-calculation.adjustment-constant` | Additive constant applied when adjusting the (execution) gas price cap. | `UInt` | yes | - | active |
+| `l1-submission.dynamic-gas-price-cap.gas-price-cap-calculation.base-fee-per-gas-percentile` | Percentile (1-100) of historical base fee per gas used in the calculation. | `UInt` | yes | - | active |
+| `l1-submission.dynamic-gas-price-cap.gas-price-cap-calculation.base-fee-per-gas-percentile-window` | Time window over which the base-fee-per-gas percentile is computed. | `Duration` | yes | - | active |
+| `l1-submission.dynamic-gas-price-cap.gas-price-cap-calculation.base-fee-per-gas-percentile-window-leeway` | Leeway subtracted from the base-fee-per-gas percentile window. | `Duration` | yes | - | active |
+| `l1-submission.dynamic-gas-price-cap.gas-price-cap-calculation.blob-adjustment-constant` | Additive constant applied when adjusting the blob gas price cap. | `UInt` | yes | - | active |
+| `l1-submission.dynamic-gas-price-cap.gas-price-cap-calculation.finalization-target-max-delay` | Maximum expected delay to finalization, used to scale the gas price cap. | `Duration` | yes | - | active |
+| `l1-submission.dynamic-gas-price-cap.gas-price-cap-calculation.gas-price-caps-check-coefficient` | Coefficient applied when checking computed gas price caps. | `Double` | yes | - | active |
+| `l1-submission.dynamic-gas-price-cap.gas-price-cap-calculation.historic-avg-reward-constant` | Constant used for the historical average reward calculation. | `ULong` | yes | - | active |
+| `l1-submission.dynamic-gas-price-cap.gas-price-cap-calculation.historic-base-fee-per-blob-gas-lower-bound` | Lower bound for the historical base fee per blob gas. | `ULong` | yes | - | active |
+| `l1-submission.fallback-gas-price.fee-history-block-count` | Number of blocks of fee history used to compute the fallback gas price. | `UInt` | yes | - | active |
+| `l1-submission.fallback-gas-price.fee-history-reward-percentile` | Reward percentile (1-100) used to compute the fallback gas price. | `UInt` | yes | - | active |
 
 ### `l2-network-gas-pricing`
 
 L2 network gas pricing (dynamic gas price publishing) settings.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `l2-network-gas-pricing.disabled` | `Boolean` | no | `false` | active | Whether L2 network gas pricing is disabled. |
-| `l2-network-gas-pricing.dynamic-gas-pricing.blob-submission-expected-execution-gas` | `ULong` | yes | - | active | Expected L1 execution gas consumed by a blob submission transaction. |
-| `l2-network-gas-pricing.dynamic-gas-pricing.calldata-based-pricing.block-size-non-calldata-overhead` | `UInt` | no | `540` | active | Per-block non-calldata size overhead (bytes) in the calculation. |
-| `l2-network-gas-pricing.dynamic-gas-pricing.calldata-based-pricing.calldata-sum-size-block-count` | `UInt` | no | `5` | active | Number of recent blocks summed when measuring calldata usage. |
-| `l2-network-gas-pricing.dynamic-gas-pricing.calldata-based-pricing.calldata-sum-size-target` | `ULong` | no | `109000` | active | Target total calldata size (bytes) across the measured blocks. |
-| `l2-network-gas-pricing.dynamic-gas-pricing.calldata-based-pricing.fee-change-denominator` | `UInt` | no | `32` | active | Denominator controlling how quickly the fee reacts to calldata-usage deviations. |
-| `l2-network-gas-pricing.dynamic-gas-pricing.l1-blob-gas` | `ULong` | yes | - | active | Expected L1 blob gas used per blob when computing the variable cost. |
-| `l2-network-gas-pricing.dynamic-gas-pricing.margin` | `Double` | yes | - | active | Multiplier applied to the computed variable cost (safety/profit margin). |
-| `l2-network-gas-pricing.dynamic-gas-pricing.variable-cost-lower-bound` | `ULong` | yes | - | active | Lower bound for the computed variable cost component. |
-| `l2-network-gas-pricing.dynamic-gas-pricing.variable-cost-upper-bound` | `ULong` | yes | - | active | Upper bound for the computed variable cost component. |
-| `l2-network-gas-pricing.extra-data-update-endpoint` | `URL` | yes | - | active | L2 endpoint that receives the computed gas pricing via the extra-data update call. Example: `http://sequencer:8545`. |
-| `l2-network-gas-pricing.extra-data-update-request-retries.backoff-delay` | `Duration` | no | `PT1S` | active | Delay between retry attempts. Example: `PT1S`. |
-| `l2-network-gas-pricing.extra-data-update-request-retries.failures-warning-threshold` | `UInt?` | no | - | active | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. |
-| `l2-network-gas-pricing.extra-data-update-request-retries.ignore-first-exceptions-until-time-elapsed` | `Duration?` | no | - | active | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. |
-| `l2-network-gas-pricing.extra-data-update-request-retries.max-retries` | `UInt?` | no | - | active | Maximum number of retry attempts. Omit for endless retries. Example: `3`. |
-| `l2-network-gas-pricing.extra-data-update-request-retries.timeout` | `Duration?` | no | - | active | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. |
-| `l2-network-gas-pricing.fee-history-block-count` | `UInt` | no | `1000` | active | Number of blocks of fee history used in gas pricing. |
-| `l2-network-gas-pricing.fee-history-reward-percentile` | `UInt` | no | `15` | active | Reward percentile (1-100) of fee history used in gas pricing. |
-| `l2-network-gas-pricing.flat-rate-gas-pricing.compressed-tx-size` | `UInt` | no | `125` | active | Assumed compressed size (bytes) of a transaction. |
-| `l2-network-gas-pricing.flat-rate-gas-pricing.expected-gas` | `UInt` | no | `21000` | active | Assumed gas used by a plain transfer transaction. |
-| `l2-network-gas-pricing.flat-rate-gas-pricing.gas-price-lower-bound` | `ULong` | yes | - | active | Lower bound (in wei) for the flat-rate L2 gas price. |
-| `l2-network-gas-pricing.flat-rate-gas-pricing.gas-price-upper-bound` | `ULong` | yes | - | active | Upper bound (in wei) for the flat-rate L2 gas price. |
-| `l2-network-gas-pricing.flat-rate-gas-pricing.plain-transfer-cost-multiplier` | `Double` | no | `1.0` | active | Multiplier applied to the plain-transfer cost when computing the price. |
-| `l2-network-gas-pricing.gas-price-fixed-cost` | `ULong` | yes | - | active | Fixed cost component (in wei) added to the computed L2 gas price. |
-| `l2-network-gas-pricing.l1-endpoint` | `URL?` | no | - | active | L1 endpoint used for gas pricing. Falls back to defaults.l1-endpoint. Example: `http://l1-el-node:8545`. |
-| `l2-network-gas-pricing.l1-request-retries.backoff-delay` | `Duration` | no | `PT1S` | active | Delay between retry attempts. Example: `PT1S`. |
-| `l2-network-gas-pricing.l1-request-retries.failures-warning-threshold` | `UInt?` | no | - | active | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. |
-| `l2-network-gas-pricing.l1-request-retries.ignore-first-exceptions-until-time-elapsed` | `Duration?` | no | - | active | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. |
-| `l2-network-gas-pricing.l1-request-retries.max-retries` | `UInt?` | no | - | active | Maximum number of retry attempts. Omit for endless retries. Example: `3`. |
-| `l2-network-gas-pricing.l1-request-retries.timeout` | `Duration?` | no | - | active | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. |
-| `l2-network-gas-pricing.l2-endpoint` | `URL?` | no | - | active | L2 endpoint used for gas pricing. Falls back to defaults.l2-endpoint. Example: `http://sequencer:8545`. |
-| `l2-network-gas-pricing.l2-request-retries.backoff-delay` | `Duration` | no | `PT1S` | active | Delay between retry attempts. Example: `PT1S`. |
-| `l2-network-gas-pricing.l2-request-retries.failures-warning-threshold` | `UInt?` | no | - | active | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. |
-| `l2-network-gas-pricing.l2-request-retries.ignore-first-exceptions-until-time-elapsed` | `Duration?` | no | - | active | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. |
-| `l2-network-gas-pricing.l2-request-retries.max-retries` | `UInt?` | no | - | active | Maximum number of retry attempts. Omit for endless retries. Example: `3`. |
-| `l2-network-gas-pricing.l2-request-retries.timeout` | `Duration?` | no | - | active | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. |
-| `l2-network-gas-pricing.price-update-interval` | `Duration` | no | `PT12S` | active | Interval between L2 gas price recalculations/updates. |
+| `l2-network-gas-pricing.disabled` | Whether L2 network gas pricing is disabled. | `Boolean` | no | `false` | active |
+| `l2-network-gas-pricing.dynamic-gas-pricing.blob-submission-expected-execution-gas` | Expected L1 execution gas consumed by a blob submission transaction. | `ULong` | yes | - | active |
+| `l2-network-gas-pricing.dynamic-gas-pricing.calldata-based-pricing.block-size-non-calldata-overhead` | Per-block non-calldata size overhead (bytes) in the calculation. | `UInt` | no | `540` | active |
+| `l2-network-gas-pricing.dynamic-gas-pricing.calldata-based-pricing.calldata-sum-size-block-count` | Number of recent blocks summed when measuring calldata usage. | `UInt` | no | `5` | active |
+| `l2-network-gas-pricing.dynamic-gas-pricing.calldata-based-pricing.calldata-sum-size-target` | Target total calldata size (bytes) across the measured blocks. | `ULong` | no | `109000` | active |
+| `l2-network-gas-pricing.dynamic-gas-pricing.calldata-based-pricing.fee-change-denominator` | Denominator controlling how quickly the fee reacts to calldata-usage deviations. | `UInt` | no | `32` | active |
+| `l2-network-gas-pricing.dynamic-gas-pricing.l1-blob-gas` | Expected L1 blob gas used per blob when computing the variable cost. | `ULong` | yes | - | active |
+| `l2-network-gas-pricing.dynamic-gas-pricing.margin` | Multiplier applied to the computed variable cost (safety/profit margin). | `Double` | yes | - | active |
+| `l2-network-gas-pricing.dynamic-gas-pricing.variable-cost-lower-bound` | Lower bound for the computed variable cost component. | `ULong` | yes | - | active |
+| `l2-network-gas-pricing.dynamic-gas-pricing.variable-cost-upper-bound` | Upper bound for the computed variable cost component. | `ULong` | yes | - | active |
+| `l2-network-gas-pricing.extra-data-update-endpoint` | L2 endpoint that receives the computed gas pricing via the extra-data update call. Example: `http://sequencer:8545`. | `URL` | yes | - | active |
+| `l2-network-gas-pricing.extra-data-update-request-retries.backoff-delay` | Delay between retry attempts. Example: `PT1S`. | `Duration` | no | `PT1S` | active |
+| `l2-network-gas-pricing.extra-data-update-request-retries.failures-warning-threshold` | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. | `UInt?` | no | - | active |
+| `l2-network-gas-pricing.extra-data-update-request-retries.ignore-first-exceptions-until-time-elapsed` | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. | `Duration?` | no | - | active |
+| `l2-network-gas-pricing.extra-data-update-request-retries.max-retries` | Maximum number of retry attempts. Omit for endless retries. Example: `3`. | `UInt?` | no | - | active |
+| `l2-network-gas-pricing.extra-data-update-request-retries.timeout` | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. | `Duration?` | no | - | active |
+| `l2-network-gas-pricing.fee-history-block-count` | Number of blocks of fee history used in gas pricing. | `UInt` | no | `1000` | active |
+| `l2-network-gas-pricing.fee-history-reward-percentile` | Reward percentile (1-100) of fee history used in gas pricing. | `UInt` | no | `15` | active |
+| `l2-network-gas-pricing.flat-rate-gas-pricing.compressed-tx-size` | Assumed compressed size (bytes) of a transaction. | `UInt` | no | `125` | active |
+| `l2-network-gas-pricing.flat-rate-gas-pricing.expected-gas` | Assumed gas used by a plain transfer transaction. | `UInt` | no | `21000` | active |
+| `l2-network-gas-pricing.flat-rate-gas-pricing.gas-price-lower-bound` | Lower bound (in wei) for the flat-rate L2 gas price. | `ULong` | yes | - | active |
+| `l2-network-gas-pricing.flat-rate-gas-pricing.gas-price-upper-bound` | Upper bound (in wei) for the flat-rate L2 gas price. | `ULong` | yes | - | active |
+| `l2-network-gas-pricing.flat-rate-gas-pricing.plain-transfer-cost-multiplier` | Multiplier applied to the plain-transfer cost when computing the price. | `Double` | no | `1.0` | active |
+| `l2-network-gas-pricing.gas-price-fixed-cost` | Fixed cost component (in wei) added to the computed L2 gas price. | `ULong` | yes | - | active |
+| `l2-network-gas-pricing.l1-endpoint` | L1 endpoint used for gas pricing. Falls back to defaults.l1-endpoint. Example: `http://l1-el-node:8545`. | `URL?` | no | - | active |
+| `l2-network-gas-pricing.l1-request-retries.backoff-delay` | Delay between retry attempts. Example: `PT1S`. | `Duration` | no | `PT1S` | active |
+| `l2-network-gas-pricing.l1-request-retries.failures-warning-threshold` | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. | `UInt?` | no | - | active |
+| `l2-network-gas-pricing.l1-request-retries.ignore-first-exceptions-until-time-elapsed` | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. | `Duration?` | no | - | active |
+| `l2-network-gas-pricing.l1-request-retries.max-retries` | Maximum number of retry attempts. Omit for endless retries. Example: `3`. | `UInt?` | no | - | active |
+| `l2-network-gas-pricing.l1-request-retries.timeout` | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. | `Duration?` | no | - | active |
+| `l2-network-gas-pricing.l2-endpoint` | L2 endpoint used for gas pricing. Falls back to defaults.l2-endpoint. Example: `http://sequencer:8545`. | `URL?` | no | - | active |
+| `l2-network-gas-pricing.l2-request-retries.backoff-delay` | Delay between retry attempts. Example: `PT1S`. | `Duration` | no | `PT1S` | active |
+| `l2-network-gas-pricing.l2-request-retries.failures-warning-threshold` | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. | `UInt?` | no | - | active |
+| `l2-network-gas-pricing.l2-request-retries.ignore-first-exceptions-until-time-elapsed` | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. | `Duration?` | no | - | active |
+| `l2-network-gas-pricing.l2-request-retries.max-retries` | Maximum number of retry attempts. Omit for endless retries. Example: `3`. | `UInt?` | no | - | active |
+| `l2-network-gas-pricing.l2-request-retries.timeout` | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. | `Duration?` | no | - | active |
+| `l2-network-gas-pricing.price-update-interval` | Interval between L2 gas price recalculations/updates. | `Duration` | no | `PT12S` | active |
 
 ### `message-anchoring`
 
 L1 to L2 message anchoring settings.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `message-anchoring.anchoring-tick-interval` | `Duration` | no | `PT10S` | active | Interval between message anchoring ticks. |
-| `message-anchoring.disabled` | `Boolean` | no | `false` | active | Whether L1 to L2 message anchoring is disabled. |
-| `message-anchoring.gas.fee-history-block-count` | `UInt` | no | `4` | active | Number of blocks of fee history used to price anchoring transactions. |
-| `message-anchoring.gas.fee-history-reward-percentile` | `UInt` | no | `15` | active | Reward percentile (1-100) of fee history used to price anchoring transactions. |
-| `message-anchoring.gas.gas-limit` | `ULong` | no | `2500000` | active | Gas limit for anchoring transactions. |
-| `message-anchoring.gas.max-fee-per-gas-cap` | `ULong` | no | `100000000000` | active | Cap on the EIP-1559 max fee per gas for anchoring transactions (wei). |
-| `message-anchoring.l1-endpoint` | `URL?` | no | - | active | L1 endpoint used for anchoring. Falls back to defaults.l1-endpoint. Example: `http://l1-el-node:8545`. |
-| `message-anchoring.l1-event-scraping.eth-logs-search-block-chunk-size` | `UInt` | no | `1000` | active | Number of blocks scanned per eth_getLogs chunk. |
-| `message-anchoring.l1-event-scraping.eth-logs-search-max-block-range` | `UInt` | no | `10000` | active | Maximum block range covered by a single eth_getLogs search. |
-| `message-anchoring.l1-event-scraping.eth-logs-search-success-backoff-delay` | `Duration` | no | `PT0.001S` | active | Backoff delay after a successful eth_getLogs search before the next one. |
-| `message-anchoring.l1-event-scraping.polling-interval` | `Duration` | no | `PT6S` | active | Interval between L1 log polling attempts. |
-| `message-anchoring.l1-event-scraping.polling-timeout` | `Duration` | no | `PT5S` | active | Timeout for each L1 log polling request. |
-| `message-anchoring.l1-highest-block-tag` | `BlockParameter` | no | `FINALIZED` | active | L1 block tag up to which message events are read (e.g. FINALIZED, LATEST, or a number). |
-| `message-anchoring.l1-request-retries.backoff-delay` | `Duration` | no | `PT1S` | active | Delay between retry attempts. Example: `PT1S`. |
-| `message-anchoring.l1-request-retries.failures-warning-threshold` | `UInt?` | no | - | active | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. |
-| `message-anchoring.l1-request-retries.ignore-first-exceptions-until-time-elapsed` | `Duration?` | no | - | active | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. |
-| `message-anchoring.l1-request-retries.max-retries` | `UInt?` | no | - | active | Maximum number of retry attempts. Omit for endless retries. Example: `3`. |
-| `message-anchoring.l1-request-retries.timeout` | `Duration?` | no | - | active | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. |
-| `message-anchoring.l2-endpoint` | `URL?` | no | - | active | L2 endpoint used for anchoring. Falls back to defaults.l2-endpoint. Example: `http://sequencer:8545`. |
-| `message-anchoring.l2-highest-block-tag` | `BlockParameter` | no | `LATEST` | active | L2 block tag up to which anchoring state is read (e.g. LATEST, FINALIZED, or a number). |
-| `message-anchoring.l2-request-retries.backoff-delay` | `Duration` | no | `PT1S` | active | Delay between retry attempts. Example: `PT1S`. |
-| `message-anchoring.l2-request-retries.failures-warning-threshold` | `UInt?` | no | - | active | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. |
-| `message-anchoring.l2-request-retries.ignore-first-exceptions-until-time-elapsed` | `Duration?` | no | - | active | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. |
-| `message-anchoring.l2-request-retries.max-retries` | `UInt?` | no | - | active | Maximum number of retry attempts. Omit for endless retries. Example: `3`. |
-| `message-anchoring.l2-request-retries.timeout` | `Duration?` | no | - | active | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. |
-| `message-anchoring.max-messages-to-anchor-per-l2-transaction` | `UInt` | no | `100` | active | Maximum number of messages anchored in a single L2 transaction. |
-| `message-anchoring.message-queue-capacity` | `UInt` | no | `10000` | active | Maximum number of messages buffered awaiting anchoring. |
-| `message-anchoring.signer.custom.name` | `String` | yes | - | active | Logical signer name resolved by the injected signer factory. |
-| `message-anchoring.signer.type` | `SignerType` | yes | - | active | Signer backend to use: WEB3J, WEB3SIGNER, or CUSTOM. Example: `web3signer`. |
-| `message-anchoring.signer.web3j.private-key` | `Masked` | yes | - | active | Hex-encoded 32-byte private key used to sign transactions. Masked in logs. |
-| `message-anchoring.signer.web3signer.endpoint` | `URL` | yes | - | active | Web3Signer HTTP endpoint. Example: `http://web3signer:9000`. |
-| `message-anchoring.signer.web3signer.keep-alive` | `Boolean` | no | `true` | active | Whether to keep Web3Signer HTTP connections alive. |
-| `message-anchoring.signer.web3signer.max-pool-size` | `Int` | no | `10` | active | Maximum size of the HTTP connection pool to Web3Signer. |
-| `message-anchoring.signer.web3signer.public-key` | `ByteArray` | yes | - | active | Hex-encoded 64-byte public key whose corresponding key Web3Signer holds. |
-| `message-anchoring.signer.web3signer.tls.key-store-password` | `Masked` | yes | - | active | Password for the client keystore. Masked in logs. |
-| `message-anchoring.signer.web3signer.tls.key-store-path` | `Path` | yes | - | active | Path to the client keystore used for mutual TLS with Web3Signer. Example: `/etc/coordinator/keystore.p12`. |
-| `message-anchoring.signer.web3signer.tls.trust-store-password` | `Masked` | yes | - | active | Password for the truststore. Masked in logs. |
-| `message-anchoring.signer.web3signer.tls.trust-store-path` | `Path` | yes | - | active | Path to the truststore used to validate the Web3Signer certificate. Example: `/etc/coordinator/truststore.p12`. |
+| `message-anchoring.anchoring-tick-interval` | Interval between message anchoring ticks. | `Duration` | no | `PT10S` | active |
+| `message-anchoring.disabled` | Whether L1 to L2 message anchoring is disabled. | `Boolean` | no | `false` | active |
+| `message-anchoring.gas.fee-history-block-count` | Number of blocks of fee history used to price anchoring transactions. | `UInt` | no | `4` | active |
+| `message-anchoring.gas.fee-history-reward-percentile` | Reward percentile (1-100) of fee history used to price anchoring transactions. | `UInt` | no | `15` | active |
+| `message-anchoring.gas.gas-limit` | Gas limit for anchoring transactions. | `ULong` | no | `2500000` | active |
+| `message-anchoring.gas.max-fee-per-gas-cap` | Cap on the EIP-1559 max fee per gas for anchoring transactions (wei). | `ULong` | no | `100000000000` | active |
+| `message-anchoring.l1-endpoint` | L1 endpoint used for anchoring. Falls back to defaults.l1-endpoint. Example: `http://l1-el-node:8545`. | `URL?` | no | - | active |
+| `message-anchoring.l1-event-scraping.eth-logs-search-block-chunk-size` | Number of blocks scanned per eth_getLogs chunk. | `UInt` | no | `1000` | active |
+| `message-anchoring.l1-event-scraping.eth-logs-search-max-block-range` | Maximum block range covered by a single eth_getLogs search. | `UInt` | no | `10000` | active |
+| `message-anchoring.l1-event-scraping.eth-logs-search-success-backoff-delay` | Backoff delay after a successful eth_getLogs search before the next one. | `Duration` | no | `PT0.001S` | active |
+| `message-anchoring.l1-event-scraping.polling-interval` | Interval between L1 log polling attempts. | `Duration` | no | `PT6S` | active |
+| `message-anchoring.l1-event-scraping.polling-timeout` | Timeout for each L1 log polling request. | `Duration` | no | `PT5S` | active |
+| `message-anchoring.l1-highest-block-tag` | L1 block tag up to which message events are read (e.g. FINALIZED, LATEST, or a number). | `BlockParameter` | no | `FINALIZED` | active |
+| `message-anchoring.l1-request-retries.backoff-delay` | Delay between retry attempts. Example: `PT1S`. | `Duration` | no | `PT1S` | active |
+| `message-anchoring.l1-request-retries.failures-warning-threshold` | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. | `UInt?` | no | - | active |
+| `message-anchoring.l1-request-retries.ignore-first-exceptions-until-time-elapsed` | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. | `Duration?` | no | - | active |
+| `message-anchoring.l1-request-retries.max-retries` | Maximum number of retry attempts. Omit for endless retries. Example: `3`. | `UInt?` | no | - | active |
+| `message-anchoring.l1-request-retries.timeout` | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. | `Duration?` | no | - | active |
+| `message-anchoring.l2-endpoint` | L2 endpoint used for anchoring. Falls back to defaults.l2-endpoint. Example: `http://sequencer:8545`. | `URL?` | no | - | active |
+| `message-anchoring.l2-highest-block-tag` | L2 block tag up to which anchoring state is read (e.g. LATEST, FINALIZED, or a number). | `BlockParameter` | no | `LATEST` | active |
+| `message-anchoring.l2-request-retries.backoff-delay` | Delay between retry attempts. Example: `PT1S`. | `Duration` | no | `PT1S` | active |
+| `message-anchoring.l2-request-retries.failures-warning-threshold` | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. | `UInt?` | no | - | active |
+| `message-anchoring.l2-request-retries.ignore-first-exceptions-until-time-elapsed` | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. | `Duration?` | no | - | active |
+| `message-anchoring.l2-request-retries.max-retries` | Maximum number of retry attempts. Omit for endless retries. Example: `3`. | `UInt?` | no | - | active |
+| `message-anchoring.l2-request-retries.timeout` | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. | `Duration?` | no | - | active |
+| `message-anchoring.max-messages-to-anchor-per-l2-transaction` | Maximum number of messages anchored in a single L2 transaction. | `UInt` | no | `100` | active |
+| `message-anchoring.message-queue-capacity` | Maximum number of messages buffered awaiting anchoring. | `UInt` | no | `10000` | active |
+| `message-anchoring.signer.custom.name` | Logical signer name resolved by the injected signer factory. | `String` | yes | - | active |
+| `message-anchoring.signer.type` | Signer backend to use: WEB3J, WEB3SIGNER, or CUSTOM. Example: `web3signer`. | `SignerType` | yes | - | active |
+| `message-anchoring.signer.web3j.private-key` | Hex-encoded 32-byte private key used to sign transactions. Masked in logs. | `Masked` | yes | - | active |
+| `message-anchoring.signer.web3signer.endpoint` | Web3Signer HTTP endpoint. Example: `http://web3signer:9000`. | `URL` | yes | - | active |
+| `message-anchoring.signer.web3signer.keep-alive` | Whether to keep Web3Signer HTTP connections alive. | `Boolean` | no | `true` | active |
+| `message-anchoring.signer.web3signer.max-pool-size` | Maximum size of the HTTP connection pool to Web3Signer. | `Int` | no | `10` | active |
+| `message-anchoring.signer.web3signer.public-key` | Hex-encoded 64-byte public key whose corresponding key Web3Signer holds. | `ByteArray` | yes | - | active |
+| `message-anchoring.signer.web3signer.tls.key-store-password` | Password for the client keystore. Masked in logs. | `Masked` | yes | - | active |
+| `message-anchoring.signer.web3signer.tls.key-store-path` | Path to the client keystore used for mutual TLS with Web3Signer. Example: `/etc/coordinator/keystore.p12`. | `Path` | yes | - | active |
+| `message-anchoring.signer.web3signer.tls.trust-store-password` | Password for the truststore. Masked in logs. | `Masked` | yes | - | active |
+| `message-anchoring.signer.web3signer.tls.trust-store-path` | Path to the truststore used to validate the Web3Signer certificate. Example: `/etc/coordinator/truststore.p12`. | `Path` | yes | - | active |
 
 ### `protocol`
 
 Lineth protocol contract addresses and genesis settings.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `protocol.genesis.genesis-shnarf` | `ByteArray` | yes | - | active | Genesis shnarf (starting shnarf) of the Lineth chain (hex). Example: `0xc286ff42414401ccdc23ea8e738775378e8f6c6f7b2966eb2747798d45571b79`. |
-| `protocol.genesis.genesis-state-root-hash` | `ByteArray` | yes | - | active | Genesis state root hash of the Lineth chain (hex). Example: `0x01d9afcd495c870f3ae9d8362cd0257a7de2057055058183596719285cae6101`. |
-| `protocol.l1.block-time` | `Duration` | no | `PT12S` | active | Average L1 block time, used for timing estimates. |
-| `protocol.l1.contract-address` | `String` | yes | - | active | Address of the Lineth rollup contract on L1. Example: `0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9`. |
-| `protocol.l1.contract-deployment-block-number` | `ULong?` | no | - | active | L1 block number at which the rollup contract was deployed. Omit if not applicable. Example: `3`. |
-| `protocol.l2.contract-address` | `String` | yes | - | active | Address of the Lineth contract on L2. Example: `0xe537D669CA013d86EBeF1D64e40fC74CADC91987`. |
-| `protocol.l2.contract-deployment-block-number` | `ULong?` | no | - | active | L2 block number at which the contract was deployed. Omit if not applicable. Example: `3`. |
+| `protocol.genesis.genesis-shnarf` | Genesis shnarf (starting shnarf) of the Lineth chain (hex). Example: `0xc286ff42414401ccdc23ea8e738775378e8f6c6f7b2966eb2747798d45571b79`. | `ByteArray` | yes | - | active |
+| `protocol.genesis.genesis-state-root-hash` | Genesis state root hash of the Lineth chain (hex). Example: `0x01d9afcd495c870f3ae9d8362cd0257a7de2057055058183596719285cae6101`. | `ByteArray` | yes | - | active |
+| `protocol.l1.block-time` | Average L1 block time, used for timing estimates. | `Duration` | no | `PT12S` | active |
+| `protocol.l1.contract-address` | Address of the Lineth rollup contract on L1. Example: `0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9`. | `String` | yes | - | active |
+| `protocol.l1.contract-deployment-block-number` | L1 block number at which the rollup contract was deployed. Omit if not applicable. Example: `3`. | `ULong?` | no | - | active |
+| `protocol.l2.contract-address` | Address of the Lineth contract on L2. Example: `0xe537D669CA013d86EBeF1D64e40fC74CADC91987`. | `String` | yes | - | active |
+| `protocol.l2.contract-deployment-block-number` | L2 block number at which the contract was deployed. Omit if not applicable. Example: `3`. | `ULong?` | no | - | active |
 
 ### `prover`
 
 File-based prover request/response directories and switch-over settings.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `prover.blob-compression.fork-name` | `String?` | no | - | active | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. |
-| `prover.blob-compression.fs-requests-directory` | `String` | yes | - | active | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. |
-| `prover.blob-compression.fs-responses-directory` | `String` | yes | - | active | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. |
-| `prover.blob-compression.program-vk` | `String?` | no | - | active | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. |
-| `prover.enable-request-files-cleanup` | `Boolean` | no | `false` | active | Whether to delete request files after their responses are processed. |
-| `prover.execution.fork-name` | `String?` | no | - | active | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. |
-| `prover.execution.fs-requests-directory` | `String` | yes | - | active | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. |
-| `prover.execution.fs-responses-directory` | `String` | yes | - | active | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. |
-| `prover.execution.program-vk` | `String?` | no | - | active | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. |
-| `prover.fs-inprogress-proving-suffix-pattern` | `String` | no | `\.inprogress\.prover.*` | active | Regex matching filenames a prover has claimed and is working on, so the coordinator treats them as in-progress. |
-| `prover.fs-inprogress-request-writing-suffix` | `String` | no | `.inprogress_coordinator_writing` | active | Filename suffix appended while the coordinator is still writing a request file, so provers ignore partially-written requests. |
-| `prover.fs-polling-interval` | `Duration` | no | `PT15S` | active | Interval between scans of the prover response directories for new responses. |
-| `prover.fs-polling-timeout` | `Duration` | no | `infinite` | active | Maximum time to wait for a prover response before timing out. Defaults to no timeout. |
-| `prover.invalidity.fork-name` | `String?` | no | - | active | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. |
-| `prover.invalidity.fs-requests-directory` | `String` | yes | - | active | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. |
-| `prover.invalidity.fs-responses-directory` | `String` | yes | - | active | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. |
-| `prover.invalidity.program-vk` | `String?` | no | - | active | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. |
-| `prover.new.blob-compression.fork-name` | `String?` | no | - | active | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. |
-| `prover.new.blob-compression.fs-requests-directory` | `String` | yes | - | active | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. |
-| `prover.new.blob-compression.fs-responses-directory` | `String` | yes | - | active | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. |
-| `prover.new.blob-compression.program-vk` | `String?` | no | - | active | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. |
-| `prover.new.enable-request-files-cleanup` | `Boolean` | no | `false` | active | Whether to delete request files after their responses are processed. |
-| `prover.new.execution.fork-name` | `String?` | no | - | active | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. |
-| `prover.new.execution.fs-requests-directory` | `String` | yes | - | active | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. |
-| `prover.new.execution.fs-responses-directory` | `String` | yes | - | active | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. |
-| `prover.new.execution.program-vk` | `String?` | no | - | active | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. |
-| `prover.new.fs-inprogress-proving-suffix-pattern` | `String` | no | `\.inprogress\.prover.*` | active | Regex matching filenames a prover has claimed and is working on, so the coordinator treats them as in-progress. |
-| `prover.new.fs-inprogress-request-writing-suffix` | `String` | no | `.inprogress_coordinator_writing` | active | Filename suffix appended while the coordinator is still writing a request file, so provers ignore partially-written requests. |
-| `prover.new.fs-polling-interval` | `Duration` | no | `PT15S` | active | Interval between scans of the prover response directories for new responses. |
-| `prover.new.fs-polling-timeout` | `Duration` | no | `infinite` | active | Maximum time to wait for a prover response before timing out. Defaults to no timeout. |
-| `prover.new.invalidity.fork-name` | `String?` | no | - | active | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. |
-| `prover.new.invalidity.fs-requests-directory` | `String` | yes | - | active | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. |
-| `prover.new.invalidity.fs-responses-directory` | `String` | yes | - | active | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. |
-| `prover.new.invalidity.program-vk` | `String?` | no | - | active | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. |
-| `prover.new.proof-aggregation.fork-name` | `String?` | no | - | active | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. |
-| `prover.new.proof-aggregation.fs-requests-directory` | `String` | yes | - | active | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. |
-| `prover.new.proof-aggregation.fs-responses-directory` | `String` | yes | - | active | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. |
-| `prover.new.proof-aggregation.program-vk` | `String?` | no | - | active | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. |
-| `prover.new.rollup.fork-name` | `String?` | no | - | active | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. |
-| `prover.new.rollup.fs-requests-directory` | `String` | yes | - | active | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. |
-| `prover.new.rollup.fs-responses-directory` | `String` | yes | - | active | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. |
-| `prover.new.rollup.program-vk` | `String?` | no | - | active | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. |
-| `prover.new.switch-block-number-inclusive` | `ULong?` | no | - | active | Inclusive L2 block number at which to switch from this prover to the `new` prover. Mutually exclusive with switchBlockTimestamp. Example: `1000000`. |
-| `prover.new.switch-block-timestamp` | `Instant?` | no | - | active | Timestamp at which to switch from this prover to the `new` prover. Mutually exclusive with switchBlockNumberInclusive. Example: `2024-01-01T00:00:00Z`. |
-| `prover.proof-aggregation.fork-name` | `String?` | no | - | active | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. |
-| `prover.proof-aggregation.fs-requests-directory` | `String` | yes | - | active | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. |
-| `prover.proof-aggregation.fs-responses-directory` | `String` | yes | - | active | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. |
-| `prover.proof-aggregation.program-vk` | `String?` | no | - | active | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. |
-| `prover.rollup.fork-name` | `String?` | no | - | active | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. |
-| `prover.rollup.fs-requests-directory` | `String` | yes | - | active | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. |
-| `prover.rollup.fs-responses-directory` | `String` | yes | - | active | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. |
-| `prover.rollup.program-vk` | `String?` | no | - | active | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. |
-| `prover.switch-block-number-inclusive` | `ULong?` | no | - | active | Inclusive L2 block number at which to switch from this prover to the `new` prover. Mutually exclusive with switchBlockTimestamp. Example: `1000000`. |
-| `prover.switch-block-timestamp` | `Instant?` | no | - | active | Timestamp at which to switch from this prover to the `new` prover. Mutually exclusive with switchBlockNumberInclusive. Example: `2024-01-01T00:00:00Z`. |
+| `prover.blob-compression.fork-name` | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. | `String?` | no | - | active |
+| `prover.blob-compression.fs-requests-directory` | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. | `String` | yes | - | active |
+| `prover.blob-compression.fs-responses-directory` | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. | `String` | yes | - | active |
+| `prover.blob-compression.program-vk` | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. | `String?` | no | - | active |
+| `prover.enable-request-files-cleanup` | Whether to delete request files after their responses are processed. | `Boolean` | no | `false` | active |
+| `prover.execution.fork-name` | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. | `String?` | no | - | active |
+| `prover.execution.fs-requests-directory` | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. | `String` | yes | - | active |
+| `prover.execution.fs-responses-directory` | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. | `String` | yes | - | active |
+| `prover.execution.program-vk` | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. | `String?` | no | - | active |
+| `prover.fs-inprogress-proving-suffix-pattern` | Regex matching filenames a prover has claimed and is working on, so the coordinator treats them as in-progress. | `String` | no | `\.inprogress\.prover.*` | active |
+| `prover.fs-inprogress-request-writing-suffix` | Filename suffix appended while the coordinator is still writing a request file, so provers ignore partially-written requests. | `String` | no | `.inprogress_coordinator_writing` | active |
+| `prover.fs-polling-interval` | Interval between scans of the prover response directories for new responses. | `Duration` | no | `PT15S` | active |
+| `prover.fs-polling-timeout` | Maximum time to wait for a prover response before timing out. Defaults to no timeout. | `Duration` | no | `infinite` | active |
+| `prover.invalidity.fork-name` | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. | `String?` | no | - | active |
+| `prover.invalidity.fs-requests-directory` | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. | `String` | yes | - | active |
+| `prover.invalidity.fs-responses-directory` | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. | `String` | yes | - | active |
+| `prover.invalidity.program-vk` | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. | `String?` | no | - | active |
+| `prover.new.blob-compression.fork-name` | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. | `String?` | no | - | active |
+| `prover.new.blob-compression.fs-requests-directory` | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. | `String` | yes | - | active |
+| `prover.new.blob-compression.fs-responses-directory` | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. | `String` | yes | - | active |
+| `prover.new.blob-compression.program-vk` | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. | `String?` | no | - | active |
+| `prover.new.enable-request-files-cleanup` | Whether to delete request files after their responses are processed. | `Boolean` | no | `false` | active |
+| `prover.new.execution.fork-name` | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. | `String?` | no | - | active |
+| `prover.new.execution.fs-requests-directory` | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. | `String` | yes | - | active |
+| `prover.new.execution.fs-responses-directory` | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. | `String` | yes | - | active |
+| `prover.new.execution.program-vk` | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. | `String?` | no | - | active |
+| `prover.new.fs-inprogress-proving-suffix-pattern` | Regex matching filenames a prover has claimed and is working on, so the coordinator treats them as in-progress. | `String` | no | `\.inprogress\.prover.*` | active |
+| `prover.new.fs-inprogress-request-writing-suffix` | Filename suffix appended while the coordinator is still writing a request file, so provers ignore partially-written requests. | `String` | no | `.inprogress_coordinator_writing` | active |
+| `prover.new.fs-polling-interval` | Interval between scans of the prover response directories for new responses. | `Duration` | no | `PT15S` | active |
+| `prover.new.fs-polling-timeout` | Maximum time to wait for a prover response before timing out. Defaults to no timeout. | `Duration` | no | `infinite` | active |
+| `prover.new.invalidity.fork-name` | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. | `String?` | no | - | active |
+| `prover.new.invalidity.fs-requests-directory` | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. | `String` | yes | - | active |
+| `prover.new.invalidity.fs-responses-directory` | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. | `String` | yes | - | active |
+| `prover.new.invalidity.program-vk` | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. | `String?` | no | - | active |
+| `prover.new.proof-aggregation.fork-name` | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. | `String?` | no | - | active |
+| `prover.new.proof-aggregation.fs-requests-directory` | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. | `String` | yes | - | active |
+| `prover.new.proof-aggregation.fs-responses-directory` | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. | `String` | yes | - | active |
+| `prover.new.proof-aggregation.program-vk` | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. | `String?` | no | - | active |
+| `prover.new.rollup.fork-name` | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. | `String?` | no | - | active |
+| `prover.new.rollup.fs-requests-directory` | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. | `String` | yes | - | active |
+| `prover.new.rollup.fs-responses-directory` | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. | `String` | yes | - | active |
+| `prover.new.rollup.program-vk` | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. | `String?` | no | - | active |
+| `prover.new.switch-block-number-inclusive` | Inclusive L2 block number at which to switch from this prover to the `new` prover. Mutually exclusive with switchBlockTimestamp. Example: `1000000`. | `ULong?` | no | - | active |
+| `prover.new.switch-block-timestamp` | Timestamp at which to switch from this prover to the `new` prover. Mutually exclusive with switchBlockNumberInclusive. Example: `2024-01-01T00:00:00Z`. | `Instant?` | no | - | active |
+| `prover.proof-aggregation.fork-name` | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. | `String?` | no | - | active |
+| `prover.proof-aggregation.fs-requests-directory` | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. | `String` | yes | - | active |
+| `prover.proof-aggregation.fs-responses-directory` | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. | `String` | yes | - | active |
+| `prover.proof-aggregation.program-vk` | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. | `String?` | no | - | active |
+| `prover.rollup.fork-name` | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. | `String?` | no | - | active |
+| `prover.rollup.fs-requests-directory` | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. | `String` | yes | - | active |
+| `prover.rollup.fs-responses-directory` | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. | `String` | yes | - | active |
+| `prover.rollup.program-vk` | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. | `String?` | no | - | active |
+| `prover.switch-block-number-inclusive` | Inclusive L2 block number at which to switch from this prover to the `new` prover. Mutually exclusive with switchBlockTimestamp. Example: `1000000`. | `ULong?` | no | - | active |
+| `prover.switch-block-timestamp` | Timestamp at which to switch from this prover to the `new` prover. Mutually exclusive with switchBlockNumberInclusive. Example: `2024-01-01T00:00:00Z`. | `Instant?` | no | - | active |
 
 ### `riscv-prover`
 
 RISC-V prover request/response directories for execution, rollup, and aggregation proofs.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `riscv-prover.blob-compression.fork-name` | `String?` | no | - | active | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. |
-| `riscv-prover.blob-compression.fs-requests-directory` | `String` | yes | - | active | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. |
-| `riscv-prover.blob-compression.fs-responses-directory` | `String` | yes | - | active | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. |
-| `riscv-prover.blob-compression.program-vk` | `String?` | no | - | active | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. |
-| `riscv-prover.enable-request-files-cleanup` | `Boolean` | no | `false` | active | Whether to delete request files after their responses are processed. |
-| `riscv-prover.execution.fork-name` | `String?` | no | - | active | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. |
-| `riscv-prover.execution.fs-requests-directory` | `String` | yes | - | active | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. |
-| `riscv-prover.execution.fs-responses-directory` | `String` | yes | - | active | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. |
-| `riscv-prover.execution.program-vk` | `String?` | no | - | active | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. |
-| `riscv-prover.fs-inprogress-proving-suffix-pattern` | `String` | no | `\.inprogress\.prover.*` | active | Regex matching filenames a prover has claimed and is working on, so the coordinator treats them as in-progress. |
-| `riscv-prover.fs-inprogress-request-writing-suffix` | `String` | no | `.inprogress_coordinator_writing` | active | Filename suffix appended while the coordinator is still writing a request file, so provers ignore partially-written requests. |
-| `riscv-prover.fs-polling-interval` | `Duration` | no | `PT15S` | active | Interval between scans of the prover response directories for new responses. |
-| `riscv-prover.fs-polling-timeout` | `Duration` | no | `infinite` | active | Maximum time to wait for a prover response before timing out. Defaults to no timeout. |
-| `riscv-prover.invalidity.fork-name` | `String?` | no | - | active | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. |
-| `riscv-prover.invalidity.fs-requests-directory` | `String` | yes | - | active | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. |
-| `riscv-prover.invalidity.fs-responses-directory` | `String` | yes | - | active | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. |
-| `riscv-prover.invalidity.program-vk` | `String?` | no | - | active | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. |
-| `riscv-prover.new.blob-compression.fork-name` | `String?` | no | - | active | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. |
-| `riscv-prover.new.blob-compression.fs-requests-directory` | `String` | yes | - | active | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. |
-| `riscv-prover.new.blob-compression.fs-responses-directory` | `String` | yes | - | active | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. |
-| `riscv-prover.new.blob-compression.program-vk` | `String?` | no | - | active | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. |
-| `riscv-prover.new.enable-request-files-cleanup` | `Boolean` | no | `false` | active | Whether to delete request files after their responses are processed. |
-| `riscv-prover.new.execution.fork-name` | `String?` | no | - | active | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. |
-| `riscv-prover.new.execution.fs-requests-directory` | `String` | yes | - | active | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. |
-| `riscv-prover.new.execution.fs-responses-directory` | `String` | yes | - | active | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. |
-| `riscv-prover.new.execution.program-vk` | `String?` | no | - | active | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. |
-| `riscv-prover.new.fs-inprogress-proving-suffix-pattern` | `String` | no | `\.inprogress\.prover.*` | active | Regex matching filenames a prover has claimed and is working on, so the coordinator treats them as in-progress. |
-| `riscv-prover.new.fs-inprogress-request-writing-suffix` | `String` | no | `.inprogress_coordinator_writing` | active | Filename suffix appended while the coordinator is still writing a request file, so provers ignore partially-written requests. |
-| `riscv-prover.new.fs-polling-interval` | `Duration` | no | `PT15S` | active | Interval between scans of the prover response directories for new responses. |
-| `riscv-prover.new.fs-polling-timeout` | `Duration` | no | `infinite` | active | Maximum time to wait for a prover response before timing out. Defaults to no timeout. |
-| `riscv-prover.new.invalidity.fork-name` | `String?` | no | - | active | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. |
-| `riscv-prover.new.invalidity.fs-requests-directory` | `String` | yes | - | active | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. |
-| `riscv-prover.new.invalidity.fs-responses-directory` | `String` | yes | - | active | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. |
-| `riscv-prover.new.invalidity.program-vk` | `String?` | no | - | active | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. |
-| `riscv-prover.new.proof-aggregation.fork-name` | `String?` | no | - | active | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. |
-| `riscv-prover.new.proof-aggregation.fs-requests-directory` | `String` | yes | - | active | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. |
-| `riscv-prover.new.proof-aggregation.fs-responses-directory` | `String` | yes | - | active | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. |
-| `riscv-prover.new.proof-aggregation.program-vk` | `String?` | no | - | active | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. |
-| `riscv-prover.new.rollup.fork-name` | `String?` | no | - | active | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. |
-| `riscv-prover.new.rollup.fs-requests-directory` | `String` | yes | - | active | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. |
-| `riscv-prover.new.rollup.fs-responses-directory` | `String` | yes | - | active | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. |
-| `riscv-prover.new.rollup.program-vk` | `String?` | no | - | active | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. |
-| `riscv-prover.new.switch-block-number-inclusive` | `ULong?` | no | - | active | Inclusive L2 block number at which to switch from this prover to the `new` prover. Mutually exclusive with switchBlockTimestamp. Example: `1000000`. |
-| `riscv-prover.new.switch-block-timestamp` | `Instant?` | no | - | active | Timestamp at which to switch from this prover to the `new` prover. Mutually exclusive with switchBlockNumberInclusive. Example: `2024-01-01T00:00:00Z`. |
-| `riscv-prover.proof-aggregation.fork-name` | `String?` | no | - | active | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. |
-| `riscv-prover.proof-aggregation.fs-requests-directory` | `String` | yes | - | active | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. |
-| `riscv-prover.proof-aggregation.fs-responses-directory` | `String` | yes | - | active | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. |
-| `riscv-prover.proof-aggregation.program-vk` | `String?` | no | - | active | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. |
-| `riscv-prover.rollup.fork-name` | `String?` | no | - | active | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. |
-| `riscv-prover.rollup.fs-requests-directory` | `String` | yes | - | active | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. |
-| `riscv-prover.rollup.fs-responses-directory` | `String` | yes | - | active | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. |
-| `riscv-prover.rollup.program-vk` | `String?` | no | - | active | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. |
-| `riscv-prover.switch-block-number-inclusive` | `ULong?` | no | - | active | Inclusive L2 block number at which to switch from this prover to the `new` prover. Mutually exclusive with switchBlockTimestamp. Example: `1000000`. |
-| `riscv-prover.switch-block-timestamp` | `Instant?` | no | - | active | Timestamp at which to switch from this prover to the `new` prover. Mutually exclusive with switchBlockNumberInclusive. Example: `2024-01-01T00:00:00Z`. |
+| `riscv-prover.blob-compression.fork-name` | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. | `String?` | no | - | active |
+| `riscv-prover.blob-compression.fs-requests-directory` | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. | `String` | yes | - | active |
+| `riscv-prover.blob-compression.fs-responses-directory` | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. | `String` | yes | - | active |
+| `riscv-prover.blob-compression.program-vk` | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. | `String?` | no | - | active |
+| `riscv-prover.enable-request-files-cleanup` | Whether to delete request files after their responses are processed. | `Boolean` | no | `false` | active |
+| `riscv-prover.execution.fork-name` | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. | `String?` | no | - | active |
+| `riscv-prover.execution.fs-requests-directory` | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. | `String` | yes | - | active |
+| `riscv-prover.execution.fs-responses-directory` | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. | `String` | yes | - | active |
+| `riscv-prover.execution.program-vk` | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. | `String?` | no | - | active |
+| `riscv-prover.fs-inprogress-proving-suffix-pattern` | Regex matching filenames a prover has claimed and is working on, so the coordinator treats them as in-progress. | `String` | no | `\.inprogress\.prover.*` | active |
+| `riscv-prover.fs-inprogress-request-writing-suffix` | Filename suffix appended while the coordinator is still writing a request file, so provers ignore partially-written requests. | `String` | no | `.inprogress_coordinator_writing` | active |
+| `riscv-prover.fs-polling-interval` | Interval between scans of the prover response directories for new responses. | `Duration` | no | `PT15S` | active |
+| `riscv-prover.fs-polling-timeout` | Maximum time to wait for a prover response before timing out. Defaults to no timeout. | `Duration` | no | `infinite` | active |
+| `riscv-prover.invalidity.fork-name` | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. | `String?` | no | - | active |
+| `riscv-prover.invalidity.fs-requests-directory` | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. | `String` | yes | - | active |
+| `riscv-prover.invalidity.fs-responses-directory` | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. | `String` | yes | - | active |
+| `riscv-prover.invalidity.program-vk` | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. | `String?` | no | - | active |
+| `riscv-prover.new.blob-compression.fork-name` | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. | `String?` | no | - | active |
+| `riscv-prover.new.blob-compression.fs-requests-directory` | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. | `String` | yes | - | active |
+| `riscv-prover.new.blob-compression.fs-responses-directory` | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. | `String` | yes | - | active |
+| `riscv-prover.new.blob-compression.program-vk` | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. | `String?` | no | - | active |
+| `riscv-prover.new.enable-request-files-cleanup` | Whether to delete request files after their responses are processed. | `Boolean` | no | `false` | active |
+| `riscv-prover.new.execution.fork-name` | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. | `String?` | no | - | active |
+| `riscv-prover.new.execution.fs-requests-directory` | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. | `String` | yes | - | active |
+| `riscv-prover.new.execution.fs-responses-directory` | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. | `String` | yes | - | active |
+| `riscv-prover.new.execution.program-vk` | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. | `String?` | no | - | active |
+| `riscv-prover.new.fs-inprogress-proving-suffix-pattern` | Regex matching filenames a prover has claimed and is working on, so the coordinator treats them as in-progress. | `String` | no | `\.inprogress\.prover.*` | active |
+| `riscv-prover.new.fs-inprogress-request-writing-suffix` | Filename suffix appended while the coordinator is still writing a request file, so provers ignore partially-written requests. | `String` | no | `.inprogress_coordinator_writing` | active |
+| `riscv-prover.new.fs-polling-interval` | Interval between scans of the prover response directories for new responses. | `Duration` | no | `PT15S` | active |
+| `riscv-prover.new.fs-polling-timeout` | Maximum time to wait for a prover response before timing out. Defaults to no timeout. | `Duration` | no | `infinite` | active |
+| `riscv-prover.new.invalidity.fork-name` | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. | `String?` | no | - | active |
+| `riscv-prover.new.invalidity.fs-requests-directory` | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. | `String` | yes | - | active |
+| `riscv-prover.new.invalidity.fs-responses-directory` | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. | `String` | yes | - | active |
+| `riscv-prover.new.invalidity.program-vk` | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. | `String?` | no | - | active |
+| `riscv-prover.new.proof-aggregation.fork-name` | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. | `String?` | no | - | active |
+| `riscv-prover.new.proof-aggregation.fs-requests-directory` | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. | `String` | yes | - | active |
+| `riscv-prover.new.proof-aggregation.fs-responses-directory` | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. | `String` | yes | - | active |
+| `riscv-prover.new.proof-aggregation.program-vk` | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. | `String?` | no | - | active |
+| `riscv-prover.new.rollup.fork-name` | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. | `String?` | no | - | active |
+| `riscv-prover.new.rollup.fs-requests-directory` | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. | `String` | yes | - | active |
+| `riscv-prover.new.rollup.fs-responses-directory` | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. | `String` | yes | - | active |
+| `riscv-prover.new.rollup.program-vk` | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. | `String?` | no | - | active |
+| `riscv-prover.new.switch-block-number-inclusive` | Inclusive L2 block number at which to switch from this prover to the `new` prover. Mutually exclusive with switchBlockTimestamp. Example: `1000000`. | `ULong?` | no | - | active |
+| `riscv-prover.new.switch-block-timestamp` | Timestamp at which to switch from this prover to the `new` prover. Mutually exclusive with switchBlockNumberInclusive. Example: `2024-01-01T00:00:00Z`. | `Instant?` | no | - | active |
+| `riscv-prover.proof-aggregation.fork-name` | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. | `String?` | no | - | active |
+| `riscv-prover.proof-aggregation.fs-requests-directory` | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. | `String` | yes | - | active |
+| `riscv-prover.proof-aggregation.fs-responses-directory` | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. | `String` | yes | - | active |
+| `riscv-prover.proof-aggregation.program-vk` | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. | `String?` | no | - | active |
+| `riscv-prover.rollup.fork-name` | L2 EVM fork name included in RISC-V execution proof requests (e.g. "cancun"). Required for the RISC-V execution prover; omit for other prover types. Example: `cancun`. | `String?` | no | - | active |
+| `riscv-prover.rollup.fs-requests-directory` | Directory the coordinator writes prover request files to. Example: `/data/prover/v3/execution/requests`. | `String` | yes | - | active |
+| `riscv-prover.rollup.fs-responses-directory` | Directory the coordinator reads prover response files from. Example: `/data/prover/v3/execution/responses`. | `String` | yes | - | active |
+| `riscv-prover.rollup.program-vk` | Guest program verifying key for the RISC-V prover. Required when this config is used as the riscvProver; omit for the standard (EVM) prover. Example: `0xabcdef1234567890`. | `String?` | no | - | active |
+| `riscv-prover.switch-block-number-inclusive` | Inclusive L2 block number at which to switch from this prover to the `new` prover. Mutually exclusive with switchBlockTimestamp. Example: `1000000`. | `ULong?` | no | - | active |
+| `riscv-prover.switch-block-timestamp` | Timestamp at which to switch from this prover to the `new` prover. Mutually exclusive with switchBlockNumberInclusive. Example: `2024-01-01T00:00:00Z`. | `Instant?` | no | - | active |
 
 ### `state-manager`
 
 Shomei state manager client settings.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `state-manager.endpoints` | `List<URL>` | yes | - | active | Shomei state manager JSON-RPC endpoints. Example: `["http://shomei:8888"]`. |
-| `state-manager.request-limit-per-endpoint` | `UInt` | no | `4294967295` | active | Maximum number of concurrent in-flight requests per state manager endpoint. |
-| `state-manager.request-retries.backoff-delay` | `Duration` | no | `PT1S` | active | Delay between retry attempts. Example: `PT1S`. |
-| `state-manager.request-retries.failures-warning-threshold` | `UInt?` | no | - | active | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. |
-| `state-manager.request-retries.ignore-first-exceptions-until-time-elapsed` | `Duration?` | no | - | active | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. |
-| `state-manager.request-retries.max-retries` | `UInt?` | no | - | active | Maximum number of retry attempts. Omit for endless retries. Example: `3`. |
-| `state-manager.request-retries.timeout` | `Duration?` | no | - | active | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. |
-| `state-manager.request-timeout` | `Duration?` | no | - | active | Timeout for each state manager request. Omit to disable the timeout. Example: `PT30S`. |
+| `state-manager.endpoints` | Shomei state manager JSON-RPC endpoints. Example: `["http://shomei:8888"]`. | `List<URL>` | yes | - | active |
+| `state-manager.request-limit-per-endpoint` | Maximum number of concurrent in-flight requests per state manager endpoint. | `UInt` | no | `4294967295` | active |
+| `state-manager.request-retries.backoff-delay` | Delay between retry attempts. Example: `PT1S`. | `Duration` | no | `PT1S` | active |
+| `state-manager.request-retries.failures-warning-threshold` | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. | `UInt?` | no | - | active |
+| `state-manager.request-retries.ignore-first-exceptions-until-time-elapsed` | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. | `Duration?` | no | - | active |
+| `state-manager.request-retries.max-retries` | Maximum number of retry attempts. Omit for endless retries. Example: `3`. | `UInt?` | no | - | active |
+| `state-manager.request-retries.timeout` | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. | `Duration?` | no | - | active |
+| `state-manager.request-timeout` | Timeout for each state manager request. Omit to disable the timeout. Example: `PT30S`. | `Duration?` | no | - | active |
 
 ### `traces`
 
 Trace generation (traces API / conflation counters) client settings.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `traces.conflation.endpoints` | `List<URL>?` | no | - | active | Endpoints for this specific traces client. Falls back to traces.endpoints when omitted. Example: `["http://traces-node:8545"]`. |
-| `traces.conflation.request-limit-per-endpoint` | `UInt?` | no | - | active | Per-endpoint concurrent request limit for this client. Falls back to the shared value. Example: `4`. |
-| `traces.conflation.request-retries.backoff-delay` | `Duration` | no | `PT1S` | active | Delay between retry attempts. Example: `PT1S`. |
-| `traces.conflation.request-retries.failures-warning-threshold` | `UInt?` | no | - | active | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. |
-| `traces.conflation.request-retries.ignore-first-exceptions-until-time-elapsed` | `Duration?` | no | - | active | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. |
-| `traces.conflation.request-retries.max-retries` | `UInt?` | no | - | active | Maximum number of retry attempts. Omit for endless retries. Example: `3`. |
-| `traces.conflation.request-retries.timeout` | `Duration?` | no | - | active | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. |
-| `traces.conflation.request-timeout` | `Duration?` | no | - | active | Request timeout for this client. Falls back to the shared value. Example: `PT30S`. |
-| `traces.counters.endpoints` | `List<URL>?` | no | - | active | Endpoints for this specific traces client. Falls back to traces.endpoints when omitted. Example: `["http://traces-node:8545"]`. |
-| `traces.counters.request-limit-per-endpoint` | `UInt?` | no | - | active | Per-endpoint concurrent request limit for this client. Falls back to the shared value. Example: `4`. |
-| `traces.counters.request-retries.backoff-delay` | `Duration` | no | `PT1S` | active | Delay between retry attempts. Example: `PT1S`. |
-| `traces.counters.request-retries.failures-warning-threshold` | `UInt?` | no | - | active | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. |
-| `traces.counters.request-retries.ignore-first-exceptions-until-time-elapsed` | `Duration?` | no | - | active | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. |
-| `traces.counters.request-retries.max-retries` | `UInt?` | no | - | active | Maximum number of retry attempts. Omit for endless retries. Example: `3`. |
-| `traces.counters.request-retries.timeout` | `Duration?` | no | - | active | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. |
-| `traces.counters.request-timeout` | `Duration?` | no | - | active | Request timeout for this client. Falls back to the shared value. Example: `PT30S`. |
-| `traces.endpoints` | `List<URL>?` | no | - | active | Traces generator endpoints shared by the counters and conflation clients. Required unless both counters.endpoints and conflation.endpoints are set. Example: `["http://traces-node:8545"]`. |
-| `traces.ignore-traces-generator-errors` | `Boolean` | no | `false` | active | Whether to continue despite traces generator errors instead of failing. |
-| `traces.new.conflation.endpoints` | `List<URL>?` | no | - | active | Endpoints for this specific traces client. Falls back to traces.endpoints when omitted. Example: `["http://traces-node:8545"]`. |
-| `traces.new.conflation.request-limit-per-endpoint` | `UInt?` | no | - | active | Per-endpoint concurrent request limit for this client. Falls back to the shared value. Example: `4`. |
-| `traces.new.conflation.request-retries.backoff-delay` | `Duration` | no | `PT1S` | active | Delay between retry attempts. Example: `PT1S`. |
-| `traces.new.conflation.request-retries.failures-warning-threshold` | `UInt?` | no | - | active | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. |
-| `traces.new.conflation.request-retries.ignore-first-exceptions-until-time-elapsed` | `Duration?` | no | - | active | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. |
-| `traces.new.conflation.request-retries.max-retries` | `UInt?` | no | - | active | Maximum number of retry attempts. Omit for endless retries. Example: `3`. |
-| `traces.new.conflation.request-retries.timeout` | `Duration?` | no | - | active | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. |
-| `traces.new.conflation.request-timeout` | `Duration?` | no | - | active | Request timeout for this client. Falls back to the shared value. Example: `PT30S`. |
-| `traces.new.counters.endpoints` | `List<URL>?` | no | - | active | Endpoints for this specific traces client. Falls back to traces.endpoints when omitted. Example: `["http://traces-node:8545"]`. |
-| `traces.new.counters.request-limit-per-endpoint` | `UInt?` | no | - | active | Per-endpoint concurrent request limit for this client. Falls back to the shared value. Example: `4`. |
-| `traces.new.counters.request-retries.backoff-delay` | `Duration` | no | `PT1S` | active | Delay between retry attempts. Example: `PT1S`. |
-| `traces.new.counters.request-retries.failures-warning-threshold` | `UInt?` | no | - | active | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. |
-| `traces.new.counters.request-retries.ignore-first-exceptions-until-time-elapsed` | `Duration?` | no | - | active | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. |
-| `traces.new.counters.request-retries.max-retries` | `UInt?` | no | - | active | Maximum number of retry attempts. Omit for endless retries. Example: `3`. |
-| `traces.new.counters.request-retries.timeout` | `Duration?` | no | - | active | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. |
-| `traces.new.counters.request-timeout` | `Duration?` | no | - | active | Request timeout for this client. Falls back to the shared value. Example: `PT30S`. |
-| `traces.new.endpoints` | `List<URL>?` | no | - | active | Traces generator endpoints shared by the counters and conflation clients. Required unless both counters.endpoints and conflation.endpoints are set. Example: `["http://traces-node:8545"]`. |
-| `traces.new.ignore-traces-generator-errors` | `Boolean` | no | `false` | active | Whether to continue despite traces generator errors instead of failing. |
-| `traces.new.request-limit-per-endpoint` | `UInt` | no | `4294967295` | active | Maximum number of concurrent in-flight requests per traces endpoint. |
-| `traces.new.request-retries.backoff-delay` | `Duration` | no | `PT1S` | active | Delay between retry attempts. Example: `PT1S`. |
-| `traces.new.request-retries.failures-warning-threshold` | `UInt?` | no | - | active | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. |
-| `traces.new.request-retries.ignore-first-exceptions-until-time-elapsed` | `Duration?` | no | - | active | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. |
-| `traces.new.request-retries.max-retries` | `UInt?` | no | - | active | Maximum number of retry attempts. Omit for endless retries. Example: `3`. |
-| `traces.new.request-retries.timeout` | `Duration?` | no | - | active | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. |
-| `traces.new.request-timeout` | `Duration?` | no | - | active | Timeout for each traces generator request. Omit to disable the timeout. Example: `PT30S`. |
-| `traces.new.switch-block-number-inclusive` | `UInt?` | no | - | active | Inclusive L2 block number at which to switch from this traces config to the `new` one. Example: `1000000`. |
-| `traces.request-limit-per-endpoint` | `UInt` | no | `4294967295` | active | Maximum number of concurrent in-flight requests per traces endpoint. |
-| `traces.request-retries.backoff-delay` | `Duration` | no | `PT1S` | active | Delay between retry attempts. Example: `PT1S`. |
-| `traces.request-retries.failures-warning-threshold` | `UInt?` | no | - | active | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. |
-| `traces.request-retries.ignore-first-exceptions-until-time-elapsed` | `Duration?` | no | - | active | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. |
-| `traces.request-retries.max-retries` | `UInt?` | no | - | active | Maximum number of retry attempts. Omit for endless retries. Example: `3`. |
-| `traces.request-retries.timeout` | `Duration?` | no | - | active | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. |
-| `traces.request-timeout` | `Duration?` | no | - | active | Timeout for each traces generator request. Omit to disable the timeout. Example: `PT30S`. |
-| `traces.switch-block-number-inclusive` | `UInt?` | no | - | active | Inclusive L2 block number at which to switch from this traces config to the `new` one. Example: `1000000`. |
+| `traces.conflation.endpoints` | Endpoints for this specific traces client. Falls back to traces.endpoints when omitted. Example: `["http://traces-node:8545"]`. | `List<URL>?` | no | - | active |
+| `traces.conflation.request-limit-per-endpoint` | Per-endpoint concurrent request limit for this client. Falls back to the shared value. Example: `4`. | `UInt?` | no | - | active |
+| `traces.conflation.request-retries.backoff-delay` | Delay between retry attempts. Example: `PT1S`. | `Duration` | no | `PT1S` | active |
+| `traces.conflation.request-retries.failures-warning-threshold` | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. | `UInt?` | no | - | active |
+| `traces.conflation.request-retries.ignore-first-exceptions-until-time-elapsed` | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. | `Duration?` | no | - | active |
+| `traces.conflation.request-retries.max-retries` | Maximum number of retry attempts. Omit for endless retries. Example: `3`. | `UInt?` | no | - | active |
+| `traces.conflation.request-retries.timeout` | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. | `Duration?` | no | - | active |
+| `traces.conflation.request-timeout` | Request timeout for this client. Falls back to the shared value. Example: `PT30S`. | `Duration?` | no | - | active |
+| `traces.counters.endpoints` | Endpoints for this specific traces client. Falls back to traces.endpoints when omitted. Example: `["http://traces-node:8545"]`. | `List<URL>?` | no | - | active |
+| `traces.counters.request-limit-per-endpoint` | Per-endpoint concurrent request limit for this client. Falls back to the shared value. Example: `4`. | `UInt?` | no | - | active |
+| `traces.counters.request-retries.backoff-delay` | Delay between retry attempts. Example: `PT1S`. | `Duration` | no | `PT1S` | active |
+| `traces.counters.request-retries.failures-warning-threshold` | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. | `UInt?` | no | - | active |
+| `traces.counters.request-retries.ignore-first-exceptions-until-time-elapsed` | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. | `Duration?` | no | - | active |
+| `traces.counters.request-retries.max-retries` | Maximum number of retry attempts. Omit for endless retries. Example: `3`. | `UInt?` | no | - | active |
+| `traces.counters.request-retries.timeout` | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. | `Duration?` | no | - | active |
+| `traces.counters.request-timeout` | Request timeout for this client. Falls back to the shared value. Example: `PT30S`. | `Duration?` | no | - | active |
+| `traces.endpoints` | Traces generator endpoints shared by the counters and conflation clients. Required unless both counters.endpoints and conflation.endpoints are set. Example: `["http://traces-node:8545"]`. | `List<URL>?` | no | - | active |
+| `traces.ignore-traces-generator-errors` | Whether to continue despite traces generator errors instead of failing. | `Boolean` | no | `false` | active |
+| `traces.new.conflation.endpoints` | Endpoints for this specific traces client. Falls back to traces.endpoints when omitted. Example: `["http://traces-node:8545"]`. | `List<URL>?` | no | - | active |
+| `traces.new.conflation.request-limit-per-endpoint` | Per-endpoint concurrent request limit for this client. Falls back to the shared value. Example: `4`. | `UInt?` | no | - | active |
+| `traces.new.conflation.request-retries.backoff-delay` | Delay between retry attempts. Example: `PT1S`. | `Duration` | no | `PT1S` | active |
+| `traces.new.conflation.request-retries.failures-warning-threshold` | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. | `UInt?` | no | - | active |
+| `traces.new.conflation.request-retries.ignore-first-exceptions-until-time-elapsed` | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. | `Duration?` | no | - | active |
+| `traces.new.conflation.request-retries.max-retries` | Maximum number of retry attempts. Omit for endless retries. Example: `3`. | `UInt?` | no | - | active |
+| `traces.new.conflation.request-retries.timeout` | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. | `Duration?` | no | - | active |
+| `traces.new.conflation.request-timeout` | Request timeout for this client. Falls back to the shared value. Example: `PT30S`. | `Duration?` | no | - | active |
+| `traces.new.counters.endpoints` | Endpoints for this specific traces client. Falls back to traces.endpoints when omitted. Example: `["http://traces-node:8545"]`. | `List<URL>?` | no | - | active |
+| `traces.new.counters.request-limit-per-endpoint` | Per-endpoint concurrent request limit for this client. Falls back to the shared value. Example: `4`. | `UInt?` | no | - | active |
+| `traces.new.counters.request-retries.backoff-delay` | Delay between retry attempts. Example: `PT1S`. | `Duration` | no | `PT1S` | active |
+| `traces.new.counters.request-retries.failures-warning-threshold` | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. | `UInt?` | no | - | active |
+| `traces.new.counters.request-retries.ignore-first-exceptions-until-time-elapsed` | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. | `Duration?` | no | - | active |
+| `traces.new.counters.request-retries.max-retries` | Maximum number of retry attempts. Omit for endless retries. Example: `3`. | `UInt?` | no | - | active |
+| `traces.new.counters.request-retries.timeout` | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. | `Duration?` | no | - | active |
+| `traces.new.counters.request-timeout` | Request timeout for this client. Falls back to the shared value. Example: `PT30S`. | `Duration?` | no | - | active |
+| `traces.new.endpoints` | Traces generator endpoints shared by the counters and conflation clients. Required unless both counters.endpoints and conflation.endpoints are set. Example: `["http://traces-node:8545"]`. | `List<URL>?` | no | - | active |
+| `traces.new.ignore-traces-generator-errors` | Whether to continue despite traces generator errors instead of failing. | `Boolean` | no | `false` | active |
+| `traces.new.request-limit-per-endpoint` | Maximum number of concurrent in-flight requests per traces endpoint. | `UInt` | no | `4294967295` | active |
+| `traces.new.request-retries.backoff-delay` | Delay between retry attempts. Example: `PT1S`. | `Duration` | no | `PT1S` | active |
+| `traces.new.request-retries.failures-warning-threshold` | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. | `UInt?` | no | - | active |
+| `traces.new.request-retries.ignore-first-exceptions-until-time-elapsed` | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. | `Duration?` | no | - | active |
+| `traces.new.request-retries.max-retries` | Maximum number of retry attempts. Omit for endless retries. Example: `3`. | `UInt?` | no | - | active |
+| `traces.new.request-retries.timeout` | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. | `Duration?` | no | - | active |
+| `traces.new.request-timeout` | Timeout for each traces generator request. Omit to disable the timeout. Example: `PT30S`. | `Duration?` | no | - | active |
+| `traces.new.switch-block-number-inclusive` | Inclusive L2 block number at which to switch from this traces config to the `new` one. Example: `1000000`. | `UInt?` | no | - | active |
+| `traces.request-limit-per-endpoint` | Maximum number of concurrent in-flight requests per traces endpoint. | `UInt` | no | `4294967295` | active |
+| `traces.request-retries.backoff-delay` | Delay between retry attempts. Example: `PT1S`. | `Duration` | no | `PT1S` | active |
+| `traces.request-retries.failures-warning-threshold` | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. | `UInt?` | no | - | active |
+| `traces.request-retries.ignore-first-exceptions-until-time-elapsed` | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. | `Duration?` | no | - | active |
+| `traces.request-retries.max-retries` | Maximum number of retry attempts. Omit for endless retries. Example: `3`. | `UInt?` | no | - | active |
+| `traces.request-retries.timeout` | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. | `Duration?` | no | - | active |
+| `traces.request-timeout` | Timeout for each traces generator request. Omit to disable the timeout. Example: `PT30S`. | `Duration?` | no | - | active |
+| `traces.switch-block-number-inclusive` | Inclusive L2 block number at which to switch from this traces config to the `new` one. Example: `1000000`. | `UInt?` | no | - | active |
 
 ### `type2-state-proof-provider`
 
 Type-2 state proof provider (shnarf/state proof) settings.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `type2-state-proof-provider.disabled` | `Boolean` | no | `false` | active | Whether the type-2 state proof provider is disabled. |
-| `type2-state-proof-provider.endpoints` | `List<URL>` | yes | - | active | Type-2 state proof provider JSON-RPC endpoints. Example: `["http://shomei-frontend:8888"]`. |
-| `type2-state-proof-provider.l1-polling-interval` | `Duration` | no | `PT6S` | active | Interval between L1 polls for state proof updates. |
-| `type2-state-proof-provider.l1-query-block-tag` | `Tag` | no | `FINALIZED` | active | L1 block tag queried for state proofs (e.g. FINALIZED, LATEST). |
-| `type2-state-proof-provider.request-retries.backoff-delay` | `Duration` | no | `PT1S` | active | Delay between retry attempts. Example: `PT1S`. |
-| `type2-state-proof-provider.request-retries.failures-warning-threshold` | `UInt?` | no | - | active | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. |
-| `type2-state-proof-provider.request-retries.ignore-first-exceptions-until-time-elapsed` | `Duration?` | no | - | active | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. |
-| `type2-state-proof-provider.request-retries.max-retries` | `UInt?` | no | - | active | Maximum number of retry attempts. Omit for endless retries. Example: `3`. |
-| `type2-state-proof-provider.request-retries.timeout` | `Duration?` | no | - | active | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. |
+| `type2-state-proof-provider.disabled` | Whether the type-2 state proof provider is disabled. | `Boolean` | no | `false` | active |
+| `type2-state-proof-provider.endpoints` | Type-2 state proof provider JSON-RPC endpoints. Example: `["http://shomei-frontend:8888"]`. | `List<URL>` | yes | - | active |
+| `type2-state-proof-provider.l1-polling-interval` | Interval between L1 polls for state proof updates. | `Duration` | no | `PT6S` | active |
+| `type2-state-proof-provider.l1-query-block-tag` | L1 block tag queried for state proofs (e.g. FINALIZED, LATEST). | `Tag` | no | `FINALIZED` | active |
+| `type2-state-proof-provider.request-retries.backoff-delay` | Delay between retry attempts. Example: `PT1S`. | `Duration` | no | `PT1S` | active |
+| `type2-state-proof-provider.request-retries.failures-warning-threshold` | Number of consecutive failures after which warning logs start being emitted. Omit to use the default threshold. Example: `3`. | `UInt?` | no | - | active |
+| `type2-state-proof-provider.request-retries.ignore-first-exceptions-until-time-elapsed` | Grace period during which initial failures are ignored (not logged/counted) before retries are treated as errors. Omit to disable. Example: `PT5S`. | `Duration?` | no | - | active |
+| `type2-state-proof-provider.request-retries.max-retries` | Maximum number of retry attempts. Omit for endless retries. Example: `3`. | `UInt?` | no | - | active |
+| `type2-state-proof-provider.request-retries.timeout` | Overall timeout across all retry attempts. Omit to disable the timeout. Example: `PT10S`. | `Duration?` | no | - | active |
 
 ## traces-limits-v4
 
 Per-module trace counter limits for v4 tracing modules.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `traces-limits` | `Map<TracingModuleV4, UInt>` | yes | - | active | Per-module trace counter limits (v4 tracing modules). Each entry maps a tracing module name to its maximum trace count. |
+| `traces-limits` | Per-module trace counter limits (v4 tracing modules). Each entry maps a tracing module name to its maximum trace count. | `Map<TracingModuleV4, UInt>` | yes | - | active |
 
 ## traces-limits-v5
 
 Per-module trace counter limits for v5 tracing modules.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `traces-limits` | `Map<TracingModuleV5, UInt>` | yes | - | active | Per-module trace counter limits (v5 tracing modules). Each entry maps a tracing module name to its maximum trace count. |
+| `traces-limits` | Per-module trace counter limits (v5 tracing modules). Each entry maps a tracing module name to its maximum trace count. | `Map<TracingModuleV5, UInt>` | yes | - | active |
 
 ## gas-price-cap-time-of-day-multipliers
 
 L1 dynamic gas price cap time-of-day multipliers.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `gas-price-cap-time-of-day-multipliers` | `Map<String, Double>` | yes | - | active | L1 dynamic gas price cap multipliers keyed by time-of-day/day-of-week slot; each entry scales the base gas price cap for that slot. |
+| `gas-price-cap-time-of-day-multipliers` | L1 dynamic gas price cap multipliers keyed by time-of-day/day-of-week slot; each entry scales the base gas price cap for that slot. | `Map<String, Double>` | yes | - | active |
 
 ## smart-contract-errors
 
 Mapping of Lineth smart-contract revert error codes to messages.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `smart-contract-errors` | `Map<String, String>` | yes | - | active | Mapping of Lineth smart-contract revert error codes to human-readable messages, used to decode on-chain rejection reasons. |
+| `smart-contract-errors` | Mapping of Lineth smart-contract revert error codes to human-readable messages, used to decode on-chain rejection reasons. | `Map<String, String>` | yes | - | active |
 
 ## Deprecated Keys
 

--- a/docs/tech/components/maru-config-reference.md
+++ b/docs/tech/components/maru-config-reference.md
@@ -6,164 +6,164 @@
 
 Main Maru configuration.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `allow-empty-blocks` | `Boolean` | no | `false` | active | Whether empty blocks are allowed when proposing and when validating blocks (needed in multi-validator networks). |
-| `follower-engine-apis` | `Map<String, ApiEndpointDto>?` | no | - | active | Named map of follower execution-layer endpoints. Each entry maps a follower name to its engine API endpoint settings. |
+| `allow-empty-blocks` | Whether empty blocks are allowed when proposing and when validating blocks (needed in multi-validator networks). | `Boolean` | no | `false` | active |
+| `follower-engine-apis` | Named map of follower execution-layer endpoints. Each entry maps a follower name to its engine API endpoint settings. | `Map<String, ApiEndpointDto>?` | no | - | active |
 
 ### `api`
 
 Maru JSON-RPC API settings.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `api.port` | `UInt` | no | `5060` | active | Port serving the Maru JSON-RPC API. |
+| `api.port` | Port serving the Maru JSON-RPC API. | `UInt` | no | `5060` | active |
 
 ### `defaults`
 
 Shared defaults reused by linea and fork-transition; currently provides the L2 endpoint.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `defaults.l2-eth-endpoint.endpoint` | `URL` | yes | - | active | Engine API endpoint URL of the execution-layer node. Example: `http://el-node:8551`. |
-| `defaults.l2-eth-endpoint.jwt-secret-path` | `String?` | no | - | active | Optional path to the JWT secret file used for authenticated Engine API calls. Omit to disable JWT authentication. Example: `/jwt.hex`. |
-| `defaults.l2-eth-endpoint.timeout` | `Duration` | no | `PT1M` | active | Overall timeout for a single request to this endpoint. |
+| `defaults.l2-eth-endpoint.endpoint` | Engine API endpoint URL of the execution-layer node. Example: `http://el-node:8551`. | `URL` | yes | - | active |
+| `defaults.l2-eth-endpoint.jwt-secret-path` | Optional path to the JWT secret file used for authenticated Engine API calls. Omit to disable JWT authentication. Example: `/jwt.hex`. | `String?` | no | - | active |
+| `defaults.l2-eth-endpoint.timeout` | Overall timeout for a single request to this endpoint. | `Duration` | no | `PT1M` | active |
 
 ### `fork-transition`
 
 Protocol fork transition monitoring settings. Has defaults so the section may be omitted.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `fork-transition.l2-eth-api-endpoint.endpoint` | `URL` | yes | - | active | Engine API endpoint URL of the execution-layer node. Example: `http://el-node:8551`. |
-| `fork-transition.l2-eth-api-endpoint.jwt-secret-path` | `String?` | no | - | active | Optional path to the JWT secret file used for authenticated Engine API calls. Omit to disable JWT authentication. Example: `/jwt.hex`. |
-| `fork-transition.l2-eth-api-endpoint.timeout` | `Duration` | no | `PT1M` | active | Overall timeout for a single request to this endpoint. |
-| `fork-transition.protocol-transition-polling-interval` | `Duration` | no | `PT1S` | active | Interval between polls for the protocol fork transition. |
+| `fork-transition.l2-eth-api-endpoint.endpoint` | Engine API endpoint URL of the execution-layer node. Example: `http://el-node:8551`. | `URL` | yes | - | active |
+| `fork-transition.l2-eth-api-endpoint.jwt-secret-path` | Optional path to the JWT secret file used for authenticated Engine API calls. Omit to disable JWT authentication. Example: `/jwt.hex`. | `String?` | no | - | active |
+| `fork-transition.l2-eth-api-endpoint.timeout` | Overall timeout for a single request to this endpoint. | `Duration` | no | `PT1M` | active |
+| `fork-transition.protocol-transition-polling-interval` | Interval between polls for the protocol fork transition. | `Duration` | no | `PT1S` | active |
 
 ### `linea`
 
 Linea-specific settings (L1/L2 endpoints, contract address). Omit on non-Linea networks. l1-eth-api is a deprecated alias of l1-eth-api-endpoint; set one of the two. l2-eth-api-endpoint falls back to defaults.l2-eth-endpoint when omitted.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `linea.contract-address` | `ByteArray` | yes | - | active | Address of the Linea rollup contract on L1 (20-byte hex). Example: `0x0000000000000000000000000000000000000000`. |
-| `linea.l1-eth-api-endpoint.endpoint` | `URL` | yes | - | active | Engine API endpoint URL of the execution-layer node. Example: `http://el-node:8551`. |
-| `linea.l1-eth-api-endpoint.jwt-secret-path` | `String?` | no | - | active | Optional path to the JWT secret file used for authenticated Engine API calls. Omit to disable JWT authentication. Example: `/jwt.hex`. |
-| `linea.l1-eth-api-endpoint.timeout` | `Duration` | no | `PT1M` | active | Overall timeout for a single request to this endpoint. |
-| `linea.l1-eth-api.endpoint` | `URL` | yes | - | deprecated | Engine API endpoint URL of the execution-layer node. Example: `http://el-node:8551`. |
-| `linea.l1-eth-api.jwt-secret-path` | `String?` | no | - | deprecated | Optional path to the JWT secret file used for authenticated Engine API calls. Omit to disable JWT authentication. Example: `/jwt.hex`. |
-| `linea.l1-eth-api.timeout` | `Duration` | no | `PT1M` | deprecated | Overall timeout for a single request to this endpoint. |
-| `linea.l1-highest-block-tag` | `String` | no | `finalized` | active | L1 block tag treated as the highest finalized block (e.g. finalized, safe, latest). |
-| `linea.l1-polling-interval` | `Duration` | no | `PT6S` | active | Interval between L1 polls for rollup contract events. |
-| `linea.l2-eth-api-endpoint.endpoint` | `URL` | yes | - | active | Engine API endpoint URL of the execution-layer node. Example: `http://el-node:8551`. |
-| `linea.l2-eth-api-endpoint.jwt-secret-path` | `String?` | no | - | active | Optional path to the JWT secret file used for authenticated Engine API calls. Omit to disable JWT authentication. Example: `/jwt.hex`. |
-| `linea.l2-eth-api-endpoint.timeout` | `Duration` | no | `PT1M` | active | Overall timeout for a single request to this endpoint. |
+| `linea.contract-address` | Address of the Linea rollup contract on L1 (20-byte hex). Example: `0x0000000000000000000000000000000000000000`. | `ByteArray` | yes | - | active |
+| `linea.l1-eth-api-endpoint.endpoint` | Engine API endpoint URL of the execution-layer node. Example: `http://el-node:8551`. | `URL` | yes | - | active |
+| `linea.l1-eth-api-endpoint.jwt-secret-path` | Optional path to the JWT secret file used for authenticated Engine API calls. Omit to disable JWT authentication. Example: `/jwt.hex`. | `String?` | no | - | active |
+| `linea.l1-eth-api-endpoint.timeout` | Overall timeout for a single request to this endpoint. | `Duration` | no | `PT1M` | active |
+| `linea.l1-eth-api.endpoint` | Engine API endpoint URL of the execution-layer node. Example: `http://el-node:8551`. | `URL` | yes | - | deprecated |
+| `linea.l1-eth-api.jwt-secret-path` | Optional path to the JWT secret file used for authenticated Engine API calls. Omit to disable JWT authentication. Example: `/jwt.hex`. | `String?` | no | - | deprecated |
+| `linea.l1-eth-api.timeout` | Overall timeout for a single request to this endpoint. | `Duration` | no | `PT1M` | deprecated |
+| `linea.l1-highest-block-tag` | L1 block tag treated as the highest finalized block (e.g. finalized, safe, latest). | `String` | no | `finalized` | active |
+| `linea.l1-polling-interval` | Interval between L1 polls for rollup contract events. | `Duration` | no | `PT6S` | active |
+| `linea.l2-eth-api-endpoint.endpoint` | Engine API endpoint URL of the execution-layer node. Example: `http://el-node:8551`. | `URL` | yes | - | active |
+| `linea.l2-eth-api-endpoint.jwt-secret-path` | Optional path to the JWT secret file used for authenticated Engine API calls. Omit to disable JWT authentication. Example: `/jwt.hex`. | `String?` | no | - | active |
+| `linea.l2-eth-api-endpoint.timeout` | Overall timeout for a single request to this endpoint. | `Duration` | no | `PT1M` | active |
 
 ### `observability`
 
 Observability (metrics, health) settings.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `observability.jvm-metrics-enabled` | `Boolean` | no | `true` | active | Whether JVM-level metrics are exposed in addition to application metrics. |
-| `observability.port` | `UInt` | no | `9545` | active | Port serving observability endpoints (metrics, health). |
-| `observability.prometheus-metrics-enabled` | `Boolean` | no | `true` | active | Whether Prometheus metrics are exposed on the observability port. |
+| `observability.jvm-metrics-enabled` | Whether JVM-level metrics are exposed in addition to application metrics. | `Boolean` | no | `true` | active |
+| `observability.port` | Port serving observability endpoints (metrics, health). | `UInt` | no | `9545` | active |
+| `observability.prometheus-metrics-enabled` | Whether Prometheus metrics are exposed on the observability port. | `Boolean` | no | `true` | active |
 
 ### `p2p`
 
 P2P networking settings. Omit to disable P2P.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `p2p.discovery.advertised-ip` | `String?` | no | - | active | IP address advertised to peers for discovery. Omit to use the listen IP address. |
-| `p2p.discovery.bootnodes` | `List<String>` | no | - | active | Bootnode addresses (enodes) used to bootstrap discovery. |
-| `p2p.discovery.port` | `UInt` | no | `9000` | active | UDP port used for discovery. |
-| `p2p.discovery.refresh-interval` | `Duration` | yes | - | active | Interval between discovery table refresh cycles. |
-| `p2p.discovery.retry-timeout` | `Duration` | no | `PT10S` | active | Timeout before retrying a failed discovery request. |
-| `p2p.discovery.search-interval` | `Duration` | no | `PT1S` | active | Interval between discovery search runs. |
-| `p2p.discovery.search-timeout` | `Duration` | no | `PT30S` | active | Timeout for a single discovery search run. |
-| `p2p.gossiping.consider-peers-as-direct` | `Boolean` | no | `false` | active | Whether all peers are scored as direct peers (same as static peers) in gossip peer scoring (libp2p GossipPeerScoreParams.isDirect). |
-| `p2p.gossiping.d` | `Int` | no | `8` | active | Target mesh degree (number of peers each topic is gossiped to). |
-| `p2p.gossiping.d-high` | `Int` | no | `16` | active | Upper bound on the mesh degree; peers are pruned when the mesh exceeds this. Defaults to 2 * d. |
-| `p2p.gossiping.d-lazy` | `Int` | no | `6` | active | Degree of lazy (non-mesh) peers used for gossip amplification. |
-| `p2p.gossiping.d-low` | `Int` | no | `6` | active | Lower bound on the mesh degree; peers are added when the mesh drops below this. |
-| `p2p.gossiping.fanout-ttl` | `Duration` | no | `PT1M` | active | Time-to-live for gossip fanout messages sent to peers outside the mesh. |
-| `p2p.gossiping.flood-publish-max-message-size-threshold` | `Int` | no | `16384` | active | Maximum message size above which flood publishing is skipped. Defaults to 16KiB. |
-| `p2p.gossiping.gossip-factor` | `Double` | no | `0.25` | active | Fraction of non-mesh peers that receive gossip messages (libp2p gossipFactor). |
-| `p2p.gossiping.gossip-size` | `Int` | no | `3` | active | Number of history windows advertised via IHAVE messages (libp2p gossipSize). |
-| `p2p.gossiping.heartbeat-interval` | `Duration` | no | `PT0.7S` | active | Interval between gossipsub heartbeat rounds. |
-| `p2p.gossiping.history` | `Int` | no | `6` | active | Number of gossip history windows retained in the message cache (libp2p gossipHistoryLength). |
-| `p2p.gossiping.seen-ttl` | `Duration` | no | `PT780.5S` | active | Time-to-live for the seen-message cache. Defaults to 700ms * 1115. |
-| `p2p.ip-address` | `String` | no | `127.0.0.1` | active | IP address the node listens on for P2P traffic. Defaults to localhost for security. |
-| `p2p.max-peers` | `Int` | no | `25` | active | Maximum number of peers the node maintains. |
-| `p2p.peering-fork-mismatch-leeway-time` | `Duration` | no | `PT20S` | active | Leeway time during which a peer is tolerated despite a fork mismatch before being penalized. |
-| `p2p.port` | `UInt` | no | `9000` | active | TCP port the node listens on for P2P traffic. UDP discovery uses p2p.discovery.port. |
-| `p2p.reconnect-delay` | `Duration` | no | `PT5S` | active | Delay before reconnecting to a dropped peer. |
-| `p2p.reputation.ban-period` | `Duration` | no | `PT1H` | active | Duration a peer is banned after dropping below the disconnect threshold. |
-| `p2p.reputation.capacity` | `Int` | no | `1024` | active | Maximum number of peers tracked in the reputation table. |
-| `p2p.reputation.cooldown-period` | `Duration` | no | `PT2M` | active | Duration a peer's reputation is held before decaying after a change. |
-| `p2p.reputation.disconnect-score-threshold` | `Int` | no | `-10` | active | Reputation score below which a peer is disconnected. Defaults to -large-change. |
-| `p2p.reputation.large-change` | `Int` | no | `10` | active | Reputation score delta applied for a large positive/negative event. |
-| `p2p.reputation.max-reputation` | `Int` | no | `20` | active | Maximum reputation score a peer can reach. Defaults to 2 * large-change. |
-| `p2p.reputation.small-change` | `Int` | no | `3` | active | Reputation score delta applied for a small positive/negative event. |
-| `p2p.static-peers` | `List<String>` | no | - | active | Static peer addresses (enodes) the node stays connected to. |
-| `p2p.status-update.refresh-interval` | `Duration` | no | `PT30S` | active | Interval between peer status refreshes. |
-| `p2p.status-update.refresh-interval-leeway` | `Duration` | no | `PT5S` | active | Leeway applied to the peer status refresh interval. |
-| `p2p.status-update.timeout` | `Duration` | no | `PT10S` | active | Timeout for a single peer status update request. |
+| `p2p.discovery.advertised-ip` | IP address advertised to peers for discovery. Omit to use the listen IP address. | `String?` | no | - | active |
+| `p2p.discovery.bootnodes` | Bootnode addresses (enodes) used to bootstrap discovery. | `List<String>` | no | - | active |
+| `p2p.discovery.port` | UDP port used for discovery. | `UInt` | no | `9000` | active |
+| `p2p.discovery.refresh-interval` | Interval between discovery table refresh cycles. | `Duration` | yes | - | active |
+| `p2p.discovery.retry-timeout` | Timeout before retrying a failed discovery request. | `Duration` | no | `PT10S` | active |
+| `p2p.discovery.search-interval` | Interval between discovery search runs. | `Duration` | no | `PT1S` | active |
+| `p2p.discovery.search-timeout` | Timeout for a single discovery search run. | `Duration` | no | `PT30S` | active |
+| `p2p.gossiping.consider-peers-as-direct` | Whether all peers are scored as direct peers (same as static peers) in gossip peer scoring (libp2p GossipPeerScoreParams.isDirect). | `Boolean` | no | `false` | active |
+| `p2p.gossiping.d` | Target mesh degree (number of peers each topic is gossiped to). | `Int` | no | `8` | active |
+| `p2p.gossiping.d-high` | Upper bound on the mesh degree; peers are pruned when the mesh exceeds this. Defaults to 2 * d. | `Int` | no | `16` | active |
+| `p2p.gossiping.d-lazy` | Degree of lazy (non-mesh) peers used for gossip amplification. | `Int` | no | `6` | active |
+| `p2p.gossiping.d-low` | Lower bound on the mesh degree; peers are added when the mesh drops below this. | `Int` | no | `6` | active |
+| `p2p.gossiping.fanout-ttl` | Time-to-live for gossip fanout messages sent to peers outside the mesh. | `Duration` | no | `PT1M` | active |
+| `p2p.gossiping.flood-publish-max-message-size-threshold` | Maximum message size above which flood publishing is skipped. Defaults to 16KiB. | `Int` | no | `16384` | active |
+| `p2p.gossiping.gossip-factor` | Fraction of non-mesh peers that receive gossip messages (libp2p gossipFactor). | `Double` | no | `0.25` | active |
+| `p2p.gossiping.gossip-size` | Number of history windows advertised via IHAVE messages (libp2p gossipSize). | `Int` | no | `3` | active |
+| `p2p.gossiping.heartbeat-interval` | Interval between gossipsub heartbeat rounds. | `Duration` | no | `PT0.7S` | active |
+| `p2p.gossiping.history` | Number of gossip history windows retained in the message cache (libp2p gossipHistoryLength). | `Int` | no | `6` | active |
+| `p2p.gossiping.seen-ttl` | Time-to-live for the seen-message cache. Defaults to 700ms * 1115. | `Duration` | no | `PT780.5S` | active |
+| `p2p.ip-address` | IP address the node listens on for P2P traffic. Defaults to localhost for security. | `String` | no | `127.0.0.1` | active |
+| `p2p.max-peers` | Maximum number of peers the node maintains. | `Int` | no | `25` | active |
+| `p2p.peering-fork-mismatch-leeway-time` | Leeway time during which a peer is tolerated despite a fork mismatch before being penalized. | `Duration` | no | `PT20S` | active |
+| `p2p.port` | TCP port the node listens on for P2P traffic. UDP discovery uses p2p.discovery.port. | `UInt` | no | `9000` | active |
+| `p2p.reconnect-delay` | Delay before reconnecting to a dropped peer. | `Duration` | no | `PT5S` | active |
+| `p2p.reputation.ban-period` | Duration a peer is banned after dropping below the disconnect threshold. | `Duration` | no | `PT1H` | active |
+| `p2p.reputation.capacity` | Maximum number of peers tracked in the reputation table. | `Int` | no | `1024` | active |
+| `p2p.reputation.cooldown-period` | Duration a peer's reputation is held before decaying after a change. | `Duration` | no | `PT2M` | active |
+| `p2p.reputation.disconnect-score-threshold` | Reputation score below which a peer is disconnected. Defaults to -large-change. | `Int` | no | `-10` | active |
+| `p2p.reputation.large-change` | Reputation score delta applied for a large positive/negative event. | `Int` | no | `10` | active |
+| `p2p.reputation.max-reputation` | Maximum reputation score a peer can reach. Defaults to 2 * large-change. | `Int` | no | `20` | active |
+| `p2p.reputation.small-change` | Reputation score delta applied for a small positive/negative event. | `Int` | no | `3` | active |
+| `p2p.static-peers` | Static peer addresses (enodes) the node stays connected to. | `List<String>` | no | - | active |
+| `p2p.status-update.refresh-interval` | Interval between peer status refreshes. | `Duration` | no | `PT30S` | active |
+| `p2p.status-update.refresh-interval-leeway` | Leeway applied to the peer status refresh interval. | `Duration` | no | `PT5S` | active |
+| `p2p.status-update.timeout` | Timeout for a single peer status update request. | `Duration` | no | `PT10S` | active |
 
 ### `payload-validator`
 
 Validator execution-layer node settings. Required when qbft is set.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `payload-validator.engine-api-endpoint.endpoint` | `URL` | yes | - | active | Engine API endpoint URL of the execution-layer node. Example: `http://el-node:8551`. |
-| `payload-validator.engine-api-endpoint.jwt-secret-path` | `String?` | no | - | active | Optional path to the JWT secret file used for authenticated Engine API calls. Omit to disable JWT authentication. Example: `/jwt.hex`. |
-| `payload-validator.engine-api-endpoint.timeout` | `Duration` | no | `PT1M` | active | Overall timeout for a single request to this endpoint. |
-| `payload-validator.payload-validation-enabled` | `Boolean` | no | `true` | active | Whether to validate execution payloads received via the Engine API. Must stay true when the qbft section is set: a validator fails to start with payload validation disabled. Only followers may set it to false. |
+| `payload-validator.engine-api-endpoint.endpoint` | Engine API endpoint URL of the execution-layer node. Example: `http://el-node:8551`. | `URL` | yes | - | active |
+| `payload-validator.engine-api-endpoint.jwt-secret-path` | Optional path to the JWT secret file used for authenticated Engine API calls. Omit to disable JWT authentication. Example: `/jwt.hex`. | `String?` | no | - | active |
+| `payload-validator.engine-api-endpoint.timeout` | Overall timeout for a single request to this endpoint. | `Duration` | no | `PT1M` | active |
+| `payload-validator.payload-validation-enabled` | Whether to validate execution payloads received via the Engine API. Must stay true when the qbft section is set: a validator fails to start with payload validation disabled. Only followers may set it to false. | `Boolean` | no | `true` | active |
 
 ### `persistence`
 
 Persistent on-disk state settings.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `persistence.data-path` | `Path` | yes | - | active | Directory where Maru stores its persistent on-disk state (database, keystore). Example: `/data/maru`. |
-| `persistence.private-key-path` | `Path` | no | `data-path/private-key` | active | Path to the node private key file. Defaults to a 'private-key' file under data-path. |
+| `persistence.data-path` | Directory where Maru stores its persistent on-disk state (database, keystore). Example: `/data/maru`. | `Path` | yes | - | active |
+| `persistence.private-key-path` | Path to the node private key file. Defaults to a 'private-key' file under data-path. | `Path` | no | `data-path/private-key` | active |
 
 ### `qbft`
 
 QBFT consensus settings. Omit on follower (non-validator) nodes.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `qbft.duplicate-message-limit` | `Int` | no | `100` | active | Maximum number of duplicate QBFT messages kept per round. |
-| `qbft.fee-recipient` | `ByteArray` | yes | - | active | Fee recipient address for blocks proposed by this validator (20-byte hex). Example: `0x0000000000000000000000000000000000000000`. |
-| `qbft.future-message-max-distance` | `Long` | no | `10` | active | Maximum number of blocks a future-dated QBFT message may be ahead of the current height. |
-| `qbft.future-messages-limit` | `Long` | no | `1000` | active | Maximum number of future-dated QBFT messages queued. |
-| `qbft.message-queue-limit` | `Int` | no | `1000` | active | Maximum number of QBFT messages queued per round. |
-| `qbft.min-block-build-time` | `Duration` | no | `PT0.5S` | active | Minimum time spent building a block before proposing it. |
-| `qbft.round-expiry` | `Duration?` | no | - | active | Optional fixed expiry duration for a QBFT round. Omit to derive it from round-expiry-coefficient. |
-| `qbft.round-expiry-coefficient` | `Double` | no | `2.0` | active | Multiplier used to derive each subsequent round's expiry from the previous one. |
-| `qbft.signer-name` | `String?` | no | - | active | Logical signer name passed to the external signer factory when signer-type is 'custom'. |
-| `qbft.signer-type` | `String` | no | `local` | active | Validator signing backend. Use 'local' for the node private key or 'custom' for an external signer. |
+| `qbft.duplicate-message-limit` | Maximum number of duplicate QBFT messages kept per round. | `Int` | no | `100` | active |
+| `qbft.fee-recipient` | Fee recipient address for blocks proposed by this validator (20-byte hex). Example: `0x0000000000000000000000000000000000000000`. | `ByteArray` | yes | - | active |
+| `qbft.future-message-max-distance` | Maximum number of blocks a future-dated QBFT message may be ahead of the current height. | `Long` | no | `10` | active |
+| `qbft.future-messages-limit` | Maximum number of future-dated QBFT messages queued. | `Long` | no | `1000` | active |
+| `qbft.message-queue-limit` | Maximum number of QBFT messages queued per round. | `Int` | no | `1000` | active |
+| `qbft.min-block-build-time` | Minimum time spent building a block before proposing it. | `Duration` | no | `PT0.5S` | active |
+| `qbft.round-expiry` | Optional fixed expiry duration for a QBFT round. Omit to derive it from round-expiry-coefficient. | `Duration?` | no | - | active |
+| `qbft.round-expiry-coefficient` | Multiplier used to derive each subsequent round's expiry from the previous one. | `Double` | no | `2.0` | active |
+| `qbft.signer-name` | Logical signer name passed to the external signer factory when signer-type is 'custom'. | `String?` | no | - | active |
+| `qbft.signer-type` | Validator signing backend. Use 'local' for the node private key or 'custom' for an external signer. | `String` | no | `local` | active |
 
 ### `syncing`
 
 Sync settings used while catching up to the chain head.
 
-| Key | Type | Required | Default | Status | Description |
+| Key | Description | Type | Required | Default | Status |
 | --- | --- | --- | --- | --- | --- |
-| `syncing.desync-tolerance` | `ULong` | no | `5` | active | How far the sync target may be ahead of this node's head before the node is considered desynced. |
-| `syncing.download.backoff-delay` | `Duration` | no | `PT1S` | active | Backoff delay between download retries. |
-| `syncing.download.block-range-request-timeout` | `Duration` | no | `PT5S` | active | Timeout for a single block-range download request. |
-| `syncing.download.blocks-batch-size` | `UInt` | no | `100` | active | Number of blocks requested in a single download batch. |
-| `syncing.download.blocks-parallelism` | `UInt` | no | `1` | active | Number of block-range download requests issued in parallel. |
-| `syncing.download.max-retries` | `UInt` | no | `5` | active | Maximum number of retries for a failed download request. |
-| `syncing.download.use-unconditional-random-download-peer` | `Boolean` | no | `false` | active | When false (default), pick a random peer among those whose latest reported block is at least the download range end. When true, skip that end-block filter and pick any peer at random. |
-| `syncing.el-sync-status-refresh-interval` | `Duration?` | no | - | active | Optional interval to refresh the execution-layer sync status. Omit to disable. |
-| `syncing.peer-chain-height-polling-interval` | `Duration` | yes | - | active | Interval between polls for peer chain height updates. |
-| `syncing.sync-target-selection` | `SyncTargetSelection` | yes | - | active | Sync target selection strategy. Use a bare string 'Highest' to sync to the highest peer head, or an inline table { _type = 'MostFrequent', peer-chain-height-granularity = <n> } to sync to the most frequent peer chain height. Sealed-type dispatch is enabled by the loader. |
+| `syncing.desync-tolerance` | How far the sync target may be ahead of this node's head before the node is considered desynced. | `ULong` | no | `5` | active |
+| `syncing.download.backoff-delay` | Backoff delay between download retries. | `Duration` | no | `PT1S` | active |
+| `syncing.download.block-range-request-timeout` | Timeout for a single block-range download request. | `Duration` | no | `PT5S` | active |
+| `syncing.download.blocks-batch-size` | Number of blocks requested in a single download batch. | `UInt` | no | `100` | active |
+| `syncing.download.blocks-parallelism` | Number of block-range download requests issued in parallel. | `UInt` | no | `1` | active |
+| `syncing.download.max-retries` | Maximum number of retries for a failed download request. | `UInt` | no | `5` | active |
+| `syncing.download.use-unconditional-random-download-peer` | When false (default), pick a random peer among those whose latest reported block is at least the download range end. When true, skip that end-block filter and pick any peer at random. | `Boolean` | no | `false` | active |
+| `syncing.el-sync-status-refresh-interval` | Optional interval to refresh the execution-layer sync status. Omit to disable. | `Duration?` | no | - | active |
+| `syncing.peer-chain-height-polling-interval` | Interval between polls for peer chain height updates. | `Duration` | yes | - | active |
+| `syncing.sync-target-selection` | Sync target selection strategy. Use a bare string 'Highest' to sync to the highest peer head, or an inline table { _type = 'MostFrequent', peer-chain-height-granularity = <n> } to sync to the most frequent peer chain height. Sealed-type dispatch is enabled by the loader. | `SyncTargetSelection` | yes | - | active |
 
 ## Deprecated Keys
 

--- a/jvm-libs/linea/config-docs/src/main/kotlin/linea/config/docs/ConfigDocMarkdownGenerator.kt
+++ b/jvm-libs/linea/config-docs/src/main/kotlin/linea/config/docs/ConfigDocMarkdownGenerator.kt
@@ -75,13 +75,12 @@ object ConfigDocMarkdownGenerator {
   }
 
   private fun appendTable(sb: StringBuilder, leaves: List<ConfigKey>) {
-    sb.appendLine("| Key | Type | Required | Default | Status | Description |")
+    sb.appendLine("| Key | Description | Type | Required | Default | Status |")
     sb.appendLine("| --- | --- | --- | --- | --- | --- |")
     for (key in leaves) {
       sb.appendLine(
-        "| `${key.path}` | `${key.type}` | ${if (key.required) "yes" else "no"} " +
-          "| ${key.default?.let { "`$it`" } ?: "-"} | ${if (key.deprecated) "deprecated" else "active"} " +
-          "| ${describe(key)} |",
+        "| `${key.path}` | ${describe(key)} | `${key.type}` | ${if (key.required) "yes" else "no"} " +
+          "| ${key.default?.let { "`$it`" } ?: "-"} | ${if (key.deprecated) "deprecated" else "active"} |",
       )
     }
   }

--- a/jvm-libs/linea/config-docs/src/main/kotlin/linea/config/docs/ConfigDocMdxGenerator.kt
+++ b/jvm-libs/linea/config-docs/src/main/kotlin/linea/config/docs/ConfigDocMdxGenerator.kt
@@ -78,15 +78,15 @@ object ConfigDocMdxGenerator {
   }
 
   private fun appendTable(sb: StringBuilder, leaves: List<ConfigKey>) {
-    sb.appendLine("| Key | Type | Required | Default | Status | Description |")
+    sb.appendLine("| Key | Description | Type | Required | Default | Status |")
     sb.appendLine("| --- | --- | --- | --- | --- | --- |")
     for (key in leaves) {
       sb.appendLine(
-        "| `${escapeInlineCode(key.path)}` | `${escapeInlineCode(key.type)}` " +
+        "| `${escapeInlineCode(key.path)}` | ${describe(key)} " +
+          "| `${escapeInlineCode(key.type)}` " +
           "| ${if (key.required) "yes" else "no"} " +
           "| ${key.default?.let { "`" + escapeInlineCode(it) + "`" } ?: "-"} " +
-          "| ${if (key.deprecated) "deprecated" else "active"} " +
-          "| ${describe(key)} |",
+          "| ${if (key.deprecated) "deprecated" else "active"} |",
       )
     }
   }

--- a/jvm-libs/linea/config-docs/src/test/kotlin/linea/config/docs/ConfigDocGeneratorsTest.kt
+++ b/jvm-libs/linea/config-docs/src/test/kotlin/linea/config/docs/ConfigDocGeneratorsTest.kt
@@ -52,7 +52,7 @@ class ConfigDocGeneratorsTest {
     assertThat(md).contains("Do not edit by hand")
     assertThat(md).contains("## sample")
     assertThat(md).contains("### `nested`")
-    assertThat(md).contains("| `nested.max-attempts` | `UInt` | no | `3` | active | Max attempts. |")
+    assertThat(md).contains("| `nested.max-attempts` | Max attempts. | `UInt` | no | `3` | active |")
     assertThat(md).contains("The hostname. Example: `localhost`.")
     assertThat(md).contains("| File | Key | Replacement | Description |")
     assertThat(md).contains("| sample | `legacy-gas` | `port` | Legacy gas. |")

--- a/jvm-libs/linea/config-docs/src/test/kotlin/linea/config/docs/ConfigDocMdxGeneratorTest.kt
+++ b/jvm-libs/linea/config-docs/src/test/kotlin/linea/config/docs/ConfigDocMdxGeneratorTest.kt
@@ -37,7 +37,7 @@ class ConfigDocMdxGeneratorTest {
     val mdx = ConfigDocMdxGenerator.generate(files, detector, "./gradlew generateDocs")
     assertThat(mdx).contains("## sample")
     assertThat(mdx).contains("### `nested`")
-    assertThat(mdx).contains("| `nested.max-attempts` | `UInt` | no | `3` | active | Max attempts. |")
+    assertThat(mdx).contains("| `nested.max-attempts` | Max attempts. | `UInt` | no | `3` | active |")
     assertThat(mdx).contains("The hostname. Example: `localhost`.")
   }
 
@@ -68,7 +68,7 @@ class ConfigDocMdxGeneratorTest {
       detector,
       "cmd",
     )
-    assertThat(mdx).contains("| `value` | `String` | no | `a&#96;b` | active | A value. |")
+    assertThat(mdx).contains("| `value` | A value. | `String` | no | `a&#96;b` | active |")
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Reorder config reference tables so Description is the 2nd column (Key | Description | Type | Required | Default | Status), matching the Prover / Besu plugin options pages. On small screens the description was hidden because it was the last column.
- Updates both ConfigDocMarkdownGenerator and ConfigDocMdxGenerator, regenerates committed maru/coordinator reference markdown, and updates generator tests.

Ref: https://docs.linea.build/reference/component-configuration/linea-maru-options

## Test plan
- [ ] ./gradlew :jvm-libs:linea:config-docs:test passes
- [ ] ./gradlew :maru:config:generateConfigDocs :coordinator:app:generateConfigDocs produces no diff
- [ ] Public Maru config reference page renders Description as 2nd column after CI republishes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and doc-generator output only; no coordinator, Maru, or runtime configuration behavior changes.
> 
> **Overview**
> Reorders **generated** coordinator and Maru config reference tables so **Description** is the second column (`Key | Description | Type | Required | Default | Status`), aligning with other option pages and keeping descriptions visible on narrow viewports where the last column was clipped.
> 
> The change is in `ConfigDocMarkdownGenerator` and `ConfigDocMdxGenerator`, with committed snapshots under `docs/tech/components/` regenerated and unit tests updated for the new row shape. **`.kotlin/`** is also added to **`.gitignore`** for local Kotlin build artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcd7657e6f0418f55eb37fe2edca263bc48c876f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->