### PR TITLE
fix(ci): retarget doc.linea publishing to Consensys-Incorporated

### DIFF
--- a/.github/actions/publish-config-docs/action.yml
+++ b/.github/actions/publish-config-docs/action.yml
@@ -2,7 +2,7 @@ name: 'Publish config docs to doc.linea'
 description: >-
   Reusable publishing for any component using the shared `config-docs` engine.
   Downloads the artifact produced by `validate-config-docs`, checks out
-  `Consensys/doc.linea` with a GitHub App token, atomically swaps the component's
+  `Consensys-Incorporated/doc.linea` with a GitHub App token, atomically swaps the component's
   generated namespace into place, refuses any change that escapes the
   namespace, and opens a pull request against doc.linea's main branch.
 
@@ -11,9 +11,9 @@ description: >-
 
 inputs:
   docs-owner:
-    description: 'Owner of the target docs repository. Defaults to Consensys.'
+    description: 'Owner of the target docs repository. Defaults to Consensys-Incorporated.'
     required: false
-    default: 'Consensys'
+    default: 'Consensys-Incorporated'
   docs-repo-name:
     description: 'Name of the target docs repository. Defaults to doc.linea.'
     required: false

--- a/.github/workflows/besu-plugin-options-docs.yml
+++ b/.github/workflows/besu-plugin-options-docs.yml
@@ -1,7 +1,7 @@
 name: "Besu plugin options docs"
 
 # Extracts Linea-Besu plugin options with Java reflection, renders ephemeral MDX,
-# and publishes only docs/stack/reference/_generated/besu/ to Consensys/doc.linea.
+# and publishes only docs/stack/reference/_generated/besu/ to Consensys-Incorporated/doc.linea.
 
 permissions:
   contents: read
@@ -161,20 +161,20 @@ jobs:
           } > "$OUT"
           echo "Wrote $OUT"
 
-      - name: Generate App token for Consensys/doc.linea
+      - name: Generate App token for Consensys-Incorporated/doc.linea
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.DOC_LINEA_PR_APP_ID }}
           private-key: ${{ secrets.DOC_LINEA_PR_PRIVATE_KEY }}
-          owner: Consensys
+          owner: Consensys-Incorporated
           repositories: |
             doc.linea
 
       - name: Checkout doc.linea
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: Consensys/doc.linea
+          repository: Consensys-Incorporated/doc.linea
           token: ${{ steps.app-token.outputs.token }}
           path: doc.linea
 

--- a/.github/workflows/coordinator-config-docs.yml
+++ b/.github/workflows/coordinator-config-docs.yml
@@ -2,7 +2,7 @@ name: "Coordinator config docs"
 
 # Generates the committed Coordinator config reference (Markdown + JSON) and an ephemeral
 # MDX partial, validates they stay in sync, and publishes only
-# docs/stack/reference/_generated/coordinator/ to Consensys/doc.linea.
+# docs/stack/reference/_generated/coordinator/ to Consensys-Incorporated/doc.linea.
 #
 # Publishing is release-gated: automatic publishing fires only when a
 # `releases/coordinator/*` tag is cut, so doc.linea always reflects a released
@@ -56,7 +56,7 @@ on:
   workflow_dispatch:
     inputs:
       publish:
-        description: "Publish generated Coordinator config docs to Consensys/doc.linea"
+        description: "Publish generated Coordinator config docs to Consensys-Incorporated/doc.linea"
         required: false
         type: boolean
         default: false

--- a/.github/workflows/maru-config-docs.yml
+++ b/.github/workflows/maru-config-docs.yml
@@ -2,7 +2,7 @@ name: "Maru config docs"
 
 # Generates the committed Maru config reference (Markdown + JSON) and an ephemeral
 # MDX partial, validates they stay in sync, and publishes only
-# docs/stack/reference/_generated/maru/ to Consensys/doc.linea.
+# docs/stack/reference/_generated/maru/ to Consensys-Incorporated/doc.linea.
 #
 # Publishing is release-gated: automatic publishing fires only when a
 # `releases/maru/*` tag is cut, so doc.linea always reflects a released
@@ -55,7 +55,7 @@ on:
   workflow_dispatch:
     inputs:
       publish:
-        description: "Publish generated Maru config docs to Consensys/doc.linea"
+        description: "Publish generated Maru config docs to Consensys-Incorporated/doc.linea"
         required: false
         type: boolean
         default: false

--- a/.github/workflows/postman-config-docs.yml
+++ b/.github/workflows/postman-config-docs.yml
@@ -1,7 +1,7 @@
 name: "Postman config docs"
 
 # Auto-generates Linea Postman env-var config MDX partials and opens a PR
-# into Consensys/doc.linea writing ONLY docs/stack/reference/_generated/postman/.
+# into Consensys-Incorporated/doc.linea writing ONLY docs/stack/reference/_generated/postman/.
 #
 # Triggers automatically when envLoader.ts, schema.ts, or the generator script
 # change on main. Can also be triggered manually via workflow_dispatch.
@@ -74,20 +74,20 @@ jobs:
           echo "Wrote $OUT"
           cat "$OUT"
 
-      - name: Generate App token for Consensys/doc.linea
+      - name: Generate App token for Consensys-Incorporated/doc.linea
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.DOC_LINEA_PR_APP_ID }}
           private-key: ${{ secrets.DOC_LINEA_PR_PRIVATE_KEY }}
-          owner: Consensys
+          owner: Consensys-Incorporated
           repositories: |
             doc.linea
 
       - name: Checkout doc.linea
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: Consensys/doc.linea
+          repository: Consensys-Incorporated/doc.linea
           token: ${{ steps.app-token.outputs.token }}
           path: doc.linea
 

--- a/.github/workflows/prover-config-docs.yml
+++ b/.github/workflows/prover-config-docs.yml
@@ -1,7 +1,7 @@
 name: "Prover config docs"
 
 # Generates public-safe Prover configuration partials for review and publishes
-# only docs/stack/reference/_generated/prover/ to Consensys/doc.linea.
+# only docs/stack/reference/_generated/prover/ to Consensys-Incorporated/doc.linea.
 
 permissions:
   contents: read
@@ -27,7 +27,7 @@ on:
   workflow_dispatch:
     inputs:
       publish:
-        description: "Publish generated Prover config docs to Consensys/doc.linea"
+        description: "Publish generated Prover config docs to Consensys-Incorporated/doc.linea"
         required: false
         type: boolean
         default: false
@@ -145,20 +145,20 @@ jobs:
             echo ""
           } > "$OUT"
 
-      - name: Generate App token for Consensys/doc.linea
+      - name: Generate App token for Consensys-Incorporated/doc.linea
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.DOC_LINEA_PR_APP_ID }}
           private-key: ${{ secrets.DOC_LINEA_PR_PRIVATE_KEY }}
-          owner: Consensys
+          owner: Consensys-Incorporated
           repositories: |
             doc.linea
 
       - name: Checkout doc.linea
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: Consensys/doc.linea
+          repository: Consensys-Incorporated/doc.linea
           token: ${{ steps.app-token.outputs.token }}
           path: doc.linea
 


### PR DESCRIPTION
## Problem

The `doc.linea` repository was transferred to a new GitHub organisation. The config-docs publish jobs still request a GitHub App installation on the old `Consensys/doc.linea` path, which no longer resolves. Token minting fails before checkout:

```
GET /repos/Consensys/doc.linea/installation -> 404 Not Found
```

This surfaced on the `Besu plugin options docs` workflow on a push to `main`. The same hardcoded owner is present in the Prover and Postman workflows, and in the shared publish action that Coordinator and Maru consume, so those will fail on their next publish for the same reason.

## Change

Retargets owner/repository from `Consensys` to `Consensys-Incorporated`:

- `.github/workflows/besu-plugin-options-docs.yml` — `owner` + `repository`
- `.github/workflows/prover-config-docs.yml` — `owner` + `repository`
- `.github/workflows/postman-config-docs.yml` — `owner` + `repository`
- `.github/actions/publish-config-docs/action.yml` — `docs-owner` default (used by Coordinator and Maru)

Comments and `workflow_dispatch` descriptions updated to match. No change to secret names, permissions, triggers, publish gating, or the namespace boundary checks.

## Verification

Publish jobs only run on push to `main` / release tags, so this cannot be exercised from a PR. After merge, re-run `Besu plugin options docs` on `main` to confirm the token step succeeds.

If it still fails on `Consensys-Incorporated/doc.linea/installation`, the App installation did not follow the repository transfer and needs to be granted on the new organisation — that is an org-settings action, separate from this PR.

Made with [Cursor](https://cursor.com)