### PR TITLE
chore(misc): increase timeout to avoid CI flakiness

### DIFF
--- a/coordinator/ethereum/message-anchoring/src/test/kotlin/lineth/anchoring/MessageAnchoringAppTest.kt
+++ b/coordinator/ethereum/message-anchoring/src/test/kotlin/lineth/anchoring/MessageAnchoringAppTest.kt
@@ -209,7 +209,7 @@ class MessageAnchoringAppTest {
 
     anchoringApp.start().get()
     await()
-      .atMost(10.seconds.toJavaDuration())
+      .atMost(20.seconds.toJavaDuration())
       .untilAsserted {
         assertThat(l2MessageService.getLastAnchoredL1MessageNumber(block = BlockParameter.Tag.LATEST).get())
           .isEqualTo(ethLogs.last().l1RollingHashUpdated.event.messageNumber)


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timeout adjustment with no runtime behavior changes.
> 
> **Overview**
> Raises the **Awaitility** wait in `should be resilient to low activity or downtimes and find messages on L1 spread apart and anchor them` from **10s to 20s** so the slow scenario (sparse L1 logs over a large block range with small search chunks and tight polling) has enough time to finish anchoring under CI load.
> 
> No production or anchoring logic changes—test timing only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f14ea4968bb7a4ea4accc349db7e85ac7f6e942. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->