### PR TITLE
feat(docker): add local RISC-V stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,38 @@ clean-environment:
 		docker volume rm linea-local-dev linea-logs || true; # ignore failure if volumes do not exist already
 		docker image prune -f || true;
 
+RISCV_COMPOSE_FILE ?= docker/compose-riscv.yml
+RISCV_COMPOSE_PROJECT ?= linea-riscv-dev
+RISCV_COMPOSE = COMPOSE_PROFILES=l1,l2,riscv docker compose \
+	--project-name $(RISCV_COMPOSE_PROJECT) \
+	--file $(RISCV_COMPOSE_FILE)
+
+.PHONY: clean-riscv-environment start-env-with-riscv
+
+clean-riscv-environment:
+	$(RISCV_COMPOSE) down --volumes --remove-orphans
+	rm -rf tmp/riscv
+
+start-env-with-riscv:
+	$(MAKE) clean-riscv-environment
+	mkdir -p \
+		tmp/riscv/prover/riscv/execution/requests \
+		tmp/riscv/prover/riscv/execution/responses
+	chmod -R a+rwX tmp/riscv/prover
+	$(MAKE) seed-deny-list
+	$(RISCV_COMPOSE) up --detach --wait --wait-timeout 600 \
+		l1-cl-node \
+		maru \
+		postgres
+	$(MAKE) deploy-contracts \
+		L1_CONTRACT_VERSION=9 \
+		LINETH_PROTOCOL_CONTRACTS_ONLY=true \
+		LINETH_L1_CONTRACT_DEPLOYMENT_TARGET=deploy-lineth-rollup-v9-stub \
+		DEPLOY_FORCED_TRANSACTION_GATEWAY=false
+	$(RISCV_COMPOSE) up --detach --wait --wait-timeout 600 \
+		riscv-proof-responder \
+		coordinator
+
 # Ensure the runtime sequencer deny-list exists (empty) before docker compose
 # bind-mounts it. Gitignored; may be mutated at test time by withDenyListAddresses.
 # Also drop any stale lockfile from a crashed previous run, otherwise every

--- a/coordinator/app/src/test/kotlin/lineth/coordinator/config/v2/LocalStackConfigsParsingTest.kt
+++ b/coordinator/app/src/test/kotlin/lineth/coordinator/config/v2/LocalStackConfigsParsingTest.kt
@@ -4,6 +4,7 @@ import lineth.coordinator.config.v2.toml.loadConfigs
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.nio.file.Path
+import kotlin.time.Instant
 
 class LocalStackConfigsParsingTest {
   @Test
@@ -26,6 +27,42 @@ class LocalStackConfigsParsingTest {
     ).also { configs ->
       // just small assertion to ensure that the configs are loaded and overridden correctly
       assertThat(configs.database.host).isEqualTo("127.0.0.1")
+    }
+  }
+
+  @Test
+  fun `should load RISC-V local stack override`() {
+    loadConfigs(
+      coordinatorConfigFiles =
+      listOf(
+        Path.of("../../docker/config/coordinator/coordinator-config-v2.toml"),
+        Path.of("../../docker/config/coordinator/coordinator-config-riscv.toml"),
+      ),
+      tracesLimitsFileV4 = Path.of("../../docker/config/common/traces-limits-v4.4.toml"),
+      tracesLimitsFileV5 = Path.of("../../docker/config/common/traces-limits-v5.toml"),
+      gasPriceCapTimeOfDayMultipliersFile = Path.of(
+        "../../docker/config/common/gas-price-cap-time-of-day-multipliers.toml",
+      ),
+      smartContractErrorsFile = Path.of("../../docker/config/common/smart-contract-errors.toml"),
+      enforceStrict = true,
+    ).also { configs ->
+      assertThat(configs.protocol.l1.contractAddress).isEqualTo("0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9")
+      assertThat(configs.conflation.blocksLimit).isEqualTo(1u)
+      assertThat(configs.conflation.riscvStartingBlockTimestampInclusive).isEqualTo(Instant.fromEpochSeconds(0))
+      assertThat(configs.conflation.proofAggregation.timestampBasedHardForks)
+        .containsExactly(Instant.fromEpochSeconds(0))
+      assertThat(configs.riscvProversConfig?.proverA?.execution?.forkName).isEqualTo("Osaka")
+      assertThat(configs.riscvProversConfig?.proverA?.execution?.requestsDirectory)
+        .isEqualTo(Path.of("/data/prover/riscv/execution/requests"))
+      assertThat(requireNotNull(configs.traces.counters).endpoints.map { it.toExternalForm() })
+        .containsExactly("http://sequencer:8545/")
+      assertThat(requireNotNull(configs.traces.conflation).endpoints.map { it.toExternalForm() })
+        .containsExactly("http://sequencer:8545/")
+      assertThat(configs.type2StateProofProvider.disabled).isTrue()
+      assertThat(configs.l1Submission.disabled).isTrue()
+      assertThat(configs.messageAnchoring?.disabled).isTrue()
+      assertThat(configs.forcedTransactions?.disabled).isTrue()
+      assertThat(configs.l2NetworkGasPricing?.disabled).isTrue()
     }
   }
 }

--- a/docker/compose-riscv.yml
+++ b/docker/compose-riscv.yml
@@ -1,0 +1,174 @@
+volumes:
+  local-dev:
+    name: "linea-riscv-local-dev"
+
+networks:
+  linea:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 10.42.24.0/24
+  l1network:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 10.42.23.0/24
+
+services:
+  l1-el-node:
+    extends:
+      file: compose-spec-l1-services.yml
+      service: l1-el-node
+    container_name: linea-riscv-l1-el-node
+    ports: !override
+      - "8445:8545"
+    networks:
+      l1network:
+        ipv4_address: 10.42.23.201
+
+  l1-cl-node:
+    extends:
+      file: compose-spec-l1-services.yml
+      service: l1-cl-node
+    container_name: linea-riscv-l1-cl-node
+    command:
+      - --config-file=/config/config-file.yaml
+      - --ee-endpoint=http://l1-el-node:8551
+    ports: !override []
+    networks:
+      l1network:
+        ipv4_address: 10.42.23.202
+
+  l1-node-genesis-generator:
+    extends:
+      file: compose-spec-l1-services.yml
+      service: l1-node-genesis-generator
+    container_name: linea-riscv-l1-node-genesis-generator
+
+  l2-genesis-initialization:
+    extends:
+      file: compose-spec-l2-services.yml
+      service: l2-genesis-initialization
+    container_name: linea-riscv-l2-genesis-initialization
+
+  maru:
+    extends:
+      file: compose-spec-l2-services.yml
+      service: maru
+    container_name: linea-riscv-maru
+    environment:
+      LINETH_USE_MARU_OVERRIDE_CONFIG: "true"
+    ports: !override []
+    volumes:
+      - ./config/maru/sequencer.riscv.config.overrides.toml:/opt/consensys/maru/configs/config.overrides.toml:ro
+    networks:
+      l1network:
+      linea:
+        ipv4_address: 10.42.24.210
+
+  sequencer:
+    extends:
+      file: compose-spec-l2-services.yml
+      service: sequencer
+    container_name: linea-riscv-sequencer
+    command:
+      - --config-file=/var/lib/besu/sequencer.config.toml
+      - --node-private-key-file=/var/lib/besu/key
+      - --plugin-linea-node-type=SEQUENCER
+      - --plugin-linea-liveness-enabled=false
+      - >-
+        --plugins=LineaEstimateGasEndpointPlugin,LineaExtraDataPlugin,
+        LineaTransactionPoolValidatorPlugin,LineaBundleEndpointsPlugin,
+        LineaSetExtraDataEndpointPlugin,LineaTransactionSelectorPlugin
+    ports: !override
+      - "8545:8545"
+    networks:
+      l1network:
+      linea:
+        ipv4_address: 10.42.24.101
+
+  postgres:
+    extends:
+      file: compose-spec-l2-services.yml
+      service: postgres
+    container_name: linea-riscv-postgres
+    ports: !override []
+
+  riscv-proof-responder:
+    container_name: linea-riscv-proof-responder
+    image: busybox:latest
+    profiles: ["riscv"]
+    entrypoint: ["/bin/sh", "/opt/linea/proof-responder.sh"]
+    environment:
+      R5_L2_EXECUTION_PROGRAM_VK: ${R5_L2_EXECUTION_PROGRAM_VK:-0x17d2e0660946012c80c5fe6bbecc2076a6f6f5aa58606efe66a14426d2ffe46f}
+    volumes:
+      - ./config/riscv/proof-responder.sh:/opt/linea/proof-responder.sh:ro
+      - ../tmp/riscv/prover/riscv:/data/prover/riscv
+    networks:
+      - linea
+
+  coordinator:
+    container_name: linea-riscv-coordinator
+    hostname: coordinator
+    image: ${LINEA_COORDINATOR_IMAGE_NAME:-consensys/linea-coordinator}:${LINEA_COORDINATOR_TAG:-local}
+    platform: linux/amd64
+    profiles: ["l2"]
+    depends_on:
+      l2-genesis-initialization:
+        condition: service_completed_successfully
+      l1-el-node:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+      sequencer:
+        condition: service_healthy
+    ports:
+      - "9545:9545"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          bash -ec 'exec 3<>/dev/tcp/127.0.0.1/9545;
+          printf "GET /health HTTP/1.0\r\n\r\n" >&3;
+          grep -q "200 OK" <&3'
+      interval: 1s
+      timeout: 1s
+      retries: 120
+    restart: on-failure
+    environment:
+      dev_LINETH_COORDINATOR_DISABLED: "false"
+      CONFIG_OVERRIDE_OPTS: ""
+    command:
+      - sh
+      - -c
+      - |
+        exec java \
+          -Xmx768m \
+          -Dvertx.configurationFile=/var/lib/coordinator/vertx-options.json \
+          -Dlog4j2.configurationFile=/var/lib/coordinator/log4j2-dev.xml \
+          -jar "$${LINETH_APP_JAR:-/opt/consensys/linea/coordinator/libs/coordinator.jar}" \
+          --traces-limits-v5 config/traces-limits-v5.toml \
+          --smart-contract-errors config/smart-contract-errors.toml \
+          --gas-price-cap-time-of-day-multipliers config/gas-price-cap-time-of-day-multipliers.toml \
+          config/coordinator-config.toml \
+          config/coordinator-config-riscv.toml
+    volumes:
+      - ./config/coordinator/coordinator-config-v2.toml:/opt/consensys/linea/coordinator/config/coordinator-config.toml:ro
+      - ./config/coordinator/coordinator-config-riscv.toml:/opt/consensys/linea/coordinator/config/coordinator-config-riscv.toml:ro
+      - ./config/common/traces-limits-v5.toml:/opt/consensys/linea/coordinator/config/traces-limits-v5.toml:ro
+      - ./config/common/smart-contract-errors.toml:/opt/consensys/linea/coordinator/config/smart-contract-errors.toml:ro
+      - ./config/common/gas-price-cap-time-of-day-multipliers.toml:/opt/consensys/linea/coordinator/config/gas-price-cap-time-of-day-multipliers.toml:ro
+      - ./config/coordinator/vertx-options.json:/var/lib/coordinator/vertx-options.json:ro
+      - ./config/coordinator/log4j2-dev.xml:/var/lib/coordinator/log4j2-dev.xml:ro
+      - ../tmp/riscv:/data
+    deploy:
+      resources:
+        limits:
+          memory: 1100M
+        reservations:
+          memory: 512M
+    networks:
+      l1network:
+        ipv4_address: 10.42.23.106
+      linea:
+        ipv4_address: 10.42.24.106

--- a/docker/config/coordinator/coordinator-config-riscv.toml
+++ b/docker/config/coordinator/coordinator-config-riscv.toml
@@ -1,0 +1,63 @@
+[protocol.l1]
+contract-address = "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"
+
+[conflation]
+blocks-limit = 1
+riscv-starting-block-timestamp-inclusive = 0
+
+[conflation.proof-aggregation]
+timestamp-based-hard-forks = [0]
+
+[riscv-prover]
+fs-polling-interval = "PT1S"
+fs-polling-timeout = "PT10M"
+enable-request-files-cleanup = false
+
+[riscv-prover.execution]
+fs-requests-directory = "/data/prover/riscv/execution/requests"
+fs-responses-directory = "/data/prover/riscv/execution/responses"
+program-vk = "0x17d2e0660946012c80c5fe6bbecc2076a6f6f5aa58606efe66a14426d2ffe46f"
+fork-name = "Osaka"
+
+[riscv-prover.rollup]
+fs-requests-directory = "/data/prover/riscv/rollup/requests"
+fs-responses-directory = "/data/prover/riscv/rollup/responses"
+program-vk = "0x0000000000000000000000000000000000000000000000000000000000000000"
+
+[riscv-prover.proof-aggregation]
+fs-requests-directory = "/data/prover/riscv/aggregation/requests"
+fs-responses-directory = "/data/prover/riscv/aggregation/responses"
+program-vk = "0x0000000000000000000000000000000000000000000000000000000000000000"
+
+[traces.counters]
+endpoints = ["http://sequencer:8545/"]
+
+[traces.conflation]
+endpoints = ["http://sequencer:8545/"]
+
+[type2-state-proof-provider]
+disabled = true
+
+[l1-submission.blob]
+disabled = true
+
+[l1-submission.blob.signer]
+type = "Web3j"
+
+[l1-submission.aggregation]
+disabled = true
+
+[l1-submission.aggregation.signer]
+type = "Web3j"
+
+[message-anchoring]
+disabled = true
+
+[message-anchoring.signer]
+type = "Web3j"
+
+[forced-transactions]
+disabled = true
+
+[l2-network-gas-pricing]
+disabled = true

--- a/docker/config/maru/sequencer.riscv.config.overrides.toml
+++ b/docker/config/maru/sequencer.riscv.config.overrides.toml
@@ -1,0 +1,2 @@
+[linea]
+contract-address = "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"

--- a/docker/config/riscv/proof-responder.sh
+++ b/docker/config/riscv/proof-responder.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+set -eu
+
+requests_dir=${RISCV_EXECUTION_REQUESTS_DIR:-/data/prover/riscv/execution/requests}
+responses_dir=${RISCV_EXECUTION_RESPONSES_DIR:-/data/prover/riscv/execution/responses}
+program_vk=${R5_L2_EXECUTION_PROGRAM_VK:?R5_L2_EXECUTION_PROGRAM_VK is required}
+zero_hash=0x0000000000000000000000000000000000000000000000000000000000000000
+
+mkdir -p "$responses_dir"
+
+while true; do
+  for request_file in "$requests_dir"/*-getZkL2ExecutionProof.json; do
+    [ -f "$request_file" ] || continue
+
+    file_name=${request_file##*/}
+    start_block=${file_name%%-*}
+    remainder=${file_name#*-}
+    end_block=${remainder%%-*}
+    response_file="$responses_dir/$file_name"
+
+    [ -f "$response_file" ] && continue
+
+    temporary_file="$response_file.tmp"
+    cat >"$temporary_file" <<EOF
+{
+  "proverVersion": "riscv-local-dev",
+  "startBlockNumber": $start_block,
+  "proof": "0x00",
+  "publicInputs": {
+    "parentBlockHash": "$zero_hash",
+    "endBlockHash": "$zero_hash",
+    "endBlockNumber": $end_block,
+    "endBlockTimestamp": 0,
+    "l2L1MessagesHash": "$zero_hash",
+    "parentL1L2BridgeRollingHash": "$zero_hash",
+    "parentL1L2BridgeRollingHashMessageNumber": 0,
+    "endL1L2BridgeRollingHash": "$zero_hash",
+    "endL1L2BridgeRollingHashMessageNumber": 0,
+    "dynamicChainConfigHash": "$zero_hash",
+    "parentFtxRollingHash": "$zero_hash",
+    "parentFtxNumber": 0,
+    "endFtxRollingHash": "$zero_hash",
+    "endProcessedFtxNumber": 0,
+    "filteredAddressesHash": "$zero_hash",
+    "txFromsHash": "$zero_hash"
+  },
+  "l2L1Messages": [],
+  "txFroms": [],
+  "filteredAddresses": [],
+  "programVk": "$program_vk"
+}
+EOF
+    mv "$temporary_file" "$response_file"
+    echo "Created development proof response: $file_name"
+  done
+
+  sleep 1
+done

--- a/docs/riscv-local-development.md
+++ b/docs/riscv-local-development.md
@@ -1,0 +1,40 @@
+# RISC-V local stack
+
+## Prerequisites
+
+Install the repository prerequisites from [get-started.md](get-started.md) and
+build the coordinator image:
+
+```bash
+make docker-build-coordinator
+```
+
+The sequencer image must return execution witnesses for the local Lineth
+network, which currently uses Osaka. The repository's default image predates
+`debug_executionWitness`, while the initial upstream implementation requires
+Amsterdam block access lists. Compatible Linea Besu integration is tracked by
+[issue #3084](https://github.com/LFDT-Lineth/lineth-monorepo/issues/3084).
+
+## Start
+
+```bash
+LINEA_BESU_PACKAGE_TAG="<tag-with-debug_executionWitness>" make start-env-with-riscv
+```
+
+This starts a development responder that returns structurally valid execution
+proof responses without proving them. It can be replaced with an R5 prover once
+a compatible image is available.
+
+## Diagnostics
+
+```bash
+docker compose -p linea-riscv-dev -f docker/compose-riscv.yml ps
+docker compose -p linea-riscv-dev -f docker/compose-riscv.yml logs coordinator riscv-proof-responder
+find tmp/riscv/prover/riscv -type f -print
+```
+
+## Cleanup
+
+```bash
+make clean-riscv-environment
+```

--- a/jvm-libs/linea/web3j-extensions/src/main/kotlin/linea/web3j/ethapi/Web3jExecutionWitnessClient.kt
+++ b/jvm-libs/linea/web3j-extensions/src/main/kotlin/linea/web3j/ethapi/Web3jExecutionWitnessClient.kt
@@ -3,6 +3,7 @@ package linea.web3j.ethapi
 import linea.domain.BlockParameter
 import linea.ethapi.ExecutionWitness
 import linea.ethapi.ExecutionWitnessClient
+import linea.kotlin.toHexString
 import linea.web3j.requestAsync
 import org.web3j.protocol.Web3jService
 import org.web3j.protocol.core.Request
@@ -35,7 +36,7 @@ class Web3jExecutionWitnessClient(
 private fun BlockParameter.toDebugExecutionWitnessRpcParam(): String =
   when (this) {
     is BlockParameter.Tag -> tag
-    is BlockParameter.BlockNumber -> number.toString()
+    is BlockParameter.BlockNumber -> number.toHexString()
     is BlockParameter.BlockHash -> hashHex
   }
 

--- a/jvm-libs/linea/web3j-extensions/src/test/kotlin/linea/web3j/ethapi/Web3jExecutionWitnessClientTest.kt
+++ b/jvm-libs/linea/web3j-extensions/src/test/kotlin/linea/web3j/ethapi/Web3jExecutionWitnessClientTest.kt
@@ -50,7 +50,7 @@ class Web3jExecutionWitnessClientTest {
     wiremock.stubFor(
       post(urlEqualTo("/"))
         .withRequestBody(containing("\"method\":\"debug_executionWitness\""))
-        .withRequestBody(containing("\"params\":[\"42\"]"))
+        .withRequestBody(containing("\"params\":[\"0x2a\"]"))
         .willReturn(
           ok(
             JsonObject.of("jsonrpc", "2.0", "id", 1, "result", JsonObject(witnessJson)).encode(),


### PR DESCRIPTION
Adds a local RISC-V stack using the V9 stub, RISC-V coordinator pipeline, and a filesystem proof responder. Shomei, tracer nodes, prover-v3, and forced transactions are excluded.

The stack boots and reaches `debug_executionWitness`. Full request/response validation is blocked because the upstream witness implementation requires Amsterdam block access lists and Bonsai, while the local Lineth network uses Osaka/Forest and Maru supports only through Osaka.

Part of #3823.