### PR TITLE
test(ci): remove increased wait time in sequencer int test

### DIFF
--- a/linea-besu/plugins/linea-sequencer/acceptance-tests/src/main/kotlin/lineth/plugin/acc/test/RecordingTransactionSelectorPlugin.kt
+++ b/linea-besu/plugins/linea-sequencer/acceptance-tests/src/main/kotlin/lineth/plugin/acc/test/RecordingTransactionSelectorPlugin.kt
@@ -90,10 +90,6 @@ class RecordingTransactionSelectorPlugin : BesuPlugin {
       // rejection recorded by an earlier pass: block building runs many selection passes over the
       // node's lifetime, and a transaction that is ultimately selected must not keep reporting a
       // stale rejection from a pass that was cancelled, timed out, or otherwise abandoned.
-      //
-      // This is the authoritative positive signal, and is what makes the recording self-correcting.
-      // Enumerating every transient not-selected outcome in onTransactionNotSelected cannot be made
-      // complete (Besu keeps adding/wrapping them); observing "it was selected" can.
       rejections.remove(evaluationContext.pendingTransaction.transaction.hash)
       return TransactionSelectionResult.SELECTED
     }
@@ -103,52 +99,7 @@ class RecordingTransactionSelectorPlugin : BesuPlugin {
       transactionSelectionResult: TransactionSelectionResult,
     ) {
       val txHash = evaluationContext.pendingTransaction.transaction.hash
-      // Only substantive rejections are worth recording. Transient/scheduling outcomes
-      // (SELECTION_CANCELLED, the *_TIMEOUT family, a penalized EXECUTION_INTERRUPTED) say
-      // "block building gave up", not "this transaction was rejected on its merits", and Besu
-      // itself warns they are not reliable: handleTransactionSelected reports
-      // BLOCK_SELECTION_TIMEOUT for a transaction that already passed every check when the timeout
-      // fires before commit.
-      if (isTransientSchedulingOutcome(transactionSelectionResult)) {
-        return
-      }
-      // A substantive rejection always wins, including over one recorded by an earlier pass.
       rejections[txHash] = transactionSelectionResult
     }
-
-    private fun isTransientSchedulingOutcome(result: TransactionSelectionResult): Boolean =
-      result in TRANSIENT_SCHEDULING_RESULTS ||
-        (
-          result.penalize() &&
-            result.maybeInvalidReason().orElse(null) == EXECUTION_INTERRUPTED_REASON
-          )
-  }
-
-  companion object {
-    /**
-     * The `TransactionInvalidReason.EXECUTION_INTERRUPTED` name, produced when a block build's time
-     * budget interrupts a transaction's execution. Referenced by name because that enum lives in
-     * Besu's internal (non-plugin-api) module.
-     */
-    private const val EXECUTION_INTERRUPTED_REASON: String = "EXECUTION_INTERRUPTED"
-
-    /**
-     * Outcomes that mean "block building ran out of time / was superseded", not "this transaction
-     * was rejected on its merits".
-     *
-     * Besu wraps the underlying reason when a build times out, e.g. it reports
-     * `BLOCK_SELECTION_TIMEOUT (original result INVALID_PENALIZED(EXECUTION_INTERRUPTED))`. The
-     * wrapper does not carry `penalize()` or the invalid reason, so matching on those alone misses
-     * it; the wrapper results have to be listed explicitly.
-     */
-    private val TRANSIENT_SCHEDULING_RESULTS: Set<TransactionSelectionResult> = setOf(
-      TransactionSelectionResult.SELECTION_CANCELLED,
-      TransactionSelectionResult.BLOCK_SELECTION_TIMEOUT,
-      TransactionSelectionResult.BLOCK_SELECTION_TIMEOUT_INVALID_TX,
-      TransactionSelectionResult.PLUGIN_SELECTION_TIMEOUT,
-      TransactionSelectionResult.PLUGIN_SELECTION_TIMEOUT_INVALID_TX,
-      TransactionSelectionResult.TX_EVALUATION_TOO_LONG,
-      TransactionSelectionResult.INVALID_TX_EVALUATION_TOO_LONG,
-    )
   }
 }

--- a/linea-besu/plugins/linea-sequencer/acceptance-tests/src/main/kotlin/lineth/plugin/acc/test/RecordingTransactionSelectorPlugin.kt
+++ b/linea-besu/plugins/linea-sequencer/acceptance-tests/src/main/kotlin/lineth/plugin/acc/test/RecordingTransactionSelectorPlugin.kt
@@ -8,6 +8,7 @@
  */
 package lineth.plugin.acc.test
 
+import lineth.txselection.LineaTransactionSelectionResult
 import org.hyperledger.besu.datatypes.Hash
 import org.hyperledger.besu.plugin.BesuPlugin
 import org.hyperledger.besu.plugin.ServiceManager
@@ -45,6 +46,7 @@ class RecordingTransactionSelectorPlugin : BesuPlugin {
 
   private lateinit var transactionSelectionService: TransactionSelectionService
   private val rejections: ConcurrentHashMap<Hash, TransactionSelectionResult> = ConcurrentHashMap()
+  private val lineaRejections: ConcurrentHashMap<Hash, LineaTransactionSelectionResult> = ConcurrentHashMap()
 
   override fun register(serviceManager: ServiceManager) {
     transactionSelectionService =
@@ -57,6 +59,11 @@ class RecordingTransactionSelectorPlugin : BesuPlugin {
         val txHashHex = request.params[0] as String
         val txHash = Hash.fromHexString(txHashHex)
         rejections[txHash]?.toString()
+      }
+      rpcEndpointService.registerRPCEndpoint("test", "getLineaRejectionReason") { request: PluginRpcRequest ->
+        val txHashHex = request.params[0] as String
+        val txHash = Hash.fromHexString(txHashHex)
+        lineaRejections[txHash]?.toString()
       }
     }
   }
@@ -90,11 +97,8 @@ class RecordingTransactionSelectorPlugin : BesuPlugin {
       // rejection recorded by an earlier pass: block building runs many selection passes over the
       // node's lifetime, and a transaction that is ultimately selected must not keep reporting a
       // stale rejection from a pass that was cancelled, timed out, or otherwise abandoned.
-      //
-      // This is the authoritative positive signal, and is what makes the recording self-correcting.
-      // Enumerating every transient not-selected outcome in onTransactionNotSelected cannot be made
-      // complete (Besu keeps adding/wrapping them); observing "it was selected" can.
       rejections.remove(evaluationContext.pendingTransaction.transaction.hash)
+      lineaRejections.remove(evaluationContext.pendingTransaction.transaction.hash)
       return TransactionSelectionResult.SELECTED
     }
 
@@ -103,52 +107,11 @@ class RecordingTransactionSelectorPlugin : BesuPlugin {
       transactionSelectionResult: TransactionSelectionResult,
     ) {
       val txHash = evaluationContext.pendingTransaction.transaction.hash
-      // Only substantive rejections are worth recording. Transient/scheduling outcomes
-      // (SELECTION_CANCELLED, the *_TIMEOUT family, a penalized EXECUTION_INTERRUPTED) say
-      // "block building gave up", not "this transaction was rejected on its merits", and Besu
-      // itself warns they are not reliable: handleTransactionSelected reports
-      // BLOCK_SELECTION_TIMEOUT for a transaction that already passed every check when the timeout
-      // fires before commit.
-      if (isTransientSchedulingOutcome(transactionSelectionResult)) {
-        return
+      if (transactionSelectionResult is LineaTransactionSelectionResult) {
+        lineaRejections[txHash] = transactionSelectionResult
+      } else {
+        rejections[txHash] = transactionSelectionResult
       }
-      // A substantive rejection always wins, including over one recorded by an earlier pass.
-      rejections[txHash] = transactionSelectionResult
     }
-
-    private fun isTransientSchedulingOutcome(result: TransactionSelectionResult): Boolean =
-      result in TRANSIENT_SCHEDULING_RESULTS ||
-        (
-          result.penalize() &&
-            result.maybeInvalidReason().orElse(null) == EXECUTION_INTERRUPTED_REASON
-          )
-  }
-
-  companion object {
-    /**
-     * The `TransactionInvalidReason.EXECUTION_INTERRUPTED` name, produced when a block build's time
-     * budget interrupts a transaction's execution. Referenced by name because that enum lives in
-     * Besu's internal (non-plugin-api) module.
-     */
-    private const val EXECUTION_INTERRUPTED_REASON: String = "EXECUTION_INTERRUPTED"
-
-    /**
-     * Outcomes that mean "block building ran out of time / was superseded", not "this transaction
-     * was rejected on its merits".
-     *
-     * Besu wraps the underlying reason when a build times out, e.g. it reports
-     * `BLOCK_SELECTION_TIMEOUT (original result INVALID_PENALIZED(EXECUTION_INTERRUPTED))`. The
-     * wrapper does not carry `penalize()` or the invalid reason, so matching on those alone misses
-     * it; the wrapper results have to be listed explicitly.
-     */
-    private val TRANSIENT_SCHEDULING_RESULTS: Set<TransactionSelectionResult> = setOf(
-      TransactionSelectionResult.SELECTION_CANCELLED,
-      TransactionSelectionResult.BLOCK_SELECTION_TIMEOUT,
-      TransactionSelectionResult.BLOCK_SELECTION_TIMEOUT_INVALID_TX,
-      TransactionSelectionResult.PLUGIN_SELECTION_TIMEOUT,
-      TransactionSelectionResult.PLUGIN_SELECTION_TIMEOUT_INVALID_TX,
-      TransactionSelectionResult.TX_EVALUATION_TOO_LONG,
-      TransactionSelectionResult.INVALID_TX_EVALUATION_TOO_LONG,
-    )
   }
 }

--- a/linea-besu/plugins/linea-sequencer/acceptance-tests/src/main/kotlin/lineth/plugin/acc/test/RecordingTransactionSelectorPlugin.kt
+++ b/linea-besu/plugins/linea-sequencer/acceptance-tests/src/main/kotlin/lineth/plugin/acc/test/RecordingTransactionSelectorPlugin.kt
@@ -90,6 +90,10 @@ class RecordingTransactionSelectorPlugin : BesuPlugin {
       // rejection recorded by an earlier pass: block building runs many selection passes over the
       // node's lifetime, and a transaction that is ultimately selected must not keep reporting a
       // stale rejection from a pass that was cancelled, timed out, or otherwise abandoned.
+      //
+      // This is the authoritative positive signal, and is what makes the recording self-correcting.
+      // Enumerating every transient not-selected outcome in onTransactionNotSelected cannot be made
+      // complete (Besu keeps adding/wrapping them); observing "it was selected" can.
       rejections.remove(evaluationContext.pendingTransaction.transaction.hash)
       return TransactionSelectionResult.SELECTED
     }
@@ -99,7 +103,52 @@ class RecordingTransactionSelectorPlugin : BesuPlugin {
       transactionSelectionResult: TransactionSelectionResult,
     ) {
       val txHash = evaluationContext.pendingTransaction.transaction.hash
+      // Only substantive rejections are worth recording. Transient/scheduling outcomes
+      // (SELECTION_CANCELLED, the *_TIMEOUT family, a penalized EXECUTION_INTERRUPTED) say
+      // "block building gave up", not "this transaction was rejected on its merits", and Besu
+      // itself warns they are not reliable: handleTransactionSelected reports
+      // BLOCK_SELECTION_TIMEOUT for a transaction that already passed every check when the timeout
+      // fires before commit.
+      if (isTransientSchedulingOutcome(transactionSelectionResult)) {
+        return
+      }
+      // A substantive rejection always wins, including over one recorded by an earlier pass.
       rejections[txHash] = transactionSelectionResult
     }
+
+    private fun isTransientSchedulingOutcome(result: TransactionSelectionResult): Boolean =
+      result in TRANSIENT_SCHEDULING_RESULTS ||
+        (
+          result.penalize() &&
+            result.maybeInvalidReason().orElse(null) == EXECUTION_INTERRUPTED_REASON
+          )
+  }
+
+  companion object {
+    /**
+     * The `TransactionInvalidReason.EXECUTION_INTERRUPTED` name, produced when a block build's time
+     * budget interrupts a transaction's execution. Referenced by name because that enum lives in
+     * Besu's internal (non-plugin-api) module.
+     */
+    private const val EXECUTION_INTERRUPTED_REASON: String = "EXECUTION_INTERRUPTED"
+
+    /**
+     * Outcomes that mean "block building ran out of time / was superseded", not "this transaction
+     * was rejected on its merits".
+     *
+     * Besu wraps the underlying reason when a build times out, e.g. it reports
+     * `BLOCK_SELECTION_TIMEOUT (original result INVALID_PENALIZED(EXECUTION_INTERRUPTED))`. The
+     * wrapper does not carry `penalize()` or the invalid reason, so matching on those alone misses
+     * it; the wrapper results have to be listed explicitly.
+     */
+    private val TRANSIENT_SCHEDULING_RESULTS: Set<TransactionSelectionResult> = setOf(
+      TransactionSelectionResult.SELECTION_CANCELLED,
+      TransactionSelectionResult.BLOCK_SELECTION_TIMEOUT,
+      TransactionSelectionResult.BLOCK_SELECTION_TIMEOUT_INVALID_TX,
+      TransactionSelectionResult.PLUGIN_SELECTION_TIMEOUT,
+      TransactionSelectionResult.PLUGIN_SELECTION_TIMEOUT_INVALID_TX,
+      TransactionSelectionResult.TX_EVALUATION_TOO_LONG,
+      TransactionSelectionResult.INVALID_TX_EVALUATION_TOO_LONG,
+    )
   }
 }

--- a/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/lineth/plugin/acc/test/CompressionAwareBlockBuildingTest.kt
+++ b/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/lineth/plugin/acc/test/CompressionAwareBlockBuildingTest.kt
@@ -113,11 +113,11 @@ class CompressionAwareBlockBuildingTest : LineaPluginPoSTestBase() {
       .atMost(4, TimeUnit.SECONDS)
       .pollInterval(50, TimeUnit.MILLISECONDS)
       .untilAsserted {
-        assertThat(getRejectionReason(largeTxHash))
+        assertThat(getLineaRejectionReason(largeTxHash))
           .withFailMessage { "Expected large tx to be rejected with BLOCK_COMPRESSED_SIZE_OVERFLOW" }
           .isEqualTo(LineaTransactionSelectionResult.BLOCK_COMPRESSED_SIZE_OVERFLOW.toString())
       }
-    assertThat(getRejectionReason(smallTxHash))
+    assertThat(getLineaRejectionReason(smallTxHash))
       .withFailMessage { "Expected small tx to not have a rejection reason (it was selected)" }
       .isNull()
   }
@@ -218,9 +218,9 @@ class CompressionAwareBlockBuildingTest : LineaPluginPoSTestBase() {
     return TransactionEncoder.signMessage(rawTx, sender.web3jCredentialsOrThrow()).encodeHex()
   }
 
-  private fun getRejectionReason(txHash: String): String? {
+  private fun getLineaRejectionReason(txHash: String): String? {
     val response = org.web3j.protocol.core.Request(
-      "test_getRejectionReason",
+      "test_getLineaRejectionReason",
       listOf(txHash),
       minerNode.nodeRequests().web3jService,
       TestRejectionResponse::class.java,

--- a/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/lineth/plugin/acc/test/CompressionAwareBlockBuildingTest.kt
+++ b/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/lineth/plugin/acc/test/CompressionAwareBlockBuildingTest.kt
@@ -109,14 +109,8 @@ class CompressionAwareBlockBuildingTest : LineaPluginPoSTestBase() {
 
     minerNode.verify(eth.expectSuccessfulTransactionReceipt(smallTxHash))
     minerNode.verify(eth.expectNoTransactionReceipt(largeTxHash))
-    // Under Vert.x 5 (Besu 26.8.1) the first block build on a loaded CI runner can take several
-    // seconds before the selector's slow-path compression check records the rejection, so give the
-    // poll a budget comfortably above one block period. The RecordingTransactionSelectorPlugin keeps
-    // the substantive BLOCK_COMPRESSED_SIZE_OVERFLOW (it is not overwritten by later transient
-    // SELECTION_CANCELLED / EXECUTION_INTERRUPTED outcomes), so a longer window only adds patience,
-    // not false positives.
     await()
-      .atMost(3L * getBlockPeriodSeconds(), TimeUnit.SECONDS)
+      .atMost(4, TimeUnit.SECONDS)
       .pollInterval(50, TimeUnit.MILLISECONDS)
       .untilAsserted {
         assertThat(getRejectionReason(largeTxHash))

--- a/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/lineth/plugin/acc/test/EcDataLimitsTest.kt
+++ b/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/lineth/plugin/acc/test/EcDataLimitsTest.kt
@@ -67,14 +67,6 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
     // Verify that the transaction for transferring funds was successful
     minerNode.verify(eth.expectSuccessfulTransactionReceipt(fundTxHash))
 
-    // Stop background block production before submitting the batch: the background scheduler
-    // builds a block on a fixed tick independent of this submission loop, so a tick landing
-    // mid-loop can split the "fitting" transactions across two blocks. This was observed as
-    // CI-only flakiness once Vert.x 5 (Besu 26.8.1) made the loop's RPC round-trips slower and
-    // more variable, widening the window in which a tick can land mid-loop. Building the block
-    // explicitly after every tx is submitted removes that race without touching any wait/timeout.
-    buildBlocksInBackground = false
-
     val txHashes = Array<String?>(nTransactions) { null }
     for (i in 0 until nTransactions) {
       // With decreasing nonce we force the transactions to be included in the same block
@@ -98,24 +90,17 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
       txHashes[nonce] = resp.transactionHash
     }
 
-    // eth_sendRawTransaction returning does not mean the tx is selectable yet: with
-    // noLocalPriority(true) it still has to traverse the layered txpool. Building before the whole
-    // batch is in the pool lets a subset be selected, splitting the fitting txs across two blocks
-    // (the CI-only failure). Wait for the condition, not for a duration.
-    awaitTransactionsInPool(txHashes.filterNotNull())
-
-    // Build the block explicitly now that every tx in the batch has been submitted: all of them
-    // are evaluated together for this single block-build attempt.
-    //
-    // An explicit build window is required. The no-arg overload gives Besu only one block period,
-    // after which engine_getPayload interrupts whatever is still being evaluated
-    // (INVALID_PENALIZED(EXECUTION_INTERRUPTED)) and seals the block with the subset evaluated so
-    // far, splitting the fitting batch across two blocks. EcPairing transactions have been measured
-    // at 1-5 s each here, so the batch needs a window that can accommodate all of them.
-    buildNewBlockAndWait(BATCH_BLOCK_BUILDING_TIME_MS)
-    // The overflow tx doesn't fit and stays pending; build a second block explicitly (background
-    // production is off) so it gets mined for the assertion below.
-    buildNewBlockAndWait()
+    // Transfer used as sentry to ensure a new block is mined
+    val transferTxHash = accountTransactions
+      .createTransfer(
+        accounts.primaryBenefactor,
+        accounts.secondaryBenefactor,
+        1,
+        BigInteger.ONE, // nonce is 1 as primary benefactor also deploys the contract
+      )
+      .execute(minerNode.nodeRequests())
+    // Wait for the sentry to be mined
+    minerNode.verify(eth.expectSuccessfulTransactionReceipt(transferTxHash.bytes.toHexString()))
 
     // Assert the limit's ordering semantics: all but the last transaction (the ones that fit) were
     // mined together, and the last one (which exceeds the limit) was mined in a strictly later
@@ -177,14 +162,6 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
     // Verify that the transaction for transferring funds was successful
     minerNode.verify(eth.expectSuccessfulTransactionReceipt(fundTxHash))
 
-    // Stop background block production before submitting the batch: the background scheduler
-    // builds a block on a fixed tick independent of this submission loop, so a tick landing
-    // mid-loop can split the "fitting" transactions across two blocks. This was observed as
-    // CI-only flakiness once Vert.x 5 (Besu 26.8.1) made the loop's RPC round-trips slower and
-    // more variable, widening the window in which a tick can land mid-loop. Building the block
-    // explicitly after every tx is submitted removes that race without touching any wait/timeout.
-    buildBlocksInBackground = false
-
     val txHashes = Array<String?>(nTransactions) { null }
     for (i in 0 until nTransactions) {
       // With decreasing nonce we force the transactions to be included in the same block
@@ -203,24 +180,17 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
       txHashes[nonce] = resp.transactionHash
     }
 
-    // eth_sendRawTransaction returning does not mean the tx is selectable yet: with
-    // noLocalPriority(true) it still has to traverse the layered txpool. Building before the whole
-    // batch is in the pool lets a subset be selected, splitting the fitting txs across two blocks
-    // (the CI-only failure). Wait for the condition, not for a duration.
-    awaitTransactionsInPool(txHashes.filterNotNull())
-
-    // Build the block explicitly now that every tx in the batch has been submitted: all of them
-    // are evaluated together for this single block-build attempt.
-    //
-    // An explicit build window is required. The no-arg overload gives Besu only one block period,
-    // after which engine_getPayload interrupts whatever is still being evaluated
-    // (INVALID_PENALIZED(EXECUTION_INTERRUPTED)) and seals the block with the subset evaluated so
-    // far, splitting the fitting batch across two blocks. EcPairing transactions have been measured
-    // at 1-5 s each here, so the batch needs a window that can accommodate all of them.
-    buildNewBlockAndWait(BATCH_BLOCK_BUILDING_TIME_MS)
-    // The overflow tx doesn't fit and stays pending; build a second block explicitly (background
-    // production is off) so it gets mined for the assertion below.
-    buildNewBlockAndWait()
+    // Transfer used as sentry to ensure a new block is mined
+    val transferTxHash = accountTransactions
+      .createTransfer(
+        accounts.primaryBenefactor,
+        accounts.secondaryBenefactor,
+        1,
+        BigInteger.ONE, // nonce is 1 as primary benefactor also deploys the contract
+      )
+      .execute(minerNode.nodeRequests())
+    // Wait for the sentry to be mined
+    minerNode.verify(eth.expectSuccessfulTransactionReceipt(transferTxHash.bytes.toHexString()))
 
     // Assert the limit's ordering semantics: all but the last transaction (the ones that fit) were
     // mined together, and the last one (which exceeds the limit) was mined in a strictly later
@@ -277,14 +247,6 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
     // Verify that the transaction for transferring funds was successful
     minerNode.verify(eth.expectSuccessfulTransactionReceipt(fundTxHash))
 
-    // Stop background block production before submitting the batch: the background scheduler
-    // builds a block on a fixed tick independent of this submission loop, so a tick landing
-    // mid-loop can split the "fitting" transactions across two blocks. This was observed as
-    // CI-only flakiness once Vert.x 5 (Besu 26.8.1) made the loop's RPC round-trips slower and
-    // more variable, widening the window in which a tick can land mid-loop. Building the block
-    // explicitly after every tx is submitted removes that race without touching any wait/timeout.
-    buildBlocksInBackground = false
-
     val txHashes = Array<String?>(nTransactions) { null }
     for (i in 0 until nTransactions) {
       // With decreasing nonce we force the transactions to be included in the same block
@@ -303,24 +265,17 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
       txHashes[nonce] = resp.transactionHash
     }
 
-    // eth_sendRawTransaction returning does not mean the tx is selectable yet: with
-    // noLocalPriority(true) it still has to traverse the layered txpool. Building before the whole
-    // batch is in the pool lets a subset be selected, splitting the fitting txs across two blocks
-    // (the CI-only failure). Wait for the condition, not for a duration.
-    awaitTransactionsInPool(txHashes.filterNotNull())
-
-    // Build the block explicitly now that every tx in the batch has been submitted: all of them
-    // are evaluated together for this single block-build attempt.
-    //
-    // An explicit build window is required. The no-arg overload gives Besu only one block period,
-    // after which engine_getPayload interrupts whatever is still being evaluated
-    // (INVALID_PENALIZED(EXECUTION_INTERRUPTED)) and seals the block with the subset evaluated so
-    // far, splitting the fitting batch across two blocks. EcPairing transactions have been measured
-    // at 1-5 s each here, so the batch needs a window that can accommodate all of them.
-    buildNewBlockAndWait(BATCH_BLOCK_BUILDING_TIME_MS)
-    // The overflow tx doesn't fit and stays pending; build a second block explicitly (background
-    // production is off) so it gets mined for the assertion below.
-    buildNewBlockAndWait()
+    // Transfer used as sentry to ensure a new block is mined
+    val transferTxHash = accountTransactions
+      .createTransfer(
+        accounts.primaryBenefactor,
+        accounts.secondaryBenefactor,
+        1,
+        BigInteger.ONE, // nonce is 1 as primary benefactor also deploys the contract
+      )
+      .execute(minerNode.nodeRequests())
+    // Wait for the sentry to be mined
+    minerNode.verify(eth.expectSuccessfulTransactionReceipt(transferTxHash.bytes.toHexString()))
 
     // Assert the limit's ordering semantics: all but the last transaction (the ones that fit) were
     // mined together, and the last one (which exceeds the limit) was mined in a strictly later
@@ -379,14 +334,6 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
     // Verify that the transaction for transferring funds was successful
     minerNode.verify(eth.expectSuccessfulTransactionReceipt(fundTxHash))
 
-    // Stop background block production before submitting the batch: the background scheduler
-    // builds a block on a fixed tick independent of this submission loop, so a tick landing
-    // mid-loop can split the "fitting" transactions across two blocks. This was observed as
-    // CI-only flakiness once Vert.x 5 (Besu 26.8.1) made the loop's RPC round-trips slower and
-    // more variable, widening the window in which a tick can land mid-loop. Building the block
-    // explicitly after every tx is submitted removes that race without touching any wait/timeout.
-    buildBlocksInBackground = false
-
     // send first tx (nonce=0) last one, so they will stay ready in the pool,
     // but will not be included in a block due to the nonce gap, doing this before
     // to avoid timing issues caused by slow tx sending calls that could cause flakiness
@@ -406,24 +353,17 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
     }
       .reversed()
 
-    // eth_sendRawTransaction returning does not mean the tx is selectable yet: with
-    // noLocalPriority(true) it still has to traverse the layered txpool. Building before the whole
-    // batch is in the pool lets a subset be selected, splitting the fitting txs across two blocks
-    // (the CI-only failure). Wait for the condition, not for a duration.
-    awaitTransactionsInPool(txHashes.filterNotNull())
-
-    // Build the block explicitly now that every tx in the batch has been submitted: all of them
-    // are evaluated together for this single block-build attempt.
-    //
-    // An explicit build window is required. The no-arg overload gives Besu only one block period,
-    // after which engine_getPayload interrupts whatever is still being evaluated
-    // (INVALID_PENALIZED(EXECUTION_INTERRUPTED)) and seals the block with the subset evaluated so
-    // far, splitting the fitting batch across two blocks. EcPairing transactions have been measured
-    // at 1-5 s each here, so the batch needs a window that can accommodate all of them.
-    buildNewBlockAndWait(BATCH_BLOCK_BUILDING_TIME_MS)
-    // The overflow tx doesn't fit and stays pending; build a second block explicitly (background
-    // production is off) so it gets mined for the assertion below.
-    buildNewBlockAndWait()
+    // Transfer used as sentry to ensure a new block is mined
+    val transferTxHash = accountTransactions
+      .createTransfer(
+        accounts.primaryBenefactor,
+        accounts.secondaryBenefactor,
+        1,
+        BigInteger.ONE, // nonce is 1 as primary benefactor also deploys the contract
+      )
+      .execute(minerNode.nodeRequests())
+    // Wait for the sentry to be mined
+    minerNode.verify(eth.expectSuccessfulTransactionReceipt(transferTxHash.bytes.toHexString()))
 
     // Assert the limit's ordering semantics: all but the last transaction (the ones that fit) were
     // mined together, and the last one (which exceeds the limit) was mined in a strictly later
@@ -439,16 +379,6 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
   }
 
   companion object {
-    /**
-     * Build window granted to the block that must contain the whole fitting batch.
-     *
-     * EcPairing transactions are expensive to trace (measured at 1-5 s each here), so the default
-     * one-block-period window is not enough: engine_getPayload would interrupt evaluation mid-batch
-     * and seal a partial block. This stays below the `3 * blockPeriod` budget that
-     * `buildNewBlockAndWait` allows for the block to appear.
-     */
-    const val BATCH_BLOCK_BUILDING_TIME_MS = 20_000L
-
     @JvmStatic
     fun ecPairingLimitsTestSource(): Stream<Arguments> {
       val moduleLimits = ModuleLineCountValidator.createLimitModules(getResourcePath("/moduleLimits.toml"))
@@ -511,11 +441,6 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
         ),
       )
 
-      // Keep this small: each pairing adds EVM + tracing work to a single transaction's evaluation,
-      // and the whole fitting batch has to be evaluated within one block build. At 16 pairings a
-      // single transaction took 1.3-3.0 s to evaluate, so the batch overran the build window, was
-      // interrupted mid-batch, and the fitting transactions ended up split across two blocks on
-      // slower runners.
       val nPairsPerTransaction = 8
 
       /*

--- a/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/lineth/plugin/acc/test/EcDataLimitsTest.kt
+++ b/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/lineth/plugin/acc/test/EcDataLimitsTest.kt
@@ -112,7 +112,7 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
       txHashes[nTransactions - 1]!!,
     )
 
-    asserLogsContain(target)
+    assertLogsContain(target)
   }
 
   /**
@@ -202,7 +202,7 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
       txHashes[nTransactions - 1]!!,
     )
 
-    asserLogsContain(target)
+    assertLogsContain(target)
   }
 
   /**
@@ -287,7 +287,7 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
       txHashes[nTransactions - 1]!!,
     )
 
-    asserLogsContain(target)
+    assertLogsContain(target)
   }
 
   /**
@@ -375,7 +375,7 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
       txHashes[nTransactions - 1]!!,
     )
 
-    asserLogsContain(target)
+    assertLogsContain(target)
   }
 
   companion object {

--- a/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/lineth/plugin/acc/test/EcDataLimitsTest.kt
+++ b/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/lineth/plugin/acc/test/EcDataLimitsTest.kt
@@ -30,16 +30,11 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
       .build()
   }
 
-  override fun getBlockTxsSelectionMaxTimeMillis(): Int =
-    // The whole fitting batch must be evaluated inside ONE block's transaction selection budget,
-    // otherwise Besu returns BLOCK_SELECTION_TIMEOUT mid-batch, seals the block with the subset it
-    // managed to evaluate, and the rest spills into the next block (the `got [3, 4]` failure).
-    //
-    // EcPairing transactions are very expensive to trace: individual transactions here have been
-    // measured at 1-5 s, and the batch has 8 of them, so the default (one block period) is far too
-    // small. This only widens how long Besu may spend selecting; it does not change the block
-    // period or add any fixed wait to the test.
-    120_000
+  override fun getBlockPeriodSeconds(): Int =
+    // adding 2 more seconds to the block period, in order to avoid flakiness on the CI
+    // due to EcPairing sometimes taking all the selection time before all pending txs
+    // have been evaluated
+    BLOCK_PERIOD_SECONDS + 2
 
   /**
    * Tests the EcPairing limits, that are the number of times a certain circuit may be invoked in a

--- a/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/lineth/plugin/acc/test/LineaPluginTestBase.kt
+++ b/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/lineth/plugin/acc/test/LineaPluginTestBase.kt
@@ -736,12 +736,18 @@ abstract class LineaPluginTestBase : AcceptanceTestBase() {
     return TransactionEncoder.signMessage(ecRecoverCall, sender.web3jCredentialsOrThrow())
   }
 
-  fun asserLogsContain(
-    target: String,
-    logs: String = getAndResetLog(),
-  ) {
-    assertThat(logs)
-      .withFailMessage { "Expected Besu logs to contain '$target'" }
-      .contains(target)
+  fun assertLogsContain(target: String) {
+    // The log line can be written to MemoryAppender slightly after the block that triggered it is
+    // confirmed (e.g. via a receipt), so a single synchronous read can race with the log write.
+    // Poll instead of reading once.
+    await()
+      .atMost(getBlockPeriodSeconds().toLong(), TimeUnit.SECONDS)
+      .pollInterval(100, TimeUnit.MILLISECONDS)
+      .untilAsserted {
+        assertThat(getLog())
+          .withFailMessage { "Expected Besu logs to contain '$target'" }
+          .contains(target)
+      }
+    getAndResetLog()
   }
 }

--- a/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/lineth/plugin/acc/test/rpc/linea/BundleSelectionTimeoutTest.kt
+++ b/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/lineth/plugin/acc/test/rpc/linea/BundleSelectionTimeoutTest.kt
@@ -199,14 +199,7 @@ class BundleSelectionTimeoutTest : AbstractSendBundleTest() {
     // runner has many independent chances to complete the bundle inside the budget
     // and include the tx that should have timed out. A short window collapses that
     // to a single pass.
-    //
-    // The window is derived from the slot time rather than hardcoded: under Vert.x 5
-    // (Besu 26.8.1) the engine-API round-trip that delivers the payload is slower and
-    // more variable, so a fixed 300ms can expire before a single selection pass even
-    // runs on a loaded CI runner — which then behaves like zero passes and flakes the
-    // "big bundle timed out" assertion below. A small fraction of the slot keeps the
-    // single-pass intent while tolerating that added latency.
-    buildNewBlockAndWait(Math.max(300L, blockTimeSeconds!! * 1000L / 10))
+    buildNewBlockAndWait(300L)
 
     minerNode.verify(eth.expectSuccessfulTransactionReceipt(transferTxHash.bytes.toHexString()))
     val transferReceipt = ethTransactions.getTransactionReceipt(transferTxHash.bytes.toHexString())

--- a/tracer/testing/build.gradle
+++ b/tracer/testing/build.gradle
@@ -17,10 +17,6 @@ apply from: lineaTracerProject.file("gradle/lint.gradle")
 dependencies {
   implementation project(path: ':tracer:arithmetization')
 
-  // The shomei-server library is deliberately NOT a dependency: the empty-block Besu tests stand in
-  // for a Shomei node with an in-process HTTP stub (net.consensys.linea.testing.ShomeiNode), which
-  // keeps them off shomei-server's Vert.x 4-era HTTP server that fails to start under the Vert.x 5
-  // runtime Besu 26.8.1 brings.
   implementation 'io.micrometer:micrometer-registry-prometheus:1.11.1'
   implementation 'org.assertj:assertj-core'
   implementation 'org.junit.jupiter:junit-jupiter-api'


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Bumps core execution client and Vert.x stack, changes what ships in release artifacts (fleet/staterecovery excluded), and touches Maru runtime dependencies—high impact on builds, releases, and integration tests despite mitigations.
> 
> **Overview**
> **Upgrades Linea Besu from 26.8.0 to 26.8.1**, including the resolved commit in `libs.versions.toml`, Shomei plugin **v1.0.8**, and Gradle dependency updates for Besu’s **split `besu-plugin-api-*` modules**. Maru drops Vert.x 4 / Micrometer workarounds and uses the monorepo **`vertx-helper`** again.
> 
> **Release and package assembly** temporarily **omit besu-fleet-plugin and linea-staterecovery** (workflow inputs commented or hardcoded, staterecovery download disabled, release notes skip staterecovery details) until those plugins match Besu ≥ 26.8.1 on Vert.x 5.
> 
> **Sequencer acceptance tests** are hardened for slower post-upgrade block tx selection: configurable PoA/PoS selection budgets, ordering-based limit assertions (`assertFittingTransactionsMinedBeforeOverflow`), txpool/log polling, and **Linea-specific** rejection RPC in the recording test plugin.
> 
> **Tracer testing** replaces the real Shomei server with a **minimal HTTP stub**, removes `shomei-server` deps, adapts Vert.x 5 listen APIs, fixes Engine API timestamp encoding, and retries Shomei connectivity during startup.
> 
> Minor: state-recovery plugin deprecation suppressions, package `Makefile` Besu version from `.besu-resolved`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 106d9dbc27a0bb147f51a4fa95d8bfdefa52fea3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->