### PR TITLE
fix(coordinator): stabilize persistence retryer timing test

### DIFF
--- a/jvm-libs/generic/extensions/futures/src/main/kotlin/net/consensys/linea/async/AsyncRetryer.kt
+++ b/jvm-libs/generic/extensions/futures/src/main/kotlin/net/consensys/linea/async/AsyncRetryer.kt
@@ -2,6 +2,7 @@ package net.consensys.linea.async
 
 import io.vertx.core.Vertx
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.time.Clock
 import java.time.Instant
 import java.util.function.Consumer
 import kotlin.time.Duration
@@ -29,6 +30,7 @@ interface AsyncRetryer<T> {
       maxRetries: Int? = null,
       timeout: Duration? = null,
       initialDelay: Duration? = null,
+      clock: Clock = Clock.systemUTC(),
     ): AsyncRetryer<T> {
       return SequentialAsyncRetryerFactory(
         vertx = vertx,
@@ -36,6 +38,7 @@ interface AsyncRetryer<T> {
         maxRetries = maxRetries,
         initialDelay = initialDelay,
         timeout = timeout,
+        clock = clock,
       )
     }
 
@@ -49,21 +52,22 @@ interface AsyncRetryer<T> {
       stopRetriesOnErrorPredicate: (Throwable) -> Boolean = ::alwaysFalsePredicate,
       exceptionConsumer: Consumer<Throwable>? = null,
       ignoreFirstExceptionsUntilTimeElapsed: Duration? = null,
+      clock: Clock = Clock.systemUTC(),
       action: () -> SafeFuture<T>,
     ): SafeFuture<T> {
-      return SequentialAsyncRetryerFactory<T>(
+      return SequentialAsyncActionRetryer<T>(
         vertx = vertx,
         backoffDelay = backoffDelay,
         maxRetries = maxRetries,
         timeout = timeout,
         initialDelay = initialDelay,
-      ).retry(
-        stopRetriesPredicate,
-        stopRetriesOnErrorPredicate,
-        exceptionConsumer,
-        ignoreFirstExceptionsUntilTimeElapsed,
-        action,
-      )
+        stopRetriesPredicate = stopRetriesPredicate,
+        stopRetriesOnErrorPredicate = stopRetriesOnErrorPredicate,
+        exceptionConsumer = exceptionConsumer,
+        ignoreFirstExceptionsUntilTimeElapsed = ignoreFirstExceptionsUntilTimeElapsed,
+        clock = clock,
+        action = action,
+      ).retry()
     }
   }
 }
@@ -81,6 +85,7 @@ internal class SequentialAsyncActionRetryer<T>(
   val stopRetriesOnErrorPredicate: (Throwable) -> Boolean = ::alwaysFalsePredicate,
   val exceptionConsumer: Consumer<Throwable>? = null,
   val ignoreFirstExceptionsUntilTimeElapsed: Duration? = null,
+  val clock: Clock = Clock.systemUTC(),
   val action: () -> SafeFuture<T>,
 ) {
   init {
@@ -103,17 +108,17 @@ internal class SequentialAsyncActionRetryer<T>(
 
   private val resultFuture = SafeFuture<T>()
   private var remainingRetries: Int? = maxRetries
-  private var startTime: Instant = Instant.now()
+  private var startTime: Instant = clock.instant()
   private var remainingTime: Long? = timeout?.inWholeMilliseconds
 
   fun retry(): SafeFuture<T> {
     if (initialDelay != null && initialDelay > 0.milliseconds) {
       vertx.setTimer(initialDelay.inWholeMilliseconds) {
-        startTime = Instant.now()
+        startTime = clock.instant()
         retryLoop()
       }
     } else {
-      startTime = Instant.now()
+      startTime = clock.instant()
       retryLoop()
     }
 
@@ -128,7 +133,7 @@ internal class SequentialAsyncActionRetryer<T>(
     }
 
     actionFuture.handle { result, throwable ->
-      val timeElapsedSinceStarted = (Instant.now().toEpochMilli() - startTime.toEpochMilli())
+      val timeElapsedSinceStarted = (clock.instant().toEpochMilli() - startTime.toEpochMilli())
       var errorThrowable = throwable
       remainingTime =
         timeout?.let { it.inWholeMilliseconds - timeElapsedSinceStarted }
@@ -189,6 +194,7 @@ private class SequentialAsyncRetryerFactory<T>(
   val maxRetries: Int? = null,
   val timeout: Duration? = null,
   val initialDelay: Duration? = null,
+  val clock: Clock = Clock.systemUTC(),
 ) : AsyncRetryer<T> {
   override fun retry(action: () -> SafeFuture<T>): SafeFuture<T> {
     return SequentialAsyncActionRetryer(
@@ -200,6 +206,7 @@ private class SequentialAsyncRetryerFactory<T>(
       stopRetriesPredicate = ::alwaysTruePredicate,
       exceptionConsumer = null,
       ignoreFirstExceptionsUntilTimeElapsed = null,
+      clock = clock,
       action = action,
     ).retry()
   }
@@ -221,6 +228,7 @@ private class SequentialAsyncRetryerFactory<T>(
       stopRetriesOnErrorPredicate = stopRetriesOnErrorPredicate,
       exceptionConsumer = exceptionConsumer,
       ignoreFirstExceptionsUntilTimeElapsed = ignoreFirstExceptionsUntilTimeElapsed,
+      clock = clock,
       action = action,
     ).retry()
   }

--- a/jvm-libs/generic/extensions/futures/src/main/kotlin/net/consensys/linea/async/AsyncRetryer.kt
+++ b/jvm-libs/generic/extensions/futures/src/main/kotlin/net/consensys/linea/async/AsyncRetryer.kt
@@ -55,19 +55,20 @@ interface AsyncRetryer<T> {
       clock: Clock = Clock.systemUTC(),
       action: () -> SafeFuture<T>,
     ): SafeFuture<T> {
-      return SequentialAsyncActionRetryer<T>(
+      return SequentialAsyncRetryerFactory<T>(
         vertx = vertx,
         backoffDelay = backoffDelay,
         maxRetries = maxRetries,
         timeout = timeout,
         initialDelay = initialDelay,
-        stopRetriesPredicate = stopRetriesPredicate,
-        stopRetriesOnErrorPredicate = stopRetriesOnErrorPredicate,
-        exceptionConsumer = exceptionConsumer,
-        ignoreFirstExceptionsUntilTimeElapsed = ignoreFirstExceptionsUntilTimeElapsed,
         clock = clock,
-        action = action,
-      ).retry()
+      ).retry(
+        stopRetriesPredicate,
+        stopRetriesOnErrorPredicate,
+        exceptionConsumer,
+        ignoreFirstExceptionsUntilTimeElapsed,
+        action,
+      )
     }
   }
 }

--- a/jvm-libs/generic/extensions/futures/src/main/kotlin/net/consensys/linea/async/AsyncRetryer.kt
+++ b/jvm-libs/generic/extensions/futures/src/main/kotlin/net/consensys/linea/async/AsyncRetryer.kt
@@ -2,11 +2,11 @@ package net.consensys.linea.async
 
 import io.vertx.core.Vertx
 import tech.pegasys.teku.infrastructure.async.SafeFuture
-import java.time.Clock
-import java.time.Instant
 import java.util.function.Consumer
+import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Instant
 
 class RetriedExecutionException(override val message: String) : RuntimeException(message)
 
@@ -30,7 +30,7 @@ interface AsyncRetryer<T> {
       maxRetries: Int? = null,
       timeout: Duration? = null,
       initialDelay: Duration? = null,
-      clock: Clock = Clock.systemUTC(),
+      clock: Clock = Clock.System,
     ): AsyncRetryer<T> {
       return SequentialAsyncRetryerFactory(
         vertx = vertx,
@@ -52,7 +52,7 @@ interface AsyncRetryer<T> {
       stopRetriesOnErrorPredicate: (Throwable) -> Boolean = ::alwaysFalsePredicate,
       exceptionConsumer: Consumer<Throwable>? = null,
       ignoreFirstExceptionsUntilTimeElapsed: Duration? = null,
-      clock: Clock = Clock.systemUTC(),
+      clock: Clock = Clock.System,
       action: () -> SafeFuture<T>,
     ): SafeFuture<T> {
       return SequentialAsyncRetryerFactory<T>(
@@ -86,7 +86,7 @@ internal class SequentialAsyncActionRetryer<T>(
   val stopRetriesOnErrorPredicate: (Throwable) -> Boolean = ::alwaysFalsePredicate,
   val exceptionConsumer: Consumer<Throwable>? = null,
   val ignoreFirstExceptionsUntilTimeElapsed: Duration? = null,
-  val clock: Clock = Clock.systemUTC(),
+  val clock: Clock = Clock.System,
   val action: () -> SafeFuture<T>,
 ) {
   init {
@@ -109,17 +109,17 @@ internal class SequentialAsyncActionRetryer<T>(
 
   private val resultFuture = SafeFuture<T>()
   private var remainingRetries: Int? = maxRetries
-  private var startTime: Instant = clock.instant()
+  private var startTime: Instant = clock.now()
   private var remainingTime: Long? = timeout?.inWholeMilliseconds
 
   fun retry(): SafeFuture<T> {
     if (initialDelay != null && initialDelay > 0.milliseconds) {
       vertx.setTimer(initialDelay.inWholeMilliseconds) {
-        startTime = clock.instant()
+        startTime = clock.now()
         retryLoop()
       }
     } else {
-      startTime = clock.instant()
+      startTime = clock.now()
       retryLoop()
     }
 
@@ -134,7 +134,7 @@ internal class SequentialAsyncActionRetryer<T>(
     }
 
     actionFuture.handle { result, throwable ->
-      val timeElapsedSinceStarted = (clock.instant().toEpochMilli() - startTime.toEpochMilli())
+      val timeElapsedSinceStarted = (clock.now().toEpochMilliseconds() - startTime.toEpochMilliseconds())
       var errorThrowable = throwable
       remainingTime =
         timeout?.let { it.inWholeMilliseconds - timeElapsedSinceStarted }
@@ -195,7 +195,7 @@ private class SequentialAsyncRetryerFactory<T>(
   val maxRetries: Int? = null,
   val timeout: Duration? = null,
   val initialDelay: Duration? = null,
-  val clock: Clock = Clock.systemUTC(),
+  val clock: Clock = Clock.System,
 ) : AsyncRetryer<T> {
   override fun retry(action: () -> SafeFuture<T>): SafeFuture<T> {
     return SequentialAsyncActionRetryer(

--- a/jvm-libs/generic/persistence/db/src/main/kotlin/linea/persistence/db/PersistenceRetryer.kt
+++ b/jvm-libs/generic/persistence/db/src/main/kotlin/linea/persistence/db/PersistenceRetryer.kt
@@ -5,12 +5,14 @@ import net.consensys.linea.async.AsyncRetryer
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.time.Clock
 import kotlin.time.Duration
 
 open class PersistenceRetryer(
   private val vertx: Vertx,
   private val config: Config,
   private val log: Logger = LogManager.getLogger(PersistenceRetryer::class.java),
+  private val clock: Clock = Clock.systemUTC(),
 ) {
   data class Config(
     val backoffDelay: Duration,
@@ -47,6 +49,7 @@ open class PersistenceRetryer(
       stopRetriesOnErrorPredicate = stopRetriesOnErrorPredicate,
       exceptionConsumer = exceptionConsumer,
       ignoreFirstExceptionsUntilTimeElapsed = config.ignoreFirstExceptionsUntilTimeElapsed,
+      clock = clock,
       action = action,
     )
   }

--- a/jvm-libs/generic/persistence/db/src/main/kotlin/linea/persistence/db/PersistenceRetryer.kt
+++ b/jvm-libs/generic/persistence/db/src/main/kotlin/linea/persistence/db/PersistenceRetryer.kt
@@ -5,14 +5,14 @@ import net.consensys.linea.async.AsyncRetryer
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import tech.pegasys.teku.infrastructure.async.SafeFuture
-import java.time.Clock
+import kotlin.time.Clock
 import kotlin.time.Duration
 
 open class PersistenceRetryer(
   private val vertx: Vertx,
   private val config: Config,
   private val log: Logger = LogManager.getLogger(PersistenceRetryer::class.java),
-  private val clock: Clock = Clock.systemUTC(),
+  private val clock: Clock = Clock.System,
 ) {
   data class Config(
     val backoffDelay: Duration,

--- a/jvm-libs/generic/persistence/db/src/test/kotlin/linea/persistence/db/PersistenceRetryerTest.kt
+++ b/jvm-libs/generic/persistence/db/src/test/kotlin/linea/persistence/db/PersistenceRetryerTest.kt
@@ -12,17 +12,36 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.time.Clock
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
+import java.time.Duration as JavaDuration
+
+private class MutableClock(
+  private var currentInstant: Instant,
+) : Clock() {
+  override fun getZone(): ZoneId = ZoneOffset.UTC
+
+  override fun withZone(zone: ZoneId?): Clock = this
+
+  override fun instant(): Instant = currentInstant
+
+  fun advanceBy(duration: JavaDuration) {
+    currentInstant = currentInstant.plus(duration)
+  }
+}
 
 @ExtendWith(VertxExtension::class)
 class PersistenceRetryerTest {
   private lateinit var persistenceRetryer: PersistenceRetryer
   private lateinit var listAppender: ListAppender
+  private lateinit var clock: MutableClock
 
   @BeforeEach
   fun setup(vertx: Vertx) {
@@ -30,6 +49,7 @@ class PersistenceRetryerTest {
     listAppender = ctx.configuration.getAppender("ListAppender") as ListAppender
     listAppender.clear()
 
+    clock = MutableClock(Instant.parse("2026-09-08T00:00:00Z"))
     persistenceRetryer = PersistenceRetryer(
       vertx = vertx,
       config = PersistenceRetryer.Config(
@@ -38,6 +58,7 @@ class PersistenceRetryerTest {
         timeout = 2.seconds,
         ignoreFirstExceptionsUntilTimeElapsed = 80.milliseconds,
       ),
+      clock = clock,
     )
   }
 
@@ -104,19 +125,16 @@ class PersistenceRetryerTest {
       "some-code",
       "some-detail",
     )
-    val startTime = Clock.System.now()
 
     assertThrows<ExecutionException> {
-      persistenceRetryer.retryQuery(
+      persistenceRetryer.retryQuery<Unit>(
         action = {
-          if (callCounter.incrementAndGet() < 20) {
-            if (Clock.System.now().minus(startTime) < 80.milliseconds) {
-              SafeFuture.failedFuture(pgErrorBeforeMute)
-            } else {
-              SafeFuture.failedFuture(pgErrorAfterMute)
+          when (callCounter.incrementAndGet()) {
+            1 -> SafeFuture.failedFuture<Unit>(pgErrorBeforeMute)
+            else -> {
+              clock.advanceBy(JavaDuration.ofMillis(100))
+              SafeFuture.failedFuture<Unit>(pgErrorAfterMute)
             }
-          } else {
-            SafeFuture.completedFuture("success")
           }
         },
       ).get()

--- a/jvm-libs/generic/persistence/db/src/test/kotlin/linea/persistence/db/PersistenceRetryerTest.kt
+++ b/jvm-libs/generic/persistence/db/src/test/kotlin/linea/persistence/db/PersistenceRetryerTest.kt
@@ -3,6 +3,7 @@ package linea.persistence.db
 import io.vertx.core.Vertx
 import io.vertx.junit5.VertxExtension
 import io.vertx.pgclient.PgException
+import net.consensys.FakeFixedClock
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.core.LoggerContext
 import org.apache.logging.log4j.core.test.appender.ListAppender
@@ -12,36 +13,18 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import tech.pegasys.teku.infrastructure.async.SafeFuture
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneId
-import java.time.ZoneOffset
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 import kotlin.time.toJavaDuration
-import java.time.Duration as JavaDuration
-
-private class MutableClock(
-  private var currentInstant: Instant,
-) : Clock() {
-  override fun getZone(): ZoneId = ZoneOffset.UTC
-
-  override fun withZone(zone: ZoneId?): Clock = this
-
-  override fun instant(): Instant = currentInstant
-
-  fun advanceBy(duration: JavaDuration) {
-    currentInstant = currentInstant.plus(duration)
-  }
-}
 
 @ExtendWith(VertxExtension::class)
 class PersistenceRetryerTest {
   private lateinit var persistenceRetryer: PersistenceRetryer
   private lateinit var listAppender: ListAppender
-  private lateinit var clock: MutableClock
+  private lateinit var clock: FakeFixedClock
 
   @BeforeEach
   fun setup(vertx: Vertx) {
@@ -49,7 +32,7 @@ class PersistenceRetryerTest {
     listAppender = ctx.configuration.getAppender("ListAppender") as ListAppender
     listAppender.clear()
 
-    clock = MutableClock(Instant.parse("2026-09-08T00:00:00Z"))
+    clock = FakeFixedClock(Instant.parse("2026-09-08T00:00:00Z"))
     persistenceRetryer = PersistenceRetryer(
       vertx = vertx,
       config = PersistenceRetryer.Config(
@@ -132,7 +115,7 @@ class PersistenceRetryerTest {
           when (callCounter.incrementAndGet()) {
             1 -> SafeFuture.failedFuture<Unit>(pgErrorBeforeMute)
             else -> {
-              clock.advanceBy(JavaDuration.ofMillis(100))
+              clock.advanceBy(100.milliseconds)
               SafeFuture.failedFuture<Unit>(pgErrorAfterMute)
             }
           }


### PR DESCRIPTION
Fixes the flaky persistence retryer test seen in #3939: an error created before the 80 ms mute window expired could be handled after it expired, causing an unexpected log and a failed assertion.

Injects a clock into the retryer so the test controls elapsed time, while production continues to use the system clock.
