### PR TITLE
chore(ci): bump besu version to include support of debug_executionWit…

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,7 +41,7 @@ undercouchDownload = "5.6.0"
 # During task execution, linea-besu/besu/build.gradle resolves this commit,
 # writes linea-besu/besu/.besu-resolved, and read by dependent modules.
 # Besu version: 26.8.1
-besuCommit = "d97cbd61976a52bb109e637196fef9a8ebf2b617"
+besuCommit = "efa817c5abc989ef8bb82de14920518ce2a41173"
 blobCompressor = "4.0.1"
 commonsIo = "2.21.0"
 blobShnarfCalculator = "3.0.1"

--- a/linea-besu/besu/.besu-resolved
+++ b/linea-besu/besu/.besu-resolved
@@ -2,5 +2,5 @@
 # Written by Gradle (:linea-besu:resolveBesuVersion) and refreshed by CI
 # (.github/workflows/linea-besu-build-and-publish.yml) on besuCommit bumps.
 # Do NOT edit by hand and do NOT commit local changes — this file is gitignored.
-besuCommit=d97cbd61976a52bb109e637196fef9a8ebf2b617
-besuVersion=26.8.1-d97cbd6
+besuCommit=efa817c5abc989ef8bb82de14920518ce2a41173
+besuVersion=26.7.0-efa817c

--- a/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/lineth/plugin/acc/test/EcDataLimitsTest.kt
+++ b/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/lineth/plugin/acc/test/EcDataLimitsTest.kt
@@ -43,7 +43,10 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
    * @param nTransactions the number of transactions to try to include in the same block. The last
    *     one is not supposed to fit as it exceeds the limit, thus it is included in the next block
    * @param input a function that generates the input data for each transaction
-   * @param target the expected string to be found in the blocks log
+   * @param moduleName the name of the module whose limit is being crossed
+   * @param moduleLimit the line-count limit of that module
+   * @param attemptedCount the cumulated line count the overflowing transaction would push the module
+   *     to (i.e. `moduleLimit + <lines of the overflow tx>`); this is what the rejection log reports
    * @throws Exception if an error occurs during the test
    */
   @ParameterizedTest
@@ -51,7 +54,9 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
   fun ecPairingLimitsTest(
     nTransactions: Int,
     input: BiFunction<Int, Int, String>,
-    target: String,
+    moduleName: String,
+    moduleLimit: Int,
+    attemptedCount: Int,
   ) {
     // Deploy the EcPairing contract
     val ecPairing = deployEcPairing()
@@ -102,17 +107,18 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
     // Wait for the sentry to be mined
     minerNode.verify(eth.expectSuccessfulTransactionReceipt(transferTxHash.bytes.toHexString()))
 
-    // Assert the limit's ordering semantics: all but the last transaction (the ones that fit) were
-    // mined together, and the last one (which exceeds the limit) was mined in a strictly later
-    // block. This asserts ordering rather than an exact one-block-vs-next-block layout, which is not
-    // guaranteed under block-build timing jitter (see assertFittingTransactionsMinedBeforeOverflow).
-    assertFittingTransactionsMinedBeforeOverflow(
+    // Assert the limit semantics: the fitting transactions were mined together, the overflowing
+    // one landed in a strictly later block, and the sequencer logged that the overflow pushed the
+    // module's cumulated count to `attemptedCount`, above `moduleLimit`. See
+    // assertModuleLimitOverflowed for why this is sequenced after the overflow receipt.
+    assertModuleLimitOverflowed(
       minerNode.nodeRequests().eth(),
       txHashes.toList().subList(0, nTransactions - 1).filterNotNull(),
       txHashes[nTransactions - 1]!!,
+      moduleName,
+      moduleLimit,
+      attemptedCount,
     )
-
-    assertLogsContain(target)
   }
 
   /**
@@ -132,7 +138,9 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
      *     reach the limit with a smaller number of transaction
      *
      * input: input data for each transaction
-     * target: the expected string to be found in the blocks log
+     * moduleName/moduleLimit: the module whose limit is crossed and its limit
+     * attemptedCount: the cumulated count the overflow tx would push the module to
+     *     (`moduleLimit + <lines of the overflow tx>`); this is what the rejection log reports
      */
     val callsPerTransaction = 32
     val nTransactions = PRECOMPILE_ECADD_EFFECTIVE_CALLS / callsPerTransaction + 1
@@ -141,12 +149,11 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
         "041b98f07f44aa55ce8bd97e32cacf55f1e42229d540d5e7a767d1138a5da656" +
         "185f6f5cf93c8afa0461a948c2da7c403b6f8477c488155dfa8d2da1c62517b8" +
         "13d83d7a51eb18fdb51225873c87d44f883e770ce2ca56c305d02d6cb99ca5b8"
-    val target =
-      "Cumulated line count for module PRECOMPILE_ECADD_EFFECTIVE_CALLS=" +
-        (PRECOMPILE_ECADD_EFFECTIVE_CALLS + callsPerTransaction) +
-        " is above the limit " +
-        PRECOMPILE_ECADD_EFFECTIVE_CALLS +
-        ", stopping selection"
+    // The overflowing transaction adds `callsPerTransaction` calls, so the rejected cumulated count
+    // is `moduleLimit + callsPerTransaction`.
+    val moduleName = "PRECOMPILE_ECADD_EFFECTIVE_CALLS"
+    val moduleLimit = PRECOMPILE_ECADD_EFFECTIVE_CALLS
+    val attemptedCount = moduleLimit + callsPerTransaction
 
     // Deploy the EcAdd contract
     val ecAdd = deployEcAdd()
@@ -192,17 +199,18 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
     // Wait for the sentry to be mined
     minerNode.verify(eth.expectSuccessfulTransactionReceipt(transferTxHash.bytes.toHexString()))
 
-    // Assert the limit's ordering semantics: all but the last transaction (the ones that fit) were
-    // mined together, and the last one (which exceeds the limit) was mined in a strictly later
-    // block. This asserts ordering rather than an exact one-block-vs-next-block layout, which is not
-    // guaranteed under block-build timing jitter (see assertFittingTransactionsMinedBeforeOverflow).
-    assertFittingTransactionsMinedBeforeOverflow(
+    // Assert the limit semantics: the fitting transactions were mined together, the overflowing
+    // one landed in a strictly later block, and the sequencer logged that the overflow pushed the
+    // module's cumulated count to `attemptedCount`, above `moduleLimit`. See
+    // assertModuleLimitOverflowed for why this is sequenced after the overflow receipt.
+    assertModuleLimitOverflowed(
       minerNode.nodeRequests().eth(),
       txHashes.toList().subList(0, nTransactions - 1).filterNotNull(),
       txHashes[nTransactions - 1]!!,
+      moduleName,
+      moduleLimit,
+      attemptedCount,
     )
-
-    assertLogsContain(target)
   }
 
   /**
@@ -219,19 +227,20 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
      *     The last one is not supposed to fit as it exceeds the limit, thus it is
      *     included in the next block
      * input: input data for each transaction
-     * target: the expected string to be found in the blocks log
+     * moduleName/moduleLimit: the module whose limit is crossed and its limit
+     * attemptedCount: the cumulated count the overflow tx would push the module to
+     *     (`moduleLimit + <lines of the overflow tx>`); this is what the rejection log reports
      */
     val nTransactions = PRECOMPILE_ECMUL_EFFECTIVE_CALLS + 1
     val input =
       "030644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd3" +
         "15ed738c0e0a7c92e7845f96b2ae9c0a68a6a449e3538fc7ff3ebf7a5a18a2c4" +
         "0000000000000000000000000000000000000000000000000000000000000001"
-    val target =
-      "Cumulated line count for module PRECOMPILE_ECMUL_EFFECTIVE_CALLS=" +
-        (PRECOMPILE_ECMUL_EFFECTIVE_CALLS + 1) +
-        " is above the limit " +
-        PRECOMPILE_ECMUL_EFFECTIVE_CALLS +
-        ", stopping selection"
+    // The overflowing transaction adds 1 call, so the rejected cumulated count is
+    // `moduleLimit + 1`.
+    val moduleName = "PRECOMPILE_ECMUL_EFFECTIVE_CALLS"
+    val moduleLimit = PRECOMPILE_ECMUL_EFFECTIVE_CALLS
+    val attemptedCount = moduleLimit + 1
 
     // Deploy the EcMul contract
     val ecMul = deployEcMul()
@@ -277,17 +286,18 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
     // Wait for the sentry to be mined
     minerNode.verify(eth.expectSuccessfulTransactionReceipt(transferTxHash.bytes.toHexString()))
 
-    // Assert the limit's ordering semantics: all but the last transaction (the ones that fit) were
-    // mined together, and the last one (which exceeds the limit) was mined in a strictly later
-    // block. This asserts ordering rather than an exact one-block-vs-next-block layout, which is not
-    // guaranteed under block-build timing jitter (see assertFittingTransactionsMinedBeforeOverflow).
-    assertFittingTransactionsMinedBeforeOverflow(
+    // Assert the limit semantics: the fitting transactions were mined together, the overflowing
+    // one landed in a strictly later block, and the sequencer logged that the overflow pushed the
+    // module's cumulated count to `attemptedCount`, above `moduleLimit`. See
+    // assertModuleLimitOverflowed for why this is sequenced after the overflow receipt.
+    assertModuleLimitOverflowed(
       minerNode.nodeRequests().eth(),
       txHashes.toList().subList(0, nTransactions - 1).filterNotNull(),
       txHashes[nTransactions - 1]!!,
+      moduleName,
+      moduleLimit,
+      attemptedCount,
     )
-
-    assertLogsContain(target)
   }
 
   /**
@@ -304,7 +314,9 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
      *     The last one is not supposed to fit as it exceeds the limit, thus it is
      *     included in the next block
      * input: input data for each transaction
-     * target: the expected string to be found in the blocks log
+     * moduleName/moduleLimit: the module whose limit is crossed and its limit
+     * attemptedCount: the cumulated count the overflow tx would push the module to
+     *     (`moduleLimit + <lines of the overflow tx>`); this is what the rejection log reports
      */
     val nTransactions = PRECOMPILE_ECRECOVER_EFFECTIVE_CALLS + 1
     val input =
@@ -314,12 +326,11 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
           "c2ff96feed8749a5ad1c0714f950b5ac939d8acedbedcbc2949614ab8af06312" +
           "1feecd50adc6273fdd5d11c6da18c8cfe14e2787f5a90af7c7c1328e7d0a2c42",
       )
-    val target =
-      "Cumulated line count for module PRECOMPILE_ECRECOVER_EFFECTIVE_CALLS=" +
-        (PRECOMPILE_ECRECOVER_EFFECTIVE_CALLS + 1) +
-        " is above the limit " +
-        PRECOMPILE_ECRECOVER_EFFECTIVE_CALLS +
-        ", stopping selection"
+    // The overflowing transaction adds 1 call, so the rejected cumulated count is
+    // `moduleLimit + 1`.
+    val moduleName = "PRECOMPILE_ECRECOVER_EFFECTIVE_CALLS"
+    val moduleLimit = PRECOMPILE_ECRECOVER_EFFECTIVE_CALLS
+    val attemptedCount = moduleLimit + 1
 
     // Deploy the EcRecover contract
     val ecRecover = deployEcRecover()
@@ -365,17 +376,18 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
     // Wait for the sentry to be mined
     minerNode.verify(eth.expectSuccessfulTransactionReceipt(transferTxHash.bytes.toHexString()))
 
-    // Assert the limit's ordering semantics: all but the last transaction (the ones that fit) were
-    // mined together, and the last one (which exceeds the limit) was mined in a strictly later
-    // block. This asserts ordering rather than an exact one-block-vs-next-block layout, which is not
-    // guaranteed under block-build timing jitter (see assertFittingTransactionsMinedBeforeOverflow).
-    assertFittingTransactionsMinedBeforeOverflow(
+    // Assert the limit semantics: the fitting transactions were mined together, the overflowing
+    // one landed in a strictly later block, and the sequencer logged that the overflow pushed the
+    // module's cumulated count to `attemptedCount`, above `moduleLimit`. See
+    // assertModuleLimitOverflowed for why this is sequenced after the overflow receipt.
+    assertModuleLimitOverflowed(
       minerNode.nodeRequests().eth(),
       txHashes.toList().subList(0, nTransactions - 1).filterNotNull(),
       txHashes[nTransactions - 1]!!,
+      moduleName,
+      moduleLimit,
+      attemptedCount,
     )
-
-    assertLogsContain(target)
   }
 
   companion object {
@@ -433,11 +445,9 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
         Arguments.of(
           PRECOMPILE_ECPAIRING_FINAL_EXPONENTIATIONS + 1, // 1 final exponentiation per transaction
           BiFunction<Int, Int, String> { _, _ -> nonTrivial }, // 1 pair per transaction
-          "Cumulated line count for module PRECOMPILE_ECPAIRING_FINAL_EXPONENTIATIONS=" +
-            (PRECOMPILE_ECPAIRING_FINAL_EXPONENTIATIONS + 1) +
-            " is above the limit " +
-            PRECOMPILE_ECPAIRING_FINAL_EXPONENTIATIONS +
-            ", stopping selection",
+          "PRECOMPILE_ECPAIRING_FINAL_EXPONENTIATIONS",
+          PRECOMPILE_ECPAIRING_FINAL_EXPONENTIATIONS,
+          PRECOMPILE_ECPAIRING_FINAL_EXPONENTIATIONS + 1, // overflow tx adds 1 final exponentiation
         ),
       )
 
@@ -469,11 +479,9 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
             nonTrivial.repeat(if (i < nTransactions - 1) nPairsPerTransaction else 1)
           },
           // nPairsPerTransaction pairs per transaction except the last one which has 1
-          "Cumulated line count for module PRECOMPILE_ECPAIRING_MILLER_LOOPS=" +
-            (PRECOMPILE_ECPAIRING_MILLER_LOOPS + 1) +
-            " is above the limit " +
-            PRECOMPILE_ECPAIRING_MILLER_LOOPS +
-            ", stopping selection",
+          "PRECOMPILE_ECPAIRING_MILLER_LOOPS",
+          PRECOMPILE_ECPAIRING_MILLER_LOOPS,
+          PRECOMPILE_ECPAIRING_MILLER_LOOPS + 1, // overflow tx adds 1 Miller loop
         ),
       )
 
@@ -504,11 +512,9 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
             leftTrivialValid.repeat(if (i < nTransactions - 1) nPairsPerTransaction else 1)
           },
           // nPairsPerTransaction pairs per transaction except the last one which has 1
-          "Cumulated line count for module PRECOMPILE_ECPAIRING_G2_MEMBERSHIP_CALLS=" +
-            (PRECOMPILE_ECPAIRING_G2_MEMBERSHIP_CALLS + 1) +
-            " is above the limit " +
-            PRECOMPILE_ECPAIRING_G2_MEMBERSHIP_CALLS +
-            ", stopping selection",
+          "PRECOMPILE_ECPAIRING_G2_MEMBERSHIP_CALLS",
+          PRECOMPILE_ECPAIRING_G2_MEMBERSHIP_CALLS,
+          PRECOMPILE_ECPAIRING_G2_MEMBERSHIP_CALLS + 1, // overflow tx adds 1 G2 membership call
         ),
       )
 
@@ -516,7 +522,7 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
       Description of the test cases:
 
       - This method defines 3 test cases.
-      - Each test case is defined by a tuple (nTransactions, input, target). See the test method signature for more details.
+      - Each test case is defined by a tuple (nTransactions, input, moduleName, moduleLimit, attemptedCount). See the test method signature for more details.
       - Each test case goal is crossing a limit independently. Specifically:
        * The first test case crosses the limit of final exponentiations.
        * The second test case crosses the limit of Miller loops.

--- a/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/lineth/plugin/acc/test/LineaPluginTestBase.kt
+++ b/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/lineth/plugin/acc/test/LineaPluginTestBase.kt
@@ -17,6 +17,7 @@ import lineth.metrics.LineaMetricCategory.SEQUENCER_FORCED_TX
 import lineth.metrics.LineaMetricCategory.SEQUENCER_LIVENESS
 import lineth.metrics.LineaMetricCategory.SEQUENCER_PROFITABILITY
 import lineth.metrics.LineaMetricCategory.TX_POOL_PROFITABILITY
+import lineth.plugin.acc.test.LineaPluginTestBase.Companion.RECEIPT_FETCH_MAX_RETRIES
 import lineth.plugin.acc.test.tests.web3j.generated.AcceptanceTestToken
 import lineth.plugin.acc.test.tests.web3j.generated.BLS12_MAP_FP_TO_G1
 import lineth.plugin.acc.test.tests.web3j.generated.DummyAdder
@@ -73,7 +74,8 @@ import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
-import java.util.*
+import java.util.Objects
+import java.util.Optional
 import java.util.concurrent.Callable
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -544,6 +546,58 @@ abstract class LineaPluginTestBase : AcceptanceTestBase() {
       .isGreaterThan(fittingBlocks.single())
   }
 
+  /**
+   * Asserts the module-line-count limit semantics for a batch of [fittingHashes] plus one
+   * [overflowHash]:
+   *  1. the fitting transactions were mined together in a single block;
+   *  2. the overflowing transaction was mined in a strictly later block; and
+   *  3. the sequencer logged that it stopped selection because adding the overflowing transaction
+   *     pushed [moduleName]'s cumulated line count to [attemptedCount], above [moduleLimit].
+   *
+   * Why this ordering: the rejection log line is only emitted during the block-building selection
+   * round that evaluates (and rejects) the overflowing transaction.
+   */
+  protected fun assertModuleLimitOverflowed(
+    web3j: Web3j,
+    fittingHashes: List<String>,
+    overflowHash: String,
+    moduleName: String,
+    moduleLimit: Int,
+    attemptedCount: Int,
+  ) {
+    val receipts = getReceiptsInParallel(web3j, fittingHashes + overflowHash)
+    val fittingBlocks = receipts.dropLast(1).map { receipt ->
+      assertThat(receipt).isNotNull
+      receipt.blockNumber.toLong()
+    }.toSet()
+    val overflowBlock = receipts.last().blockNumber.toLong()
+
+    assertThat(fittingBlocks)
+      .withFailMessage { "Expected fitting transactions to be mined in a single block, got $fittingBlocks" }
+      .hasSize(1)
+    assertThat(overflowBlock)
+      .withFailMessage {
+        "Expected overflow transaction to be mined strictly after the fitting block " +
+          "${fittingBlocks.single()}, got $overflowBlock"
+      }
+      .isGreaterThan(fittingBlocks.single())
+
+    // The rejection round has already run (proven by the overflow receipt above); only the async
+    // appender flush can still be pending, so poll for the line.
+    val target =
+      "Cumulated line count for module $moduleName=$attemptedCount is above the limit " +
+        "$moduleLimit, stopping selection"
+    await()
+      .atMost(getBlockPeriodSeconds().toLong(), TimeUnit.SECONDS)
+      .pollInterval(100, TimeUnit.MILLISECONDS)
+      .untilAsserted {
+        assertThat(getLog())
+          .withFailMessage { "Expected Besu logs to contain '$target'" }
+          .contains(target)
+      }
+    getAndResetLog()
+  }
+
   protected fun assertTransactionNotInThePool(hash: String) {
     minerNode.verify(
       TxPoolConditions(TxPoolTransactions())
@@ -561,23 +615,6 @@ abstract class LineaPluginTestBase : AcceptanceTestBase() {
       maxOf(1000L, getBlockPeriodSeconds() * 1000L / 5),
       getBlockPeriodSeconds() * 6,
     )
-  }
-
-  protected fun sendTransactionWithGivenLengthPayload(
-    account: String,
-    web3j: Web3j,
-    num: Int,
-  ): String {
-    val to = "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73"
-    val txManager = RawTransactionManager(web3j, Credentials.create(account))
-
-    return txManager.sendTransaction(
-      DefaultGasProvider.GAS_PRICE,
-      BigInteger.valueOf(MAX_TX_GAS_LIMIT.toLong()),
-      to,
-      RandomStringUtils.secure().nextAlphabetic(num),
-      BigInteger.ZERO,
-    ).transactionHash
   }
 
   protected fun createExtraDataPricingField(
@@ -742,20 +779,5 @@ abstract class LineaPluginTestBase : AcceptanceTestBase() {
     )
 
     return TransactionEncoder.signMessage(ecRecoverCall, sender.web3jCredentialsOrThrow())
-  }
-
-  fun assertLogsContain(target: String) {
-    // The log line can be written to MemoryAppender slightly after the block that triggered it is
-    // confirmed (e.g. via a receipt), so a single synchronous read can race with the log write.
-    // Poll instead of reading once.
-    await()
-      .atMost(getBlockPeriodSeconds().toLong(), TimeUnit.SECONDS)
-      .pollInterval(100, TimeUnit.MILLISECONDS)
-      .untilAsserted {
-        assertThat(getLog())
-          .withFailMessage { "Expected Besu logs to contain '$target'" }
-          .contains(target)
-      }
-    getAndResetLog()
   }
 }


### PR DESCRIPTION
…ness

This PR implements issue(s) #3084 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Runtime Besu version changes can affect CI and local builds; production risk is limited to dependency alignment and test-only harness updates.
> 
> **Overview**
> **Bumps the pinned Besu commit** in `gradle/libs.versions.toml` (still labeled **26.8.1**) so the build picks up upstream changes—including support referenced in the PR title for `debug_executionWitness`.
> 
> **Refactors EC precompile module-limit acceptance tests** so they assert the full limit story in one place: fitting txs in one block, overflow tx in a later block, and the sequencer log that reports cumulated line count above the limit. Tests now pass structured `moduleName` / `moduleLimit` / `attemptedCount` instead of brittle full log strings, and call new `assertModuleLimitOverflowed` (which waits for the overflow receipt before polling logs). Standalone `assertLogsContain` and unused `sendTransactionWithGivenLengthPayload` are removed from the test base.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f72590ae725326570ea7580bb10457581a0a502. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->