### PR TITLE
perf(verifier-ray): halve field elements directly instead of via a cached inverse

### DIFF
--- a/verifier-ray/src/crypto/poseidon2.zig
+++ b/verifier-ray/src/crypto/poseidon2.zig
@@ -270,7 +270,8 @@ fn zeroArray(comptime len: usize) [len]field.Element {
 }
 
 // Precomputed 2^{-n} mod p for the KoalaBear field (p = 2_130_706_433 = 2^31 - 2^24 + 1).
-const inv2Exp1: field.Element = .{ .value = 1_065_353_217 };
+// 2^-1 is not listed here: halving uses field.Element.halve() directly instead
+// of a cached-constant multiply.
 const inv2Exp2: field.Element = .{ .value = 1_598_029_825 };
 const inv2Exp3: field.Element = .{ .value = 1_864_368_129 };
 const inv2Exp4: field.Element = .{ .value = 1_997_537_281 };
@@ -290,10 +291,10 @@ fn matMulInternalInPlace(comptime width: usize, state: *[width]field.Element) vo
     state[0] = sum.sub(state[0].double());
     state[1] = sum.add(state[1]);
     state[2] = sum.add(state[2].double());
-    state[3] = sum.add(state[3].mul(inv2Exp1));
+    state[3] = sum.add(state[3].halve());
     state[4] = sum.add(state[4].mul(.{ .value = 3 }));
     state[5] = sum.add(state[5].double().double());
-    state[6] = sum.sub(state[6].mul(inv2Exp1));
+    state[6] = sum.sub(state[6].halve());
     state[7] = sum.sub(state[7].mul(.{ .value = 3 }));
     state[8] = sum.sub(state[8].double().double());
     state[9] = sum.add(state[9].mul(inv2Exp8));

--- a/verifier-ray/src/field/koalabear.zig
+++ b/verifier-ray/src/field/koalabear.zig
@@ -78,6 +78,11 @@ pub const Element = extern struct {
         return self.add(self);
     }
 
+    pub fn halve(self: Element) Element {
+        if ((self.value & 1) == 0) return .{ .value = self.value >> 1 };
+        return .{ .value = @as(u32, @intCast((@as(u64, self.value) + modulus) >> 1)) };
+    }
+
     pub fn mul(self: Element, rhs: Element) Element {
         return init(@as(u64, self.value) * @as(u64, rhs.value));
     }

--- a/verifier-ray/src/field/koalabear_ext.zig
+++ b/verifier-ray/src/field/koalabear_ext.zig
@@ -79,6 +79,17 @@ pub const Ext = extern struct {
         return self.mulByBase(rhs.inverse());
     }
 
+    pub fn halve(self: Ext) Ext {
+        // Halving is base-field-linear (each limb scales independently), so
+        // this halves every limb directly instead of computing 2^-1 once and
+        // calling mulByBase.
+        return .{
+            .B0 = .{ .a0 = self.B0.a0.halve(), .a1 = self.B0.a1.halve() },
+            .B1 = .{ .a0 = self.B1.a0.halve(), .a1 = self.B1.a1.halve() },
+            .B2 = .{ .a0 = self.B2.a0.halve(), .a1 = self.B2.a1.halve() },
+        };
+    }
+
     pub fn mul(self: Ext, rhs: Ext) Ext {
         // Karatsuba for cubic extension: 6 E2 muls instead of 9 (schoolbook).
         // F_{p^6} = F_{p^2}[v]/(v^3 - nr), nr = u+1 in F_{p^2}.

--- a/verifier-ray/src/query/fri.zig
+++ b/verifier-ray/src/query/fri.zig
@@ -230,7 +230,7 @@ pub fn checkFolds(
             diff = diff.mulByBase(x_inv);
             diff = diff.mul(fold_alphas[j]);
             sum = sum.add(diff);
-            sum = sum.mulByBase(inv_two);
+            sum = sum.halve();
 
             if (j < num_rounds - 1) {
                 if (!sum.eql(rq.rounds[j + 1].self)) return Error.FoldMismatch;
@@ -251,10 +251,6 @@ pub fn checkFolds(
         }
     }
 }
-
-// 2^{-1} mod p (p = 2_130_706_433 = 2^31 - 2^24 + 1). Duplicated from
-// crypto/poseidon2.zig's inv2Exp1, which is private to that module.
-const inv_two: field.Element = .{ .value = 1_065_353_217 };
 
 fn fullDomainGenerator(params: Params) field.Element {
     return field.rootOfUnityBy(@as(usize, 1) << @intCast(params.log_codeword_size)) catch unreachable;

--- a/verifier-ray/test/field_test.zig
+++ b/verifier-ray/test/field_test.zig
@@ -31,3 +31,28 @@ test "extension lift stores base element in the first limb" {
     try std.testing.expect(lifted.B1.isZero());
     try std.testing.expect(lifted.B2.isZero());
 }
+
+test "koalabear element halve matches multiplying by the modular inverse of two" {
+    const two_inv = field.Element.init(2).inverse();
+    const even = field.Element.init(4);
+    const odd = field.Element.init(5);
+    try std.testing.expect(even.halve().eql(even.mul(two_inv)));
+    try std.testing.expect(odd.halve().eql(odd.mul(two_inv)));
+}
+
+test "koalabear element halve is the inverse of double" {
+    const values = [_]field.Element{
+        field.Element.zero(),
+        field.Element.one(),
+        field.Element.init(field.modulus - 1),
+        field.Element.init(field.modulus - 2),
+    };
+    for (values) |v| {
+        try std.testing.expect(v.halve().double().eql(v));
+    }
+}
+
+test "extension halve matches dividing by the base field's two" {
+    const e = ext.Ext.fromUints(.{ 1, 2, 3, 4, 5, 6 });
+    try std.testing.expect(e.halve().eql(e.divByBase(field.Element.init(2))));
+}


### PR DESCRIPTION
This PR implements issue(s) #3652

Throughout verifier ray, halving a KoalaBear field element was done by multiplying by a precomputed constant equal to the modular inverse of two. This adds an Element.halve() that instead uses the direct trick for odd prime fields: even values shift right by one, odd values add the modulus first then shift.

An Ext.halve() applies the same trick coefficient wise to every limb of the cubic extension field, since halving is base field linear.

Both call sites that used to multiply by the cached inverse now call halve() instead:

* poseidon2.zig's internal matrix layer (state[3] and state[6] in matMulInternalInPlace)
* fri.zig's fold recurrence in checkFolds

The now unused inv_two constant in fri.zig and the inv2Exp1 constant in poseidon2.zig were removed. The other inv2ExpN constants (for dividing by larger powers of two) are unaffected and out of scope for this issue.

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this PR.
* [x] I have informed the team of any breaking changes if there are any.

No breaking changes. This is an internal implementation detail with no public API surface change.